### PR TITLE
fix(behavior): correct scan_outcome for high/critical severity findings

### DIFF
--- a/nuguard/behavior/analyzer.py
+++ b/nuguard/behavior/analyzer.py
@@ -73,7 +73,7 @@ class BehaviorAnalyzer:
             static_findings_objs = check_alignment(self._sbom, intent, self._policy)
             _log.info("BehaviorAnalyzer.analyze: %d static findings", len(static_findings_objs))
 
-        static_findings = [f.model_dump() for f in static_findings_objs]
+        static_findings = [f.model_dump(mode="json") for f in static_findings_objs]
 
         # Step 3: Dynamic analysis
         dynamic_findings: list[dict] = []

--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -1026,13 +1026,21 @@ class BehaviorRunner:
             # Accumulate deviations and findings
             scenario_deviations.extend(verdict.deviations)
             for violation in violations:
+                _vsev = violation.get("severity", "medium").lower()
                 findings.append({
                     "finding_id": str(uuid.uuid4()),
                     "title": f"Policy violation: {violation.get('type', 'unknown')}",
-                    "severity": violation.get("severity", "medium").lower(),
+                    "severity": _vsev,
                     "description": violation.get("evidence", ""),
                     "affected_component": scenario.target_component or "unknown",
                     "policy_clause": violation.get("policy_clause", ""),
+                })
+                # Mirror into scenario_deviations so run() aggregation can include
+                # these in BehaviorRunResult.findings and compute scan_outcome correctly.
+                scenario_deviations.append({
+                    "deviation_type": "policy_violation",
+                    "description": violation.get("evidence", ""),
+                    "severity": _vsev,
                 })
             if canary_hits:
                 findings.append({
@@ -1041,6 +1049,11 @@ class BehaviorRunner:
                     "severity": "critical",
                     "description": f"Canary values found in response: {canary_hits}",
                     "affected_component": scenario.target_component or "unknown",
+                })
+                scenario_deviations.append({
+                    "deviation_type": "data_leak",
+                    "description": f"Canary values found in response: {canary_hits}",
+                    "severity": "critical",
                 })
 
             turn_idx += 1
@@ -1221,7 +1234,7 @@ class BehaviorRunner:
                     all_findings.append({
                         "finding_id": str(uuid.uuid4()),
                         "title": dev.get("description", "Behavioral deviation"),
-                        "severity": dev.get("severity", "medium"),
+                        "severity": str(dev.get("severity", "medium")).lower(),
                         "description": dev.get("description", ""),
                         "affected_component": (getattr(orig, "target_component", None) or "unknown"),
                     })


### PR DESCRIPTION
## Summary

Two bugs caused `scan_outcome` to report `"findings"` even when high- or critical-severity violations existed during behavior analysis.

### Bug 1 — `analyzer.py`: static findings severity lost on Python ≤ 3.11

`static_findings = [f.model_dump() for f in static_findings_objs]`

Pydantic v2 `model_dump()` without `mode="json"` returns the `Severity` enum instance as the dict value. On Python ≤ 3.11, `str(Severity.HIGH)` produces `"Severity.HIGH"`, so the Step 6 check:

```python
str(f.get("severity", "")).lower() == "high"  # → "severity.high" == "high" → False
```

always evaluated `False`, and `scan_outcome` fell through to `"findings"` regardless of severity.

**Fix:** `model_dump(mode="json")` so severity is always a plain lowercase string (`"high"`, `"critical"`, etc.).

### Bug 2 — `runner.py`: policy violation findings silently dropped

Inside `_run_scenario()`, policy violations were accumulated into a local `findings` list that was **never returned** — `ScenarioResult` has no `findings` field. The `run()` aggregation loop tried to recover them by filtering `scenario_deviations` for `deviation_type="policy_violation"`, but `BehaviorJudge._detect_deviations()` never emits that type. Result: all policy violation findings were silently dropped from `BehaviorRunResult.findings`, so `scan_outcome` saw zero findings.

**Fix:** Mirror each policy violation and canary hit into `scenario_deviations` with the correct `deviation_type` (`"policy_violation"` / `"data_leak"`) so the existing `run()` aggregation picks them up correctly. Also normalise severity to lowercase in the aggregation step for robustness.

## Validation

```
ruff check nuguard/behavior/analyzer.py nuguard/behavior/runner.py
# All checks passed!
```