### PR TITLE
feat: sync scan_outcome values across red team and behavior (v0.4.2)

### DIFF
--- a/nuguard/behavior/analyzer.py
+++ b/nuguard/behavior/analyzer.py
@@ -80,6 +80,8 @@ class BehaviorAnalyzer:
         coverage = []
         scenario_results = []
         skipped_scenario_names: list[str] = []
+        _dynamic_run_result = None  # captured for abort/inconclusive propagation
+        _dynamic_scan_outcome = None
 
         if "dynamic" in mode:
             target_url = getattr(self._config, "target", None) or ""
@@ -212,6 +214,8 @@ class BehaviorAnalyzer:
                     judge_cache=judge_cache,
                 )
                 run_result = await runner.run(scenarios)
+                _dynamic_run_result = run_result
+                _dynamic_scan_outcome = run_result.scan_outcome
                 dynamic_findings = run_result.findings
                 coverage = run_result.coverage
                 scenario_results = run_result.scenario_results
@@ -225,6 +229,8 @@ class BehaviorAnalyzer:
             scenario_results=scenario_results,
             scenarios_skipped=skipped_scenario_names,
         )
+        if _dynamic_scan_outcome is not None:
+            result.dynamic_scan_outcome = _dynamic_scan_outcome
 
         # Step 5: Generate recommendations
         result.recommendations = self._rec_engine.generate(result)
@@ -250,6 +256,12 @@ class BehaviorAnalyzer:
             result.scan_outcome = "high_findings"
         elif all_findings:
             result.scan_outcome = "findings"
+        elif _dynamic_run_result is not None and _dynamic_run_result.scan_outcome in (
+            "aborted_target_unavailable",
+            "inconclusive_target_errors",
+        ):
+            # No findings from either phase; propagate target-health outcome from runner
+            result.scan_outcome = _dynamic_run_result.scan_outcome
         else:
             result.scan_outcome = "no_findings"
 

--- a/nuguard/behavior/models.py
+++ b/nuguard/behavior/models.py
@@ -286,12 +286,11 @@ class BehaviorAnalysisResult(BaseModel):
     @computed_field  # type: ignore[misc]
     @property
     def overall_risk_score(self) -> float:
-        """Compute overall risk score from findings.
+        """Compute overall risk score (0–100) as the weighted average severity.
 
