### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.4.2"
+version = "0.4.3"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Bumps `pyproject.toml` version from `0.4.2` → `0.4.3`.