### PR TITLE
feat: BehaviorAnalyzer endpoint auto-discovery + public redteam report module

### DIFF
--- a/nuguard/behavior/analyzer.py
+++ b/nuguard/behavior/analyzer.py
@@ -119,6 +119,88 @@ class BehaviorAnalyzer:
                     )
 
                 # Run scenarios
+                # ── Endpoint auto-discovery ─────────────────────────────
+                # When target_endpoint is not configured, attempt to infer
+                # it from SBOM metadata (zero-I/O) then fall back to a live
+                # HTTP probe.  This mirrors the RedteamOrchestrator logic so
+                # that both analysis modes share the same discovery path.
+                cfg_endpoint = getattr(self._config, "target_endpoint", "") or ""
+                if not cfg_endpoint and self._sbom is not None:
+                    from nuguard.common.endpoint_probe import (  # noqa: PLC0415
+                        discover_chat_config_from_sbom,
+                        probe_chat_endpoints,
+                    )
+
+                    # 1. Static SBOM-based discovery (no network)
+                    disc_path, disc_payload_key, disc_payload_list, disc_response_key = (
+                        discover_chat_config_from_sbom(
+                            self._sbom,
+                            chat_path="",
+                            chat_payload_key=getattr(self._config, "chat_payload_key", "message") or "message",
+                            chat_payload_list=bool(getattr(self._config, "chat_payload_list", False)),
+                        )
+                    )
+
+                    if disc_path:
+                        _log.info(
+                            "BehaviorAnalyzer: SBOM-discovered endpoint %s "
+                            "(key=%s list=%s response_key=%s)",
+                            disc_path, disc_payload_key, disc_payload_list, disc_response_key,
+                        )
+                        updates: dict = {"target_endpoint": disc_path}
+                        if disc_payload_key and disc_payload_key != getattr(self._config, "chat_payload_key", "message"):
+                            updates["chat_payload_key"] = disc_payload_key
+                        if disc_payload_list != bool(getattr(self._config, "chat_payload_list", False)):
+                            updates["chat_payload_list"] = disc_payload_list
+                        if disc_response_key and not getattr(self._config, "chat_response_key", ""):
+                            updates["chat_response_key"] = disc_response_key
+                        self._config = self._config.model_copy(update=updates)
+                    else:
+                        # 2. Live HTTP probe fallback
+                        auth_headers: dict[str, str] = {}
+                        try:
+                            from nuguard.common.auth import AuthConfig  # noqa: PLC0415
+                            from nuguard.common.auth_runtime import (
+                                resolve_auth_runtime,  # noqa: PLC0415
+                            )
+                            va = getattr(self._config, "auth", None)
+                            if va and getattr(va, "type", "none") != "none":
+                                ac = AuthConfig(
+                                    type=va.type,
+                                    header=getattr(va, "header", ""),
+                                    username=getattr(va, "username", ""),
+                                    password=getattr(va, "password", ""),
+                                )
+                                rt = resolve_auth_runtime(auth_config=ac)
+                                auth_headers = getattr(rt, "initial_headers", {}) or {}
+                        except Exception:
+                            pass
+
+                        probe_result = await probe_chat_endpoints(
+                            target_url=target_url,
+                            sbom=self._sbom,
+                            auth_headers=auth_headers or None,
+                            timeout=15.0,
+                        )
+                        if probe_result:
+                            probed_path, probed_key, probed_list = probe_result
+                            _log.info(
+                                "BehaviorAnalyzer: live-probed endpoint %s (key=%s list=%s)",
+                                probed_path, probed_key, probed_list,
+                            )
+                            probe_updates: dict = {"target_endpoint": probed_path}
+                            if probed_key and probed_key != getattr(self._config, "chat_payload_key", "message"):
+                                probe_updates["chat_payload_key"] = probed_key
+                            if probed_list != bool(getattr(self._config, "chat_payload_list", False)):
+                                probe_updates["chat_payload_list"] = probed_list
+                            self._config = self._config.model_copy(update=probe_updates)
+                        else:
+                            _log.warning(
+                                "BehaviorAnalyzer: endpoint auto-discovery found nothing "
+                                "for %s — scenarios will use default /chat",
+                                target_url,
+                            )
+
                 runner = BehaviorRunner(
                     config=self._config,
                     sbom=self._sbom,

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -660,88 +660,9 @@ def _print_findings(
 
 
 def _scenario_coverage_table(scenario_records: list) -> list[str]:
-    """Return Markdown lines for the Scenario Coverage summary table.
-
-    One row per executed scenario, sorted by impact score descending.
-    Columns: rank, title, goal, finding (YES/no), turns used / budget,
-    duration, avg time per turn.
-
-    A summary line below the table shows aggregate stats.
-    """
-    if not scenario_records:
-        return []
-
-    # Sort by impact_score desc; within same score, findings first
-    records = sorted(
-        scenario_records,
-        key=lambda r: (-getattr(r, "impact_score", 0.0), 0 if r.had_finding else 1),
-    )
-
-    # Abbreviate goal_type labels so they fit in the table
-    _GOAL_ABBREV = {
-        "DATA_EXFILTRATION": "Data Exfil",
-        "PRIVILEGE_ESCALATION": "Priv Esc",
-        "PROMPT_DRIVEN_THREAT": "Prompt Threat",
-        "POLICY_VIOLATION": "Policy Viol",
-        "TOOL_ABUSE": "Tool Abuse",
-        "API_ATTACK": "API Attack",
-        "MCP_TOXIC_FLOW": "MCP Toxic",
-    }
-
-    def _fmt_duration(s: float) -> str:
-        if s <= 0:
-            return "—"
-        return f"{s:.1f}s"
-
-    def _fmt_avg(s: float, turns: int) -> str:
-        if s <= 0 or turns <= 0:
-            return "—"
-        return f"{s / turns:.1f}s"
-
-    lines: list[str] = ["## Scenario Coverage", ""]
-    lines.append(
-        "| # | Scenario | Goal | Finding | Turns | Duration | Avg/Turn |"
-    )
-    lines.append(
-        "|---|---|---|---|---|---|---|"
-    )
-
-    total_duration = 0.0
-    total_turns = 0
-    findings_count = 0
-
-    for idx, r in enumerate(records, start=1):
-        title = r.title[:60] + ("…" if len(r.title) > 60 else "")
-        goal = _GOAL_ABBREV.get(r.goal_type, r.goal_type.replace("_", " ").title())
-        finding_cell = "**YES**" if r.had_finding else "no"
-        turns_used = getattr(r, "turns_used", len(r.steps))
-        turns_budget = getattr(r, "turns_budget", 0) or turns_used
-        turns_cell = f"{turns_used}/{turns_budget}"
-        duration = getattr(r, "duration_s", 0.0)
-        dur_cell = _fmt_duration(duration)
-        avg_cell = _fmt_avg(duration, turns_used)
-
-        total_duration += duration
-        total_turns += turns_used
-        if r.had_finding:
-            findings_count += 1
-
-        lines.append(
-            f"| {idx} | {title} | {goal} | {finding_cell} "
-            f"| {turns_cell} | {dur_cell} | {avg_cell} |"
-        )
-
-    n = len(records)
-    avg_scenario = _fmt_duration(total_duration / n if n else 0)
-    avg_turn = _fmt_avg(total_duration, total_turns)
-    lines.append("")
-    lines.append(
-        f"_{n} scenario(s) executed — {findings_count} finding(s). "
-        f"Total: {_fmt_duration(total_duration)} | "
-        f"Avg per scenario: {avg_scenario} | Avg per turn: {avg_turn}_"
-    )
-    lines.append("")
-    return lines
+    """Delegate to :func:`nuguard.redteam.report._scenario_coverage_table`."""
+    from nuguard.redteam.report import _scenario_coverage_table as _impl
+    return _impl(scenario_records)
 
 
 def _findings_to_markdown(
@@ -750,111 +671,20 @@ def _findings_to_markdown(
     remediation_plan: list | None = None,
     scenario_records: list | None = None,
 ) -> str:
-    """Render redteam findings as a Markdown report string.
-
-    When *remediation_plan* is supplied (a list of ``RemediationArtefact``
-    objects produced by :class:`RemediationSynthesizer`), a
-    ``## Remediation Plan`` section is appended with concrete, SBOM-node
-    specific patches, guardrails and architectural changes grouped by
-    component — matching the behavior report's layout.
-
-    When *scenario_records* is supplied (a list of ``ScenarioRecord`` objects
-    from the orchestrator), a ``## Scenario Coverage`` table is inserted
-    immediately after the report header, before the per-finding detail.
-    """
-    if meta is None:
-        meta = ReportMeta()
-    lines: list[str] = ["# NuGuard Red-Team Report", ""]
-    lines += meta.to_markdown_lines()
-
-    if scenario_records:
-        lines += _scenario_coverage_table(scenario_records)
-
-    if not findings:
-        lines += ["_No findings — scan complete._", ""]
-        return "\n".join(lines)
-
-    from nuguard.models.finding import Severity
-
-    lines += [f"**{len(findings)} finding(s)**", ""]
-    for f in sorted(findings, key=lambda x: list(Severity).index(x.severity)):
-        sev = f.severity.value.upper() if hasattr(f.severity, "value") else str(f.severity).upper()
-        lines += [f"## [{sev}] {f.title}", ""]
-        lines += [f.description, ""]
-        if f.affected_component:
-            lines += [f"**Component:** {f.affected_component}", ""]
-        if f.goal_type:
-            lines += [f"**Type:** {f.goal_type}", ""]
-        # Progress score (1–5 rubric)
-        scores = getattr(f, "scores", None) or {}
-        progress = scores.get("goal_progress")
-        if progress is not None:
-            lines += [f"**Progress score:** {progress}/5", ""]
-        # One-sentence reasoning from the judge
-        reasoning = getattr(f, "reasoning", "") or ""
-        if reasoning:
-            lines += [f"**Finding reasoning:** {reasoning}", ""]
-        # Named success indicator
-        success_indicator = getattr(f, "success_indicator", None)
-        if success_indicator:
-            lines += [f"**Success indicator:** `{success_indicator}`", ""]
-        # Evidence quote — exact substring proving the breach
-        evidence_quote = getattr(f, "evidence_quote", "") or ""
-        if evidence_quote:
-            lines += [
-                "**Evidence quote:**",
-                "> " + evidence_quote.replace("\n", "\n> "),
-                "",
-            ]
-        if f.remediation:
-            lines += [f"**Remediation:** {f.remediation}", ""]
-        if f.owasp_asi_ref:
-            lines += [f"**OWASP ASI:** {f.owasp_asi_ref}", ""]
-        if f.owasp_llm_ref:
-            lines += [f"**OWASP LLM:** {f.owasp_llm_ref}", ""]
-        if f.evidence:
-            lines += [
-                "**Evidence:**",
-                "```",
-                _truncate_evidence(f.evidence, limit=2500),
-                "```",
-                "",
-            ]
-
-    if remediation_plan:
-        _append_remediation_plan(lines, remediation_plan)
-    return "\n".join(lines)
+    """Delegate to :func:`nuguard.redteam.report.to_markdown`."""
+    from nuguard.redteam.report import to_markdown
+    return to_markdown(
+        findings,
+        meta=meta,
+        remediation_plan=remediation_plan,
+        scenario_records=scenario_records,
+    )
 
 
 def _append_remediation_plan(lines: list[str], remediation_plan: list) -> None:
-    """Append a Remediation Plan section to *lines*, grouped by SBOM node.
-
-    Mirrors the behavior report's remediation layout so the developer sees
-    the same actionable, per-node patch / guardrail / architectural-change
-    artefacts regardless of which tool produced the finding.
-    """
-    # Reuse the behavior report's renderer so the format stays identical.
-    from nuguard.behavior.report import _render_artefact
-
-    lines.append("## Remediation Plan")
-    lines.append("")
-    lines.append(
-        "Concrete, SBOM-node-specific remediations generated from the findings "
-        "above. Apply in priority order."
-    )
-    lines.append("")
-
-    # Group by affected component so developers see every change they need
-    # to make to a single agent/tool in one place.
-    by_component: dict[str, list] = {}
-    for art in remediation_plan:
-        by_component.setdefault(art.component, []).append(art)
-
-    for comp, arts in by_component.items():
-        lines.append(f"### {comp}")
-        lines.append("")
-        for art in arts:
-            _render_artefact(lines, art)
+    """Delegate to :func:`nuguard.redteam.report._append_remediation_plan`."""
+    from nuguard.redteam.report import _append_remediation_plan as _impl
+    _impl(lines, remediation_plan)
 
 
 def _build_redteam_remediation_plan(
@@ -896,29 +726,6 @@ def _build_redteam_remediation_plan(
     except Exception as exc:
         _log.warning("remediation synthesis failed — skipping plan: %s", exc)
         return []
-
-
-def _truncate_evidence(text: str, *, limit: int = 2500) -> str:
-    """Trim *text* to ``limit`` chars at a newline/word boundary.
-
-    The previous implementation did ``text[:500]`` which cut mid-word and
-    — worse — kept only the opening warmup turn of multi-turn evidence.
-    This variant prefers breaking on a newline, falling back to a word
-    boundary, and only hard-cuts as a last resort.
-    """
-    if len(text) <= limit:
-        return text
-    cut = text[:limit]
-    # Prefer a newline break within the last ~20% of the window — keeps
-    # turn boundaries intact when the evidence is a transcript.
-    window = max(200, limit // 5)
-    last_nl = cut.rfind("\n", limit - window)
-    if last_nl != -1:
-        return cut[:last_nl] + "\n… (truncated)"
-    last_sp = cut.rfind(" ", limit - 80)
-    if last_sp != -1:
-        return cut[:last_sp] + " … (truncated)"
-    return cut + "… (truncated)"
 
 
 def _fail_on_severity(findings: list, fail_on: str) -> None:

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -237,6 +237,127 @@ async def probe_chat_endpoints(
     return None
 
 
+def discover_chat_config_from_sbom(
+    sbom: "AiSbomDocument",
+    chat_path: str = "",
+    chat_payload_key: str = "message",
+    chat_payload_list: bool = False,
+) -> tuple[str, str, bool, str | None]:
+    """Auto-discover chat endpoint config from SBOM API_ENDPOINT node metadata.
+
+    Looks for a POST endpoint whose metadata has ``chat_payload_key`` set.
+    Falls back to framework-convention inference (e.g. LangGraph ``phrases``/
+    list semantics) when the node lacks an explicit payload key.  Falls back
+    to the provided defaults if nothing is found.
+
+    Returns ``(chat_path, chat_payload_key, chat_payload_list, response_text_key)``.
+    ``response_text_key`` is ``None`` when not determinable from the SBOM.
+
+    This function is zero-I/O (no network calls).  Use :func:`probe_chat_endpoints`
+    for live HTTP probing when the SBOM lacks sufficient metadata.
+    """
+    from nuguard.sbom.models import NodeType  # noqa: PLC0415
+
+    # Detect which AI frameworks are present in the SBOM.
+    summary = getattr(sbom, "summary", None)
+    sbom_frameworks: set[str] = set()
+    if summary is not None:
+        raw = getattr(summary, "frameworks", None)
+        if isinstance(raw, (list, tuple)):
+            sbom_frameworks = {str(f).lower() for f in raw if f}
+    has_langgraph = bool(sbom_frameworks & {"langgraph"})
+
+    candidates: list[tuple[int, str, str, bool, str, str | None]] = []
+    for node in sbom.nodes:
+        if node.component_type != NodeType.API_ENDPOINT:
+            continue
+        meta = node.metadata
+        if not meta:
+            continue
+        if meta.method and meta.method.upper() != "POST":
+            continue
+
+        discovered_path = meta.endpoint or chat_path
+        endpoint_l = discovered_path.lower()
+        source = (meta.extras or {}).get("source")
+
+        # ── Resolve payload key ────────────────────────────────────────────
+        inferred_response_key: str | None = meta.response_text_key or None
+        if meta.chat_payload_key:
+            payload_key = meta.chat_payload_key
+            payload_list = bool(meta.chat_payload_list)
+        elif has_langgraph and any(
+            tok in endpoint_l
+            for tok in ("/run_langgraph", "/run_graph", "/langgraph/run")
+        ):
+            # LangGraph convention: POST {"phrases": ["..."]} → response["prognosis"]
+            payload_key = "phrases"
+            payload_list = True
+            if inferred_response_key is None:
+                inferred_response_key = "prognosis"
+        else:
+            # No payload info and no matching framework convention — skip this node.
+            continue
+
+        # ── Scoring ────────────────────────────────────────────────────────
+        score = 0
+        if source == "auto_enrichment":
+            score -= 2
+        elif source == "runtime_probe":
+            score -= 1
+        else:
+            score += 3
+
+        if node.confidence >= 0.9:
+            score += 2
+        elif node.confidence >= 0.75:
+            score += 1
+
+        if "/chat/message" in endpoint_l:
+            score += 2
+        elif any(token in endpoint_l for token in ("/chat/queue", "/messages", "/message", "/generate", "/completions", "/respond", "/query")):
+            score += 3
+        elif endpoint_l.endswith("/chat"):
+            score += 1
+
+        # LangGraph run endpoint is always the primary agent interface.
+        if "run_langgraph" in endpoint_l or "run_graph" in endpoint_l:
+            score += 3
+
+        if endpoint_l.startswith("/api/"):
+            score += 1
+        if inferred_response_key:
+            score += 1
+
+        # Penalise nodes that had no explicit payload key (inferred).
+        if not meta.chat_payload_key:
+            score -= 1
+
+        # Penalise nodes confirmed dead by the live probe — GET 404 means the
+        # route doesn't exist at all on the deployed target; POST 405 strongly
+        # suggests the path is handled by a different mechanism (e.g. static file
+        # serving on Azure SWA, not the API backend).
+        extras = meta.extras or {}
+        if extras.get("probe_get_404"):
+            score -= 8
+        if extras.get("probe_post_405"):
+            score -= 6
+
+        candidates.append(
+            (score, discovered_path, payload_key, payload_list, node.name, inferred_response_key)
+        )
+
+    if candidates:
+        best = max(candidates, key=lambda item: item[0])
+        _log.info(
+            "SBOM auto-discovered chat config: path=%s key=%s list=%s response_key=%s (node=%s)",
+            best[1], best[2], best[3], best[5], best[4],
+        )
+        return best[1], best[2], best[3], best[5]
+
+    return chat_path, chat_payload_key, chat_payload_list, None
+
+
 def _looks_like_chat_response(data: object, response_key: str | None = None) -> bool:
     """Return True if *data* looks like a processed response from a chat endpoint.
 

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -330,120 +330,13 @@ def _print_redteam_turn(
     )
 
 
-def _discover_chat_config(
-    sbom: AiSbomDocument,
-    chat_path: str,
-    chat_payload_key: str,
-    chat_payload_list: bool,
-) -> tuple[str, str, bool, str | None]:
-    """Auto-discover chat endpoint config from SBOM API_ENDPOINT node metadata.
-
-    Looks for a POST endpoint whose metadata has ``chat_payload_key`` set.
-    Falls back to framework-convention inference (e.g. LangGraph ``phrases``/
-    list semantics) when the node lacks an explicit payload key.  Falls back
-    to the provided defaults if nothing is found.
-
-    Returns ``(chat_path, chat_payload_key, chat_payload_list, response_text_key)``.
-    ``response_text_key`` is ``None`` when not determinable from the SBOM.
-    """
-    # Detect which AI frameworks are present in the SBOM.
-    summary = getattr(sbom, "summary", None)
-    sbom_frameworks: set[str] = set()
-    if summary is not None:
-        raw = getattr(summary, "frameworks", None)
-        if isinstance(raw, (list, tuple)):
-            sbom_frameworks = {str(f).lower() for f in raw if f}
-    has_langgraph = bool(sbom_frameworks & {"langgraph"})
-
-    candidates: list[tuple[int, str, str, bool, str, str | None]] = []
-    for node in sbom.nodes:
-        if node.component_type != NodeType.API_ENDPOINT:
-            continue
-        meta = node.metadata
-        if not meta:
-            continue
-        if meta.method and meta.method.upper() != "POST":
-            continue
-
-        discovered_path = meta.endpoint or chat_path
-        endpoint_l = discovered_path.lower()
-        source = (meta.extras or {}).get("source")
-
-        # ── Resolve payload key ────────────────────────────────────────────
-        inferred_response_key: str | None = meta.response_text_key or None
-        if meta.chat_payload_key:
-            payload_key = meta.chat_payload_key
-            payload_list = bool(meta.chat_payload_list)
-        elif has_langgraph and any(
-            tok in endpoint_l
-            for tok in ("/run_langgraph", "/run_graph", "/langgraph/run")
-        ):
-            # LangGraph convention: POST {"phrases": ["..."]} → response["prognosis"]
-            payload_key = "phrases"
-            payload_list = True
-            if inferred_response_key is None:
-                inferred_response_key = "prognosis"
-        else:
-            # No payload info and no matching framework convention — skip this node.
-            continue
-
-        # ── Scoring ────────────────────────────────────────────────────────
-        score = 0
-        if source == "auto_enrichment":
-            score -= 2
-        elif source == "runtime_probe":
-            score -= 1
-        else:
-            score += 3
-
-        if node.confidence >= 0.9:
-            score += 2
-        elif node.confidence >= 0.75:
-            score += 1
-
-        if "/chat/message" in endpoint_l:
-            score += 2
-        elif any(token in endpoint_l for token in ("/chat/queue", "/messages", "/message", "/generate", "/completions", "/respond", "/query")):
-            score += 3
-        elif endpoint_l.endswith("/chat"):
-            score += 1
-
-        # LangGraph run endpoint is always the primary agent interface.
-        if "run_langgraph" in endpoint_l or "run_graph" in endpoint_l:
-            score += 3
-
-        if endpoint_l.startswith("/api/"):
-            score += 1
-        if inferred_response_key:
-            score += 1
-
-        # Penalise nodes that had no explicit payload key (inferred).
-        if not meta.chat_payload_key:
-            score -= 1
-
-        # Penalise nodes confirmed dead by the live probe — GET 404 means the
-        # route doesn't exist at all on the deployed target; POST 405 strongly
-        # suggests the path is handled by a different mechanism (e.g. static file
-        # serving on Azure SWA, not the API backend).
-        extras = meta.extras or {}
-        if extras.get("probe_get_404"):
-            score -= 8
-        if extras.get("probe_post_405"):
-            score -= 6
-
-        candidates.append(
-            (score, discovered_path, payload_key, payload_list, node.name, inferred_response_key)
-        )
-
-    if candidates:
-        best = max(candidates, key=lambda item: item[0])
-        _log.info(
-            "SBOM auto-discovered chat config: path=%s key=%s list=%s response_key=%s (node=%s)",
-            best[1], best[2], best[3], best[5], best[4],
-        )
-        return best[1], best[2], best[3], best[5]
-
-    return chat_path, chat_payload_key, chat_payload_list, None
+# ---------------------------------------------------------------------------
+# Chat config discovery — delegates to the shared implementation in
+# nuguard.common.endpoint_probe so that BehaviorAnalyzer can reuse it.
+# ---------------------------------------------------------------------------
+from nuguard.common.endpoint_probe import (  # noqa: E402
+    discover_chat_config_from_sbom as _discover_chat_config,
+)
 
 
 def _enrich_policy_from_controls(

--- a/nuguard/redteam/report.py
+++ b/nuguard/redteam/report.py
@@ -1,0 +1,267 @@
+"""Red-team report generation — Markdown and JSON.
+
+Public API mirrors :mod:`nuguard.behavior.report` so callers can import
+either module with the same interface::
+
+    from nuguard.redteam.report import to_markdown, to_json
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nuguard.cli.report_meta import ReportMeta
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def to_json(
+    findings: list,
+    meta: "ReportMeta | None" = None,
+    remediation_plan: list | None = None,
+) -> str:
+    """Generate a JSON report string from red-team findings.
+
+    Args:
+        findings: List of :class:`~nuguard.models.finding.Finding` objects.
+        meta: Optional report metadata.
+        remediation_plan: Optional list of ``RemediationArtefact`` objects.
+
+    Returns:
+        JSON string.
+    """
+    from nuguard.cli.report_meta import ReportMeta as _ReportMeta
+
+    if meta is None:
+        meta = _ReportMeta()
+
+    payload: dict[str, Any] = {
+        "_meta": meta.to_dict(),
+        "findings": [f.model_dump() for f in findings],
+        "remediation_plan": [a.model_dump() for a in (remediation_plan or [])],
+    }
+    return json.dumps(payload, indent=2, default=str)
+
+
+def to_markdown(
+    findings: list,
+    meta: "ReportMeta | None" = None,
+    remediation_plan: list | None = None,
+    scenario_records: list | None = None,
+) -> str:
+    """Render red-team findings as a Markdown report string.
+
+    When *remediation_plan* is supplied (a list of ``RemediationArtefact``
+    objects produced by :class:`~nuguard.behavior.remediation.RemediationSynthesizer`),
+    a ``## Remediation Plan`` section is appended with concrete, SBOM-node
+    specific patches, guardrails and architectural changes grouped by
+    component — matching the behavior report's layout.
+
+    When *scenario_records* is supplied (a list of ``ScenarioRecord`` objects
+    from the orchestrator), a ``## Scenario Coverage`` table is inserted
+    immediately after the report header, before the per-finding detail.
+
+    Args:
+        findings: List of :class:`~nuguard.models.finding.Finding` objects.
+        meta: Optional report metadata.
+        remediation_plan: Optional list of ``RemediationArtefact`` objects.
+        scenario_records: Optional list of ``ScenarioRecord`` objects.
+
+    Returns:
+        Markdown string.
+    """
+    from nuguard.cli.report_meta import ReportMeta as _ReportMeta
+
+    if meta is None:
+        meta = _ReportMeta()
+
+    lines: list[str] = ["# NuGuard Red-Team Report", ""]
+    lines += meta.to_markdown_lines()
+
+    if scenario_records:
+        lines += _scenario_coverage_table(scenario_records)
+
+    if not findings:
+        lines += ["_No findings — scan complete._", ""]
+        return "\n".join(lines)
+
+    from nuguard.models.finding import Severity
+
+    lines += [f"**{len(findings)} finding(s)**", ""]
+    for f in sorted(findings, key=lambda x: list(Severity).index(x.severity)):
+        sev = f.severity.value.upper() if hasattr(f.severity, "value") else str(f.severity).upper()
+        lines += [f"## [{sev}] {f.title}", ""]
+        lines += [f.description, ""]
+        if f.affected_component:
+            lines += [f"**Component:** {f.affected_component}", ""]
+        if f.goal_type:
+            lines += [f"**Type:** {f.goal_type}", ""]
+        # Progress score (1–5 rubric)
+        scores = getattr(f, "scores", None) or {}
+        progress = scores.get("goal_progress")
+        if progress is not None:
+            lines += [f"**Progress score:** {progress}/5", ""]
+        # One-sentence reasoning from the judge
+        reasoning = getattr(f, "reasoning", "") or ""
+        if reasoning:
+            lines += [f"**Finding reasoning:** {reasoning}", ""]
+        # Named success indicator
+        success_indicator = getattr(f, "success_indicator", None)
+        if success_indicator:
+            lines += [f"**Success indicator:** `{success_indicator}`", ""]
+        # Evidence quote — exact substring proving the breach
+        evidence_quote = getattr(f, "evidence_quote", "") or ""
+        if evidence_quote:
+            lines += [
+                "**Evidence quote:**",
+                "> " + evidence_quote.replace("\n", "\n> "),
+                "",
+            ]
+        if f.remediation:
+            lines += [f"**Remediation:** {f.remediation}", ""]
+        if f.owasp_asi_ref:
+            lines += [f"**OWASP ASI:** {f.owasp_asi_ref}", ""]
+        if f.owasp_llm_ref:
+            lines += [f"**OWASP LLM:** {f.owasp_llm_ref}", ""]
+        if f.evidence:
+            lines += [
+                "**Evidence:**",
+                "```",
+                _truncate_evidence(f.evidence, limit=2500),
+                "```",
+                "",
+            ]
+
+    if remediation_plan:
+        _append_remediation_plan(lines, remediation_plan)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (not part of the public API)
+# ---------------------------------------------------------------------------
+
+
+def _scenario_coverage_table(scenario_records: list) -> list[str]:
+    """Return Markdown lines for the Scenario Coverage summary table.
+
+    One row per executed scenario, sorted by impact score descending.
+    Columns: rank, title, goal, finding (YES/no), turns used / budget,
+    duration, avg time per turn.
+
+    A summary line below the table shows aggregate stats.
+    """
+    if not scenario_records:
+        return []
+
+    records = sorted(
+        scenario_records,
+        key=lambda r: (-getattr(r, "impact_score", 0.0), 0 if r.had_finding else 1),
+    )
+
+    _GOAL_ABBREV = {
+        "DATA_EXFILTRATION": "Data Exfil",
+        "PRIVILEGE_ESCALATION": "Priv Esc",
+        "PROMPT_DRIVEN_THREAT": "Prompt Threat",
+        "POLICY_VIOLATION": "Policy Viol",
+        "TOOL_ABUSE": "Tool Abuse",
+        "API_ATTACK": "API Attack",
+        "MCP_TOXIC_FLOW": "MCP Toxic",
+    }
+
+    def _fmt_duration(s: float) -> str:
+        if s <= 0:
+            return "—"
+        return f"{s:.1f}s"
+
+    def _fmt_avg(s: float, turns: int) -> str:
+        if s <= 0 or turns <= 0:
+            return "—"
+        return f"{s / turns:.1f}s"
+
+    lines: list[str] = ["## Scenario Coverage", ""]
+    lines.append("| # | Scenario | Goal | Finding | Turns | Duration | Avg/Turn |")
+    lines.append("|---|---|---|---|---|---|---|")
+
+    total_duration = 0.0
+    total_turns = 0
+    findings_count = 0
+
+    for idx, r in enumerate(records, start=1):
+        title = r.title[:60] + ("…" if len(r.title) > 60 else "")
+        goal = _GOAL_ABBREV.get(r.goal_type, r.goal_type.replace("_", " ").title())
+        finding_cell = "**YES**" if r.had_finding else "no"
+        turns_used = getattr(r, "turns_used", len(r.steps))
+        turns_budget = getattr(r, "turns_budget", 0) or turns_used
+        turns_cell = f"{turns_used}/{turns_budget}"
+        duration = getattr(r, "duration_s", 0.0)
+        dur_cell = _fmt_duration(duration)
+        avg_cell = _fmt_avg(duration, turns_used)
+
+        total_duration += duration
+        total_turns += turns_used
+        if r.had_finding:
+            findings_count += 1
+
+        lines.append(
+            f"| {idx} | {title} | {goal} | {finding_cell} "
+            f"| {turns_cell} | {dur_cell} | {avg_cell} |"
+        )
+
+    n = len(records)
+    avg_scenario = _fmt_duration(total_duration / n if n else 0)
+    avg_turn = _fmt_avg(total_duration, total_turns)
+    lines.append("")
+    lines.append(
+        f"_{n} scenario(s) executed — {findings_count} finding(s). "
+        f"Total: {_fmt_duration(total_duration)} | "
+        f"Avg per scenario: {avg_scenario} | Avg per turn: {avg_turn}_"
+    )
+    lines.append("")
+    return lines
+
+
+def _append_remediation_plan(lines: list[str], remediation_plan: list) -> None:
+    """Append a Remediation Plan section to *lines*, grouped by SBOM node."""
+    from nuguard.behavior.report import _render_artefact
+
+    lines.append("## Remediation Plan")
+    lines.append("")
+    lines.append(
+        "Concrete, SBOM-node-specific remediations generated from the findings "
+        "above. Apply in priority order."
+    )
+    lines.append("")
+
+    by_component: dict[str, list] = {}
+    for art in remediation_plan:
+        by_component.setdefault(art.component, []).append(art)
+
+    for comp, arts in by_component.items():
+        lines.append(f"### {comp}")
+        lines.append("")
+        for art in arts:
+            _render_artefact(lines, art)
+
+
+def _truncate_evidence(text: str, *, limit: int = 2500) -> str:
+    """Trim *text* to ``limit`` chars at a newline/word boundary."""
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    window = max(200, limit // 5)
+    last_nl = cut.rfind("\n", limit - window)
+    if last_nl != -1:
+        return cut[:last_nl] + "\n… (truncated)"
+    last_sp = cut.rfind(" ", limit - 80)
+    if last_sp != -1:
+        return cut[:last_sp] + " … (truncated)"
+    return cut + "… (truncated)"


### PR DESCRIPTION
## Summary

Cherry-pick of two commits from nuguard-private (PRs #43 and #44) into the public repo.

---

### 1. BehaviorAnalyzer endpoint auto-discovery (nuguard-private #43)

Adds shared endpoint auto-discovery to `BehaviorAnalyzer` via a new `nuguard.common.endpoint_probe` helper, mirroring the same capability that already existed in `RedteamOrchestrator`.

**Changes:**
- `nuguard/common/endpoint_probe.py` (new) — shared `discover_chat_config_from_sbom()` helper that probes common chat endpoint paths and reads from SBOM metadata
- `nuguard/behavior/analyzer.py` — uses `discover_chat_config_from_sbom()` when `chat_path` is not explicitly provided
- `nuguard/redteam/executor/orchestrator.py` — refactored to use the shared probe helper instead of its own inline logic

---

### 2. Public `nuguard.redteam.report` module (nuguard-private #44)

Extracts the private CLI markdown helpers into a proper public module, mirroring the existing `nuguard.behavior.report` interface.

**Problem:** `nuguard.behavior.report` has always been a public module with `to_markdown()` and `to_json()`. The equivalent red-team utilities were buried as private functions inside `nuguard/cli/commands/redteam.py`, inaccessible to non-CLI consumers.

**Changes:**
- `nuguard/redteam/report.py` (new) — public `to_markdown(findings, meta, remediation_plan, scenario_records)` and `to_json(findings, meta, remediation_plan)`
- `nuguard/cli/commands/redteam.py` — `_findings_to_markdown`, `_scenario_coverage_table`, `_append_remediation_plan` replaced with thin delegators; `_truncate_evidence` moved to the report module

---

## Validation

Both commits applied cleanly via cherry-pick with no conflicts.

```
# nuguard-private validation (run before cherry-pick):
penv/bin/python3 -c "from nuguard.redteam.report import to_markdown, to_json; print('OK')"
# OK

penv/bin/python3 -m ruff check nuguard/redteam/report.py nuguard/cli/commands/redteam.py
# All checks passed!
```