-        Normalizes to [0, 10] as: (sum of severity weights) / (n_findings * 10).
-        Weights: critical=10, high=7, medium=4, low=1, info=0.
-        Returns the average severity scaled to 0–10, so mixed-severity sets
-        score below 10 rather than immediately pinning at the cap.
+        Weights: critical=100, high=70, medium=40, low=10, info=0.
+        Score = mean of per-finding weights, so volume and mix of severities
+        influence the score proportionally. Consistent with red-team scoring.
         """
         all_findings: list[dict[str, Any]] = [
             *self.static_findings,
@@ -299,10 +298,16 @@ class BehaviorAnalysisResult(BaseModel):
         ]
         if not all_findings:
             return 0.0
-        weights = {"critical": 10.0, "high": 7.0, "medium": 4.0, "low": 1.0, "info": 0.0}
-        total = sum(weights.get(str(f.get("severity", "low")).lower(), 1.0) for f in all_findings)
-        max_possible = len(all_findings) * 10.0
-        return round((total / max_possible) * 10.0, 2)
+        _weights = {"critical": 100.0, "high": 70.0, "medium": 40.0, "low": 10.0, "info": 0.0}
+
+        def _sev_key(raw: object) -> str:
+            # Normalise plain strings ("high", "HIGH") and enum-style strings
+            # ("Severity.HIGH") produced by str(Severity.HIGH) on Python 3.12+.
+            s = str(raw).lower()
+            return s.rsplit(".", 1)[-1] if "." in s else s
+
+        total = sum(_weights.get(_sev_key(f.get("severity", "low")), 10.0) for f in all_findings)
+        return round(total / len(all_findings), 2)
 
     broken_chains: list[str] = Field(default_factory=list)
     """Names of chained scenarios where the chain broke mid-turn."""
@@ -312,6 +317,13 @@ class BehaviorAnalysisResult(BaseModel):
 
     allowed_topics_tested: list[str] = Field(default_factory=list)
     """Allowed topics from cognitive policy that were exercised."""
+
+    dynamic_scan_outcome: str | None = None
+    """Outcome from the dynamic runner phase alone (before static findings override it).
+    Set to ``aborted_target_unavailable`` or ``inconclusive_target_errors`` when the
+    dynamic phase encountered target errors, even if static findings changed the final
+    ``scan_outcome``.
+    """
 
     @computed_field  # type: ignore[misc]
     @property

--- a/nuguard/behavior/report.py
+++ b/nuguard/behavior/report.py
@@ -90,7 +90,19 @@ def to_markdown(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = No
     lines.append("")
     lines.append(f"- **Intent**: {result.intent.app_purpose or 'not determined'}")
     lines.append(f"- **Analysis Mode**: {mode}")
-    lines.append(f"- **Overall Risk Score**: {result.overall_risk_score:.1f} / 10")
+    _dyn_outcome = getattr(result, "dynamic_scan_outcome", None)
+    if result.static_findings and _dyn_outcome in ("aborted_target_unavailable", "inconclusive_target_errors"):
+        if _dyn_outcome == "aborted_target_unavailable":
+            lines.append(
+                "> **Note:** Dynamic scenario testing was aborted — the target was unreachable. "
+                "All scenario probes returned HTTP errors. Findings below are from static analysis only."
+            )
+        else:
+            lines.append(
+                "> **Note:** Dynamic scenario testing encountered significant target errors "
+                "and did not complete. Findings below are from static analysis only."
+            )
+    lines.append(f"- **Overall Risk Score**: {result.overall_risk_score:.1f} / 100")
     total_comp = len(result.coverage)
     exercised = sum(1 for c in result.coverage if c.exercised)
     lines.append(f"- **Coverage**: {result.coverage_percentage * 100:.0f}% ({exercised}/{total_comp} components exercised)")
@@ -529,7 +541,7 @@ def to_text(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = None) 
     # Summary panel
     summary_lines = [
         f"Intent:        {result.intent.app_purpose or 'not determined'}",
-        f"Risk Score:    {result.overall_risk_score:.1f} / 10",
+        f"Risk Score:    {result.overall_risk_score:.1f} / 100",
         f"Coverage:      {result.coverage_percentage * 100:.0f}%",
         f"Alignment:     {result.intent_alignment_score:.2f} / 5.0",
         f"Findings:      {len(result.static_findings) + len(result.dynamic_findings)}",

--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -1127,7 +1127,7 @@ class BehaviorRunner:
         # Build coverage map from all scenarios
         coverage = self._build_coverage_map(scenario_results)
 
-        # Determine scan outcome
+        # Determine scan outcome — severity-tiered first, then target health
         has_critical = any(str(f.get("severity", "")).lower() == "critical" for f in all_findings)
         has_high = any(str(f.get("severity", "")).lower() == "high" for f in all_findings)
         scan_outcome = "no_findings"
@@ -1137,6 +1137,16 @@ class BehaviorRunner:
             scan_outcome = "high_findings"
         elif all_findings:
             scan_outcome = "findings"
+        else:
+            # No findings — check if the target was unreachable during dynamic phase
+            _HTTP_ERROR = "http_error"
+            all_devs = [d for r in scenario_results for d in r.deviations]
+            if all_devs:
+                http_err_count = sum(1 for d in all_devs if d.get("deviation_type") == _HTTP_ERROR)
+                if http_err_count == len(all_devs):
+                    scan_outcome = "aborted_target_unavailable"
+                elif http_err_count / len(all_devs) >= 0.80:
+                    scan_outcome = "inconclusive_target_errors"
 
         _console.rule("[bold]Run complete[/bold]", style="bold cyan")
         _console.print(

--- a/nuguard/behavior/tests/test_models.py
+++ b/nuguard/behavior/tests/test_models.py
@@ -187,8 +187,8 @@ def test_behavior_analysis_result_risk_score():
             {"severity": "high", "title": "Bad thing 2"},
         ],
     )
-    # critical (10) + high (7) = 17; normalized: (17 / (2 * 10)) * 10 = 8.5
-    assert result.overall_risk_score == 8.5
+    # critical (100) + high (70) = 170; avg: 170 / 2 = 85.0
+    assert result.overall_risk_score == 85.0
 
 
 def test_behavior_analysis_result_risk_score_medium():
@@ -196,7 +196,7 @@ def test_behavior_analysis_result_risk_score_medium():
         intent=IntentProfile(),
         static_findings=[{"severity": "medium", "title": "medium thing"}],
     )
-    assert result.overall_risk_score == 4.0
+    assert result.overall_risk_score == 40.0
 
 
 def test_behavior_analysis_result_coverage_percentage():

--- a/nuguard/behavior/tests/test_report.py
+++ b/nuguard/behavior/tests/test_report.py
@@ -80,7 +80,7 @@ def test_to_json_with_findings():
         static_findings=[{"severity": "high", "title": "Bad thing"}],
     )
     data = json.loads(to_json(result))
-    assert data["overall_risk_score"] == 7.0
+    assert data["overall_risk_score"] == 70.0
     assert len(data["static_findings"]) == 1
 
 

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -177,7 +177,7 @@ def redteam(
         raise typer.Exit(code=1)
 
     try:
-        findings, llm_remediations, scenario_records = asyncio.run(
+        findings, llm_remediations, scenario_records, scan_outcome = asyncio.run(
             _run_redteam(
                 sbom_doc=sbom_doc,
                 sbom_path=sbom_path,
@@ -266,7 +266,7 @@ def redteam(
     )
 
     _print_findings(findings, effective_format, meta, remediation_plan=remediation_plan,
-                    scenario_records=scenario_records)
+                    scenario_records=scenario_records, scan_outcome=scan_outcome)
     if output:
         if effective_format == "markdown":
             output.write_text(
@@ -277,6 +277,7 @@ def redteam(
         else:
             payload = {
                 "_meta": meta.to_dict(),
+                "scan_outcome": scan_outcome,
                 "findings": [f.model_dump() for f in findings],
                 "remediation_plan": [a.model_dump() for a in remediation_plan],
             }
@@ -379,7 +380,7 @@ async def _run_redteam(
     turn_delay_seconds: float = 0.0,
     scenario_delay_seconds: float = 0.0,
     similar_miss_threshold: int = 4,
-) -> tuple[list, dict[str, str], list]:
+) -> tuple[list, dict[str, str], list, str]:
     """Async inner function: optionally launch the app, then run the orchestrator."""
     from nuguard.models.policy import CognitivePolicy
     from nuguard.redteam.target.canary import CanaryConfig
@@ -582,7 +583,7 @@ async def _run_orchestrator(
     turn_delay_seconds: float = 0.0,
     scenario_delay_seconds: float = 0.0,
     similar_miss_threshold: int = 4,
-) -> tuple[list, dict[str, str], list]:
+) -> tuple[list, dict[str, str], list, str]:
     from nuguard.common.llm_client import LLMClient
     from nuguard.redteam.executor.orchestrator import RedteamOrchestrator
 
@@ -642,7 +643,8 @@ async def _run_orchestrator(
             )
         ]
 
-    return findings, llm_remediations, scenario_records
+    scan_outcome = orchestrator.scan_outcome
+    return findings, llm_remediations, scenario_records, scan_outcome
 
 
 def _print_findings(
@@ -651,6 +653,7 @@ def _print_findings(
     meta: ReportMeta | None = None,
     remediation_plan: list | None = None,
     scenario_records: list | None = None,
+    scan_outcome: str = "no_findings",
 ) -> None:
     """Print findings to stdout in the requested format."""
     from nuguard.models.finding import Severity
@@ -661,6 +664,7 @@ def _print_findings(
     if format == "json":
         payload = {
             "_meta": meta.to_dict(),
+            "scan_outcome": scan_outcome,
             "findings": [f.model_dump() for f in findings],
             "remediation_plan": [a.model_dump() for a in (remediation_plan or [])],
         }
@@ -676,6 +680,7 @@ def _print_findings(
 
     if not findings:
         typer.echo(meta.to_text_line())
+        typer.echo(f"Outcome: {scan_outcome}")
         typer.echo("No findings — scan complete")
         return
 
@@ -690,6 +695,7 @@ def _print_findings(
     typer.echo(f"\n{'─' * 60}")
     typer.echo(f"  NuGuard Red-Team — {len(findings)} finding(s)")
     typer.echo(f"  {meta.to_text_line()}")
+    typer.echo(f"  Outcome: {scan_outcome}")
     typer.echo(f"{'─' * 60}")
     for f in sorted(findings, key=lambda x: list(Severity).index(x.severity)):
         colour = _SEV_COLOUR.get(f.severity, "white")

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -195,8 +195,12 @@ def _compute_scan_outcome(
 
     Values
     ------
-    ``passed``
-        At least one finding was raised — the target has confirmed vulnerabilities.
+    ``critical_findings``
+        At least one finding with severity CRITICAL was raised.
+    ``high_findings``
+        No critical findings, but at least one HIGH severity finding.
+    ``findings``
+        Findings exist but none are critical or high (medium / low / info).
     ``no_findings``
         Scan ran to completion but no findings were raised.
     ``inconclusive_target_errors``
@@ -209,7 +213,15 @@ def _compute_scan_outcome(
         (the circuit breaker tripped), indicating the target was unreachable.
     """
     if findings:
