### PR TITLE
feat: scenario-level 429 backoff for behavior runner and redteam executor

### DIFF
--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -33,6 +33,11 @@ from nuguard.behavior.models import (
 )
 from nuguard.common.console import _console
 from nuguard.common.console import print_turn as _common_print_turn
+from nuguard.common.rate_limit import (
+    SCENARIO_MAX_RATE_LIMIT_RETRIES,
+    is_rate_limited,
+    scenario_rate_limit_backoff,
+)
 
 if TYPE_CHECKING:
     from nuguard.behavior.models import IntentProfile
@@ -356,13 +361,23 @@ class BehaviorRunner:
         _MAX_CONSECUTIVE_FAILURES = 3
 
         turn_delay = float(getattr(self._config, "turn_delay_seconds", 0.0))
+        # Scenario-level 429 state — tracks retries for the *current* turn so that
+        # a rate-limited turn is retried (with backoff) rather than immediately
+        # recorded as FAIL.
+        _rate_limit_retries: int = 0
+        _rate_limit_retry_message: str | None = None
 
         while turn_idx < max_turns:
             # Determine next message
             message: str | None = None
 
+            # 0. Rate-limited turn retry — replay the same message after backoff.
+            if _rate_limit_retry_message is not None:
+                message = _rate_limit_retry_message
+                _rate_limit_retry_message = None
+
             # 1. Queued invocation after a "not used" probe
-            if pending_invocation is not None:
+            elif pending_invocation is not None:
                 message, _ = pending_invocation
                 pending_invocation = None
 
@@ -413,6 +428,20 @@ class BehaviorRunner:
                     if refreshed:
                         client.update_default_headers(self._auth_session.headers())
                         response, canary_hits = await client.send(message, session=session)
+                # 429 scenario-level retry — on top of TargetAppClient's per-request
+                # retries.  Back off and replay the same turn; do NOT record a FAIL
+                # verdict or increment consecutive_failures (target is alive).
+                if is_rate_limited(response) and _rate_limit_retries < SCENARIO_MAX_RATE_LIMIT_RETRIES:
+                    await scenario_rate_limit_backoff(
+                        _rate_limit_retries, context=scenario.name
+                    )
+                    _rate_limit_retries += 1
+                    _rate_limit_retry_message = message
+                    _console.print(
+                        f"  [yellow]⏳ Rate limited (429) — backing off "
+                        f"({_rate_limit_retries}/{SCENARIO_MAX_RATE_LIMIT_RETRIES})[/yellow]"
+                    )
+                    continue
                 # Treat any HTTP error response as a failure so the circuit
                 # breaker also fires for persistent 4xx (e.g. 405, 400, 422)
                 # which the TargetAppClient returns as strings, not exceptions.
@@ -420,6 +449,7 @@ class BehaviorRunner:
                     send_error = response
                 else:
                     consecutive_failures = 0  # reset only on a real reply
+                    _rate_limit_retries = 0   # reset on successful reply
             except Exception as exc:
                 send_error = str(exc)
                 _log.warning("_run_scenario turn %d: send failed: %s", turn_idx + 1, exc)
@@ -440,7 +470,13 @@ class BehaviorRunner:
 
             # On send error: record a FAIL verdict immediately and check abort threshold.
             if send_error is not None:
-                consecutive_failures += 1
+                _rate_limit_retries = 0  # reset for the next turn
+                # 429: target is alive (just rate-limiting) — do not count toward
+                # the circuit breaker that aborts the scenario on repeated failures.
+                if is_rate_limited(send_error):
+                    consecutive_failures = 0
+                else:
+                    consecutive_failures += 1
                 _fail_verdict = TurnVerdict(
                     turn=turn_idx + 1,
                     scenario_name=scenario.name,

--- a/nuguard/common/rate_limit.py
+++ b/nuguard/common/rate_limit.py
@@ -1,0 +1,77 @@
+"""Shared 429 rate-limit detection and scenario-level backoff helpers.
+
+``TargetAppClient`` handles 429 at the HTTP-request level (up to 2 retries with
+exponential backoff + ``Retry-After`` header support).  These helpers add a
+*second tier*: scenario/step-level backoff that fires when all request-level
+retries are exhausted and the target is still returning 429.
+
+Usage pattern
+-------------
+Both ``BehaviorRunner`` and ``AttackExecutor`` import from this module so the
+retry logic and constants are defined in exactly one place.
+
+    from nuguard.common.rate_limit import (
+        SCENARIO_MAX_RATE_LIMIT_RETRIES,
+        is_rate_limited,
+        scenario_rate_limit_backoff,
+    )
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+
+_log = logging.getLogger(__name__)
+
+# Sentinel prefix emitted by TargetAppClient when a 429 exhausts all
+# per-request retries.
+_RATE_LIMIT_PREFIX = "[HTTP 429]"
+
+# Scenario-level 429 defaults (layered *on top of* TargetAppClient's own
+# per-request retry loop).
+SCENARIO_MAX_RATE_LIMIT_RETRIES: int = 3
+SCENARIO_RATE_LIMIT_BACKOFF_BASE: float = 2.0   # seconds
+SCENARIO_RATE_LIMIT_BACKOFF_CAP: float = 30.0   # seconds
+
+
+def is_rate_limited(response: str) -> bool:
+    """Return ``True`` when TargetAppClient returned a 429 sentinel.
+
+    This happens after all per-request retries inside TargetAppClient are
+    exhausted and the target is *still* responding with HTTP 429.
+    """
+    return response.startswith(_RATE_LIMIT_PREFIX)
+
+
+async def scenario_rate_limit_backoff(
+    attempt: int,
+    *,
+    base_seconds: float = SCENARIO_RATE_LIMIT_BACKOFF_BASE,
+    cap_seconds: float = SCENARIO_RATE_LIMIT_BACKOFF_CAP,
+    context: str = "",
+) -> float:
+    """Sleep with capped exponential backoff + jitter for scenario-level 429.
+
+    Args:
+        attempt: Zero-based retry attempt number (0 = first retry).
+        base_seconds: Base delay before exponential growth.
+        cap_seconds: Maximum sleep duration.
+        context: Optional context string for the warning log message.
+
+    Returns:
+        Actual sleep duration in seconds (useful for tests).
+    """
+    delay = min(base_seconds * (2 ** attempt), cap_seconds)
+    jitter = random.uniform(0.0, delay * 0.25)
+    total = round(delay + jitter, 2)
+    _log.warning(
+        "Rate limited (429) at scenario level%s — backing off %.1fs "
+        "(attempt %d/%d)",
+        f" [{context}]" if context else "",
+        total,
+        attempt + 1,
+        SCENARIO_MAX_RATE_LIMIT_RETRIES,
+    )
+    await asyncio.sleep(total)
+    return total

--- a/nuguard/redteam/executor/executor.py
+++ b/nuguard/redteam/executor/executor.py
@@ -5,6 +5,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from nuguard.common.llm_client import LLMClient
+from nuguard.common.rate_limit import (
+    SCENARIO_MAX_RATE_LIMIT_RETRIES,
+    is_rate_limited,
+    scenario_rate_limit_backoff,
+)
 
 if TYPE_CHECKING:
     from nuguard.common.auth import AuthSession
@@ -344,6 +349,17 @@ class AttackExecutor:
                     "Chain %s step %s: 401 received on chat endpoint, retrying after auth refresh",
                     chain.chain_id,
                     step.step_id,
+                )
+                response, tool_calls = await self._client.send(payload, session)
+            # 429 scenario-level retry — on top of TargetAppClient's per-request
+            # retries.  Back off and retry the same step payload; the target is
+            # alive and functioning, so this must NOT count as a chain failure.
+            for _rl_attempt in range(SCENARIO_MAX_RATE_LIMIT_RETRIES):
+                if not is_rate_limited(response):
+                    break
+                await scenario_rate_limit_backoff(
+                    _rl_attempt,
+                    context=f"chain={chain.chain_id} step={step.step_id}",
                 )
                 response, tool_calls = await self._client.send(payload, session)
             session.add_turn(payload, response, tool_calls)


### PR DESCRIPTION
## Summary

Cherry-pick of nuguard-private#46 into the public repo.

Adds a second tier of 429 rate-limit handling on top of the per-request retries already in `TargetAppClient`.  When the target is persistently rate-limiting and all per-request retries are exhausted, a scenario/step-level retry kicks in — so runs can survive transient API quota bursts without recording false FAIL verdicts.

---

### New: `nuguard/common/rate_limit.py`

Shared module used by both behavior and redteam paths:

- `is_rate_limited(response)` — detects `[HTTP 429]` sentinels emitted by `TargetAppClient`
- `scenario_rate_limit_backoff(attempt, context)` — capped exponential backoff (2s base → 30s cap, 25% jitter)
- `SCENARIO_MAX_RATE_LIMIT_RETRIES = 3`

---

### `nuguard/behavior/runner.py` — per-turn retry

- Intercepts 429 after `TargetAppClient` exhausts its per-request retries
- Priority-0 retry slot: replays the same message after backoff without consuming `turn_idx`
- 429s do **not** count toward the consecutive-failure circuit breaker (target is alive)
- Prints an amber `⏳ Rate limited (429) — backing off (n/3)` to the console
- `_rate_limit_retries` resets on every successful reply

### `nuguard/redteam/executor/executor.py` — per-step retry

- In-place retry loop after the 401 refresh-and-retry check on the chat send path
- Mirrors the same pattern, delegates entirely to `scenario_rate_limit_backoff()`

---

### Net retry budget per message

| Layer | Retries | Backoff |
|---|---|---|
| `TargetAppClient` (per-request) | 2 | 0.5s base, 5s cap, Retry-After aware |
| Scenario-level (this PR) | 3 | 2s base, 30s cap, 25% jitter |
| **Total attempts** | **up to 9** | — |

---

## Validation

Cherry-picked cleanly from nuguard-private#46 with no conflicts.

```
penv/bin/ruff check nuguard/common/rate_limit.py nuguard/behavior/runner.py nuguard/redteam/executor/executor.py
# All checks passed!
```