-        return "passed"
+        def _sev(f: object) -> str:
+            s = getattr(f, "severity", None)
+            return str(getattr(s, "value", s) or "").lower()
+        sevs = {_sev(f) for f in findings}
+        if "critical" in sevs:
+            return "critical_findings"
+        if "high" in sevs:
+            return "high_findings"
+        return "findings"
 
     # Check for full abort (circuit breaker fired on every scenario)
     if records and all(r.chain_status in ("aborted", "skipped") for r in records):
@@ -511,7 +523,7 @@ class RedteamOrchestrator:
         self.prompt_cache_hit: bool = False            # True when payloads loaded from cache
         self.llm_scenario_variants: dict[str, int] = {}  # scenario_title → variant_count
         # Scan-level outcome — populated by run()
-        # Values: passed | no_findings | inconclusive_target_errors | aborted_target_unavailable
+        # Values: critical_findings | high_findings | findings | no_findings | inconclusive_target_errors | aborted_target_unavailable
         self.scan_outcome: str = "no_findings"
 
     def _trigger_enabled(self, name: str) -> bool:

--- a/nuguard/redteam/report.py
+++ b/nuguard/redteam/report.py
@@ -26,6 +26,7 @@ def to_json(
     findings: list,
     meta: "ReportMeta | None" = None,
     remediation_plan: list | None = None,
+    scan_outcome: str = "no_findings",
 ) -> str:
     """Generate a JSON report string from red-team findings.
 
@@ -44,6 +45,7 @@ def to_json(
 
     payload: dict[str, Any] = {
         "_meta": meta.to_dict(),
+        "scan_outcome": scan_outcome,
         "findings": [f.model_dump() for f in findings],
         "remediation_plan": [a.model_dump() for a in (remediation_plan or [])],
     }
@@ -91,6 +93,19 @@ def to_markdown(
     lines += ["## Summary", ""]
     if meta.scan_profile:
         lines += [f"- **Scan Profile**: {meta.scan_profile}", ""]
+    _WEIGHTS = {"CRITICAL": 100.0, "HIGH": 70.0, "MEDIUM": 40.0, "LOW": 10.0, "INFO": 0.0}
+    if findings:
+        _scores = [
+            _WEIGHTS.get(
+                f.severity.value.upper() if hasattr(f.severity, "value") else str(f.severity).upper(),
+                10.0,
+            )
+            for f in findings
+        ]
+        _risk_score = round(sum(_scores) / len(_scores), 1)
+    else:
+        _risk_score = 0.0
+    lines += [f"- **Overall Risk Score**: {_risk_score:.1f} / 100", ""]
     total = len(findings)
     lines += [f"- **Total Findings**: {total}", ""]
     if findings:

--- a/nuguard/redteam/tests/test_orchestrator_outcome.py
+++ b/nuguard/redteam/tests/test_orchestrator_outcome.py
@@ -8,6 +8,8 @@ Covers:
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from nuguard.redteam.executor.orchestrator import (
     ScenarioRecord,
     _classify_step_transport,
@@ -145,16 +147,37 @@ def _record_with_counters(
     return r
 
 
-def _fake_finding() -> object:
-    """Return a truthy stand-in for a Finding object."""
-    return object()
+def _fake_finding(severity: str = "critical") -> object:
+    """Return a Finding-like object with a .severity attribute."""
+    return SimpleNamespace(severity=SimpleNamespace(value=severity))
 
 
-def test_outcome_passed_when_findings():
-    """Any finding → passed, regardless of transport health."""
+def test_outcome_critical_findings():
+    """Critical severity finding → critical_findings."""
     records = [_record_with_counters(http_5xx=5)]
-    outcome = _compute_scan_outcome(findings=[_fake_finding()], records=records, strict=True)
-    assert outcome == "passed"
+    outcome = _compute_scan_outcome(findings=[_fake_finding("critical")], records=records, strict=True)
+    assert outcome == "critical_findings"
+
+
+def test_outcome_high_findings():
+    """High severity finding, no critical → high_findings."""
+    records = [_record_with_counters(http_2xx=5)]
+    outcome = _compute_scan_outcome(findings=[_fake_finding("high")], records=records, strict=False)
+    assert outcome == "high_findings"
+
+
+def test_outcome_findings_medium():
+    """Medium severity finding, no critical/high → findings."""
+    records = [_record_with_counters(http_2xx=5)]
+    outcome = _compute_scan_outcome(findings=[_fake_finding("medium")], records=records, strict=False)
+    assert outcome == "findings"
+
+
+def test_outcome_critical_wins_over_transport_errors():
+    """Critical finding wins even when transport is mostly errors (strict=True)."""
+    records = [_record_with_counters(http_5xx=5)]
+    outcome = _compute_scan_outcome(findings=[_fake_finding("critical")], records=records, strict=True)
+    assert outcome == "critical_findings"
 
 
 def test_outcome_no_findings_default():

--- a/tests/behavior/test_report.py
+++ b/tests/behavior/test_report.py
@@ -30,34 +30,34 @@ def test_risk_score_no_findings():
 
 def test_risk_score_single_critical():
     result = _make_result(dynamic_findings=[_finding("critical")])
-    assert result.overall_risk_score == 10.0
+    assert result.overall_risk_score == 100.0
 
 
 def test_risk_score_single_high():
     result = _make_result(dynamic_findings=[_finding("high")])
-    assert result.overall_risk_score == 7.0
+    assert result.overall_risk_score == 70.0
 
 
 def test_risk_score_single_medium():
     result = _make_result(dynamic_findings=[_finding("medium")])
-    assert result.overall_risk_score == 4.0
+    assert result.overall_risk_score == 40.0
 
 
 def test_risk_score_single_low():
     result = _make_result(dynamic_findings=[_finding("low")])
-    assert result.overall_risk_score == 1.0
+    assert result.overall_risk_score == 10.0
 
 
 def test_risk_score_mixed_critical_and_low():
-    # (10 + 1) / (2 * 10) * 10 = 5.5
+    # avg(100, 10) = 55.0
     result = _make_result(dynamic_findings=[_finding("critical"), _finding("low")])
-    assert result.overall_risk_score == 5.5
+    assert result.overall_risk_score == 55.0
 
 
 def test_risk_score_two_highs_below_10():
-    # 2 HIGH: (7+7)/(2*10)*10 = 7.0 — no longer capped-but-misleading 10.0
+    # avg(70, 70) = 70.0
     result = _make_result(dynamic_findings=[_finding("high"), _finding("high")])
-    assert result.overall_risk_score == 7.0
+    assert result.overall_risk_score == 70.0
 
 
 def test_risk_score_uses_static_and_dynamic():
@@ -65,8 +65,8 @@ def test_risk_score_uses_static_and_dynamic():
         static_findings=[_finding("medium")],
         dynamic_findings=[_finding("high")],
     )
-    # (4 + 7) / (2 * 10) * 10 = 5.5
-    assert result.overall_risk_score == 5.5
+    # avg(40, 70) = 55.0
+    assert result.overall_risk_score == 55.0
 
 
 def test_risk_score_info_counts_as_zero_weight():


### PR DESCRIPTION
## Summary

Cherry-pick of nuguard-private PR #58 (squash-merged to develop) into the public repo.

Unifies `scan_outcome` values and risk scoring across the behavior and red-team services so both produce consistent, comparable output.

### Changes

**scan_outcome unification**
- Red team `_compute_scan_outcome`: replaces `'passed'` with severity-tiered values `critical_findings` / `high_findings` / `findings` — matching behavior's existing system
- Behavior runner: detects transport-health outcomes (`aborted_target_unavailable`, `inconclusive_target_errors`) from deviation patterns when no findings are present
- Behavior analyzer: propagates abort/inconclusive outcome from dynamic phase; static findings always win

Unified values across both services:
`critical_findings | high_findings | findings | no_findings | aborted_target_unavailable | inconclusive_target_errors`

**Risk score (0–100 weighted average)**
- `behavior/models.py`: `overall_risk_score` switched to weighted avg on 0–100 scale (CRITICAL=100, HIGH=70, MEDIUM=40, LOW=10, INFO=0) + `_sev_key()` helper to normalise `str(Severity.HIGH)` → `'Severity.HIGH'` on Python 3.12+
- `behavior/report.py`: display updated to `/ 100`
- `redteam/report.py`: Summary now shows **Overall Risk Score** using same weighted avg formula

**scan_outcome surfaced in redteam output**
- JSON output (stdout + file): `scan_outcome` field added to payload
- Terminal text: `Outcome: {scan_outcome}` line printed
- `to_json()`: `scan_outcome` param added

**Static/dynamic analysis notes in behavior report**
- Summary shows a note when dynamic testing was aborted but static findings exist

**Tests**
- `test_orchestrator_outcome.py`: severity-specific outcome tests replacing the generic `passed_when_findings` test
- All risk score assertions updated to 0–100 scale

## Validation

```
python -m pytest nuguard/ tests/ --ignore=tests/apps --ignore=tests/benchmark -q
1892 passed, 5 skipped in 21.60s

uv run ruff check nuguard/
All checks passed!
```