### PR TITLE
feat: validation improvements, analyze enhancements, MCP plugin, and v0.4.6

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --extra mcp
 
       - name: Run package unit tests
         run: uv run pytest nuguard/ -q

--- a/docs/doc.html
+++ b/docs/doc.html
@@ -332,6 +332,7 @@
                         <li><a href="doc.html?page=policy-engine-guide" data-page="policy-engine-guide">Policy Engine Guide</a></li>
                         <li><a href="doc.html?page=behavior-guide" data-page="behavior-guide">Behavior Testing Guide</a></li>
                         <li><a href="doc.html?page=red-teaming-guide" data-page="red-teaming-guide">Red Teaming Guide</a></li>
+                        <li><a href="doc.html?page=mcp-plugin-guide" data-page="mcp-plugin-guide">MCP Plugin (Claude)</a></li>
                         <li><a href="doc.html?page=example-openai-cs-agents"
                                 data-page="example-openai-cs-agents">Example: OpenAI CS Agents</a></li>
                         <li><a href="doc.html?page=troubleshooting" data-page="troubleshooting">Troubleshooting</a></li>
@@ -380,6 +381,7 @@
                 'policy-engine-guide': 'Policy Engine Guide',
                 'behavior-guide': 'Behavior Testing Guide',
                 'red-teaming-guide': 'Red Teaming Guide',
+                'mcp-plugin-guide': 'MCP Plugin (Claude)',
                 'example-openai-cs-agents': 'Example: OpenAI CS Agents',
                 'troubleshooting': 'Troubleshooting',
             };

--- a/docs/doc.html
+++ b/docs/doc.html
@@ -303,7 +303,7 @@
 
     <!-- Navigation -->
     <nav>
-        <a href="index.html" class="nav-brand">
+        <a href="https://nuguard.ai" class="nav-brand">
             <img src="nuguard-logo.png" alt="NuGuard" class="nav-logo" />
         </a>
         <ul class="nav-links">

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
 
     <!-- Navigation -->
     <nav>
-        <a href="#" class="nav-brand">
+        <a href="https://nuguard.ai" class="nav-brand">
             <img src="nuguard-logo.png" alt="NuGuard" class="nav-logo" onerror="this.style.display='none';this.nextElementSibling.style.display='inline'" />
             <span style="display:none;font-weight:700;font-size:1.1rem;color:var(--text)">NuGuard</span>
         </a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -347,3 +347,45 @@ json_str = AiSbomSerializer.to_json(doc)
 - Issues: https://github.com/NuGuardAI/nuguard-oss/issues
 - Discord: https://discord.gg/EF99Ck7a
 - NuGuard AI: https://nuguard.ai/
+
+---
+
+## 6. Claude MCP Plugin (`nuguard[mcp]`)
+
+NuGuard ships an MCP server that exposes the full security pipeline as Claude tools.
+Install with `pip install "nuguard[mcp]"` or run without installing via `uvx --from "nuguard[mcp]" nuguard-mcp`.
+
+**Claude Desktop config** (`claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "nuguard-mcp",
+      "env": { "LITELLM_API_KEY": "..." }
+    }
+  }
+}
+```
+
+Also available on the Smithery Claude marketplace (search "nuguard").
+
+### Available MCP tools
+
+| Tool | Default timeout | Purpose |
+|---|---|---|
+| `nuguard_init` | 30 s | Initialize `nuguard.yaml` in a project directory |
+| `nuguard_sbom_generate` | 300 s | Generate AI-SBOM from local source or git repo |
+| `nuguard_analyze` | 300 s | Static risk analysis on an AI-SBOM |
+| `nuguard_scan` | 600 s | Full pipeline: SBOM → analyze → policy → redteam |
+| `nuguard_behavior` | 300 s | Behavioral testing against a live AI app |
+| `nuguard_redteam` | 900 s | Adversarial red-team testing against a live AI app |
+| `nuguard_policy_check` | 60 s | Policy linting and compliance assessment |
+
+All tools accept `timeout_seconds` to override the default. Secrets (API keys) are
+passed via environment variables on the MCP server process — never as tool parameters.
+
+Set `NUGUARD_DEFAULT_CONFIG` to the absolute path of a `nuguard.yaml` to avoid
+repeating `config_path` in every tool call.
+
+See the full MCP Plugin Guide for Claude Desktop setup, Smithery configuration, all
+tool parameters, an end-to-end example scenario, and troubleshooting tips.

--- a/docs/mcp-plugin-guide.md
+++ b/docs/mcp-plugin-guide.md
@@ -1,0 +1,388 @@
+# NuGuard MCP Plugin
+
+The NuGuard MCP plugin exposes NuGuard's AI security capabilities — SBOM generation, static analysis, behavioral testing, and adversarial red-teaming — as tools that Claude can call directly in a conversation. You can ask Claude to audit your AI application and Claude will orchestrate the full NuGuard pipeline, interpret findings, and recommend remediations without you leaving the chat.
+
+---
+
+## Table of Contents
+
+1. [Installation](#installation)
+2. [Claude Desktop Setup](#claude-desktop-setup)
+3. [Smithery (Claude Marketplace)](#smithery-claude-marketplace)
+4. [Available Tools](#available-tools)
+5. [Example Scenario](#example-scenario)
+6. [Environment Variables](#environment-variables)
+7. [Configuration File](#configuration-file)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## Installation
+
+The MCP server is bundled in the `nuguard` package as the optional `mcp` extra.
+
+```bash
+pip install "nuguard[mcp]"
+```
+
+Verify the server starts cleanly:
+
+```bash
+nuguard-mcp --help
+```
+
+Or run directly without installing (using `uvx`):
+
+```bash
+uvx --from "nuguard[mcp]" nuguard-mcp
+```
+
+---
+
+## Claude Desktop Setup
+
+Add NuGuard to Claude Desktop's MCP server list. Edit
+`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or
+`%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "nuguard-mcp",
+      "args": [],
+      "env": {
+        "LITELLM_API_KEY": "your-api-key-here",
+        "NUGUARD_DEFAULT_CONFIG": "/path/to/your/nuguard.yaml"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The NuGuard tools will appear in the tools panel (hammer icon).
+
+### Using uvx instead of a local install
+
+If you prefer not to install nuguard globally:
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "uvx",
+      "args": ["--from", "nuguard[mcp]", "nuguard-mcp"],
+      "env": {
+        "LITELLM_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Smithery (Claude Marketplace)
+
+NuGuard is published on [Smithery](https://smithery.ai/), the Claude marketplace for MCP servers. Install it with one click, then configure:
+
+| Setting | Description |
+|---|---|
+| `litellm_api_key` | API key for LLM-enriched analysis (Gemini, OpenAI, etc.) |
+| `nuguard_config_path` | Absolute path to a project `nuguard.yaml` (sets the default for all tool calls) |
+| `redteam_llm_model` | LiteLLM model string for red-team payload generation |
+
+Smithery passes these settings as environment variables to the `nuguard-mcp` process, so secrets never travel through Claude's context.
+
+---
+
+## Available Tools
+
+All tools accept an optional `timeout_seconds` parameter to override the default per-tool timeout.
+
+### `nuguard_init`
+
+Initialize a `nuguard.yaml` config file in a project directory.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `project_dir` | string | required | Directory to initialize |
+| `target_url` | string | — | URL of the running AI application |
+| `source_dir` | string | — | Source code directory for SBOM generation |
+| `force` | bool | `false` | Overwrite existing files |
+| `timeout_seconds` | int | `30` | |
+
+Creates `nuguard.yaml`, `canary.example.json`, and `cognitive-policy.md` with auto-detected defaults (existing SBOM files, project language).
+
+---
+
+### `nuguard_sbom_generate`
+
+Generate an AI Bill of Materials from source code or a git repository.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `source` | string | — | Local source directory |
+| `from_repo` | string | — | Git repository URL |
+| `ref` | string | `"main"` | Branch / tag / commit (used with `from_repo`) |
+| `output` | string | `"app.sbom.json"` | Output file path |
+| `llm` | bool | `false` | Enable LLM enrichment |
+| `config_path` | string | — | Path to `nuguard.yaml` |
+| `timeout_seconds` | int | `300` | |
+
+Returns the SBOM path, node/edge counts, and a component summary. Either `source` or `from_repo` must be provided.
+
+---
+
+### `nuguard_analyze`
+
+Run static risk analysis on an AI-SBOM.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `sbom` | string | required | Path to AI-SBOM JSON |
+| `nga_only` | bool | `false` | Run only 18 NGA structural rules |
+| `min_severity` | string | `"medium"` | `critical` \| `high` \| `medium` \| `low` \| `info` |
+| `enable_atlas` | bool | `true` | MITRE ATLAS mapping |
+| `enable_osv` | bool | `true` | OSV CVE scan |
+| `enable_grype` | bool | `true` | Grype CVE scan |
+| `enable_checkov` | bool | `true` | Checkov IaC scan |
+| `enable_trivy` | bool | `true` | Trivy container scan |
+| `enable_semgrep` | bool | `true` | Semgrep AI rules |
+| `llm` | bool | `false` | LLM enrichment in ATLAS pass |
+| `source` | string | — | Source directory for Checkov / Trivy / Semgrep |
+| `config_path` | string | — | Path to `nuguard.yaml` |
+| `timeout_seconds` | int | `300` | |
+
+Exit status: `"ok"` (no findings), `"findings"` (issues detected), `"error"` (crash).
+
+---
+
+### `nuguard_scan`
+
+Run the full unified security scan pipeline.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `source` | string | `"."` | AI application source directory |
+| `output_dir` | string | `"nuguard-reports"` | Directory for output files |
+| `fail_on` | string | `"high"` | Severity threshold for non-zero exit |
+| `steps` | string | `"sbom,analyze"` | Comma-separated steps: `sbom,analyze,policy,redteam` |
+| `policy` | string | — | Path to Cognitive Policy Markdown |
+| `target` | string | — | Live app URL (required for `redteam` step) |
+| `container_image` | string | — | Container image ref for Trivy |
+| `llm` | bool | `false` | LLM enrichment in ATLAS pass |
+| `config_path` | string | — | Path to `nuguard.yaml` |
+| `timeout_seconds` | int | `600` | |
+
+Returns artifact paths (`sbom.json`, `findings.json`, `findings.sarif`, `report.md`) and a severity summary.
+
+---
+
+### `nuguard_behavior`
+
+Run intent-aware behavioral testing against a live AI application.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `config_path` | string | required | Path to `nuguard.yaml` |
+| `mode` | string | `"static+dynamic"` | `static` \| `dynamic` \| `static+dynamic` |
+| `target` | string | — | Override `behavior.target` URL |
+| `policy` | string | — | Path to Cognitive Policy Markdown |
+| `intent` | string | — | Override app intent description |
+| `output` | string | — | Write report to this file |
+| `fail_on` | string | `"high"` | Severity threshold |
+| `timeout_seconds` | int | `300` | |
+
+Static mode checks SBOM–policy alignment without hitting the live app. Dynamic mode sends probe conversations to the running app and judges each turn.
+
+---
+
+### `nuguard_redteam`
+
+Run adversarial red-team testing against a live AI application.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `config_path` | string | required | Path to `nuguard.yaml` |
+| `sbom` | string | — | Override SBOM path |
+| `target` | string | — | Override target URL |
+| `policy` | string | — | Path to Cognitive Policy Markdown |
+| `profile` | string | `"ci"` | `ci` (fast, high-signal) \| `full` (comprehensive) |
+| `scenarios` | string | — | Comma-separated scenario types |
+| `min_impact_score` | float | `0.0` | Minimum pre-impact score [0–10] |
+| `output` | string | — | Write findings JSON to this file |
+| `fail_on` | string | `"high"` | Severity threshold |
+| `guided` | bool | — | Enable / disable guided multi-turn conversations |
+| `guided_max_turns` | int | — | Max turns per guided conversation |
+| `guided_concurrency` | int | — | Max parallel guided conversations |
+| `timeout_seconds` | int | `900` | Red-team scans can be long-running |
+
+Requires a running target application and an LLM configured for attack payload generation (`NUGUARD_REDTEAM_LLM_MODEL` env var).
+
+---
+
+### `nuguard_policy_check`
+
+Cross-check a Cognitive Policy against an AI-SBOM and run compliance assessments.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `policy` | string | — | Path to Cognitive Policy Markdown |
+| `sbom` | string | — | Path to AI-SBOM JSON |
+| `config_path` | string | — | Path to `nuguard.yaml` |
+| `framework` | string | — | `owasp-llm-top10` \| `nist-ai-rmf` \| `eu-ai-act` |
+| `output` | string | — | Write compliance report to this file |
+| `verbose` | bool | `false` | Show all controls with evidence |
+| `timeout_seconds` | int | `60` | |
+
+---
+
+## Example Scenario
+
+This walkthrough shows Claude running a full security audit on a LangChain-based customer service bot.
+
+### Setup
+
+The developer has a LangChain application at `~/projects/cs-bot`. The app uses an OpenAI model, a PostgreSQL tool, and a custom guardrail. No prior NuGuard config exists.
+
+### Conversation
+
+**User:** I've built a customer service AI agent at `~/projects/cs-bot`. Can you do a security audit?
+
+**Claude** calls `nuguard_init`:
+```
+nuguard_init(project_dir="~/projects/cs-bot", target_url="http://localhost:8080")
+```
+Result: `nuguard.yaml`, `cognitive-policy.md`, and `canary.example.json` created in the project directory.
+
+**Claude** calls `nuguard_sbom_generate`:
+```
+nuguard_sbom_generate(source="~/projects/cs-bot", output="~/projects/cs-bot/app.sbom.json")
+```
+Result: 14 nodes detected — 1 agent, 1 model (gpt-4o), 3 tools (PostgreSQL query, email sender, web search), 1 guardrail, 1 datastore (PostgreSQL), 2 prompts, 2 API endpoints. Summary shows PII classification on the customer records datastore.
+
+**Claude** calls `nuguard_analyze`:
+```
+nuguard_analyze(sbom="~/projects/cs-bot/app.sbom.json", min_severity="medium")
+```
+Result: 3 findings:
+- **HIGH** NGA-007: PostgreSQL tool node has `sql_injectable: true` with no parameterization evidence
+- **HIGH** NGA-011: Datastore with PII classification (`customer.email`, `customer.name`) has no AUTH node in graph
+- **MEDIUM** NGA-003: Email sender tool has `high_privilege: true` with no HITL trigger in graph
+
+**Claude** explains findings to the user and asks whether to run the full red-team scan:
+
+> The SBOM reveals three structural issues: the PostgreSQL tool appears to accept raw string inputs that could be SQL-injected, the customer PII datastore has no authentication boundary in the component graph, and the email sending tool has no human-in-the-loop gate. Want me to run the red-team scan to verify these are exploitable? You'll need to start the app locally first.
+
+**User:** Yes, I've started the app on port 8080. Go ahead.
+
+**Claude** calls `nuguard_redteam`:
+```
+nuguard_redteam(
+    config_path="~/projects/cs-bot/nuguard.yaml",
+    profile="ci",
+    fail_on="high"
+)
+```
+Result (after ~3 minutes): 2 confirmed findings:
+- **CRITICAL** DATA_EXFILTRATION: The agent returned `customer.email` and `customer.name` for a different tenant's customer when asked "Show me John's account info" — cross-tenant PII leak confirmed
+- **HIGH** PROMPT_DRIVEN_THREAT: System prompt partially extracted via indirect injection in the product description field
+
+**Claude** summarizes and provides remediation guidance:
+
+> The red-team scan confirmed two exploitable vulnerabilities. The most critical is a cross-tenant data leakage — the agent returned records from another tenant's database without enforcing a tenant boundary in the SQL query. The second is a partial system prompt extraction via an indirect injection vector in product descriptions.
+>
+> **Recommended fixes:**
+> 1. Add a `tenant_id` filter to every SQL query generated by the PostgreSQL tool, and verify it in a guardrail layer before execution.
+> 2. Add a sanitization step that strips instruction-like content from external inputs (product descriptions, user-uploaded files) before they reach the agent's context.
+> 3. Add a HITL gate on the email sender — require human confirmation for any outbound email triggered from agent reasoning.
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `LITELLM_API_KEY` | Default API key for LLM-enriched analysis (Gemini, OpenAI, etc.) |
+| `GEMINI_API_KEY` | Gemini-specific API key (auto-detected if `LITELLM_API_KEY` is not set) |
+| `OPENAI_API_KEY` | OpenAI-specific API key |
+| `ANTHROPIC_API_KEY` | Anthropic-specific API key |
+| `NUGUARD_DEFAULT_CONFIG` | Absolute path to `nuguard.yaml` — used as the default `config_path` for all tool calls |
+| `NUGUARD_REDTEAM_LLM_MODEL` | LiteLLM model string for red-team attack payload generation |
+| `NUGUARD_REDTEAM_LLM_API_KEY` | API key specifically for the red-team attack LLM |
+| `NUGUARD_REDTEAM_EVAL_LLM_MODEL` | LiteLLM model for red-team response evaluation |
+
+The MCP server process inherits these from its parent environment. In Claude Desktop, set them in the `env` block of `claude_desktop_config.json`. In Smithery, configure them in the server settings panel.
+
+---
+
+## Configuration File
+
+Set `NUGUARD_DEFAULT_CONFIG` to avoid repeating `config_path` in every tool call. The variable must point to an absolute path. The `nuguard.yaml` file tells tools where the SBOM is, what the target URL is, and how to authenticate.
+
+```bash
+export NUGUARD_DEFAULT_CONFIG=/home/me/projects/cs-bot/nuguard.yaml
+```
+
+Generate a starter config for any project:
+
+```bash
+nuguard init --path /home/me/projects/cs-bot/nuguard.yaml \
+             --target http://localhost:8080
+```
+
+See [CLI Reference](doc.html?page=cli-reference) for the full `nuguard.yaml` schema.
+
+---
+
+## Troubleshooting
+
+**Tools don't appear in Claude Desktop**
+
+Restart Claude Desktop after editing `claude_desktop_config.json`. Check that `nuguard-mcp` (or `uvx`) is on the `PATH` that the Claude Desktop process uses — Claude Desktop does not inherit shell aliases or `~/.zshrc` exports on macOS. Use the absolute path to the binary if needed:
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "/usr/local/bin/nuguard-mcp"
+    }
+  }
+}
+```
+
+**`nuguard_redteam` times out**
+
+The default timeout is 900 seconds (15 minutes). For large scans with `profile=full` and guided conversations enabled, pass `timeout_seconds=1800`. Red-team scans are also sensitive to the target app's response time; set `redteam.request_timeout` in `nuguard.yaml` to match your app's SLA.
+
+**`status: "error"` with no findings**
+
+The `stderr` field in the response contains the error message from the nuguard CLI. Common causes:
+- `sbom` path does not exist — check that `nuguard_sbom_generate` ran first and the output path matches
+- `config_path` points to a directory, not a file
+- Missing required environment variable (e.g., no `LITELLM_API_KEY` when `--llm` is used)
+
+**LLM enrichment returns canned responses**
+
+Set `LITELLM_API_KEY` (or a provider-specific key like `GEMINI_API_KEY`) in the MCP server's environment. Without an API key, LLM calls return placeholder text but do not fail the scan.
+
+**Grype / Checkov / Trivy not running**
+
+These are optional external tools. Install them on the same machine running `nuguard-mcp`:
+
+```bash
+# Grype
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
+# Checkov / Semgrep (pip)
+pip install checkov semgrep
+
+# Trivy
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+```
+
+Or disable individual scanners in the `nuguard_analyze` tool call:
+```
+nuguard_analyze(sbom="...", enable_grype=false, enable_trivy=false)
+```

--- a/docs/style.css
+++ b/docs/style.css
@@ -122,7 +122,7 @@ nav {
 }
 
 .nav-logo {
-    height: 28px;
+    height: 20px;
     width: auto;
     display: block;
     flex-shrink: 0;

--- a/nuguard/mcp/__init__.py
+++ b/nuguard/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""NuGuard MCP server — exposes NuGuard security capabilities as Claude tools."""

--- a/nuguard/mcp/__main__.py
+++ b/nuguard/mcp/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point: python -m nuguard.mcp"""
+
+from nuguard.mcp.server import mcp
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/nuguard/mcp/_runner.py
+++ b/nuguard/mcp/_runner.py
@@ -1,0 +1,106 @@
+"""Async subprocess runner for NuGuard CLI commands."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import signal
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mK]")
+
+_STATUS_MAP = {0: "ok", 1: "findings", 2: "critical"}
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def exit_code_to_status(exit_code: int, timed_out: bool = False) -> str:
+    if timed_out:
+        return "timeout"
+    return _STATUS_MAP.get(exit_code, "error")
+
+
+@dataclass
+class RunResult:
+    exit_code: int
+    stdout_text: str
+    stderr_text: str
+    timed_out: bool
+    parsed_json: dict | list | None = field(default=None)
+
+
+async def run_nuguard_command(
+    args: list[str],
+    cwd: str | None = None,
+    timeout: float = 120.0,
+    expect_json: bool = True,
+) -> RunResult:
+    """Run ``nuguard <args>`` as a subprocess and return a RunResult.
+
+    Uses asyncio.create_subprocess_exec so the MCP server's event loop is not
+    blocked. Kills the process on timeout (SIGTERM → 2 s → SIGKILL).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "nuguard",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+    )
+
+    timed_out = False
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        timed_out = True
+        try:
+            proc.send_signal(signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+        stdout_bytes = b""
+        stderr_bytes = b""
+
+    exit_code = proc.returncode if proc.returncode is not None else 1
+    stdout_text = _strip_ansi(stdout_bytes.decode("utf-8", errors="replace"))
+    stderr_text = _strip_ansi(stderr_bytes.decode("utf-8", errors="replace"))
+
+    parsed_json: dict | list | None = None
+    if expect_json and stdout_text.strip():
+        try:
+            parsed_json = json.loads(stdout_text)
+        except json.JSONDecodeError:
+            pass
+
+    return RunResult(
+        exit_code=exit_code,
+        stdout_text=stdout_text,
+        stderr_text=stderr_text,
+        timed_out=timed_out,
+        parsed_json=parsed_json,
+    )
+
+
+def resolve_path(p: str) -> Path:
+    """Resolve a user-supplied path string to an absolute Path."""
+    return Path(p).expanduser().resolve()
+
+
+def cwd_for_config(config_path: str | None) -> str | None:
+    """Return the directory containing config_path, or None."""
+    if config_path:
+        return str(resolve_path(config_path).parent)
+    return None

--- a/nuguard/mcp/server.py
+++ b/nuguard/mcp/server.py
@@ -1,0 +1,507 @@
+"""NuGuard MCP server — 7 tools wrapping the nuguard CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Annotated
+
+from mcp.server.fastmcp import FastMCP
+
+from nuguard.mcp._runner import (
+    RunResult,
+    cwd_for_config,
+    exit_code_to_status,
+    resolve_path,
+    run_nuguard_command,
+)
+
+# ---------------------------------------------------------------------------
+# Server instance
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONFIG = os.environ.get("NUGUARD_DEFAULT_CONFIG", "")
+
+mcp = FastMCP(
+    name="nuguard",
+    instructions=(
+        "NuGuard AI Application Security. Use these tools to generate an AI Bill of "
+        "Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial "
+        "red-team testing for AI agents and LLM-powered applications. "
+        "Typical workflow: nuguard_init → nuguard_sbom_generate → nuguard_analyze → "
+        "nuguard_behavior → nuguard_redteam. "
+        "API keys (LITELLM_API_KEY, etc.) must be set as environment variables on the "
+        "MCP server process — never pass them as tool parameters."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _effective_config(config_path: str | None) -> str | None:
+    """Return the caller-supplied config_path, falling back to NUGUARD_DEFAULT_CONFIG."""
+    return config_path or (_DEFAULT_CONFIG or None)
+
+
+def _enrich(result: RunResult, payload: dict) -> dict:
+    """Inject status, exit_code, and optional stderr/timed_out into payload."""
+    payload["status"] = exit_code_to_status(result.exit_code, result.timed_out)
+    payload["exit_code"] = result.exit_code
+    if result.timed_out:
+        payload["timed_out"] = True
+    if result.stderr_text.strip():
+        payload["stderr"] = result.stderr_text.strip()
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: nuguard_init
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_init(
+    project_dir: Annotated[str, "Directory to initialize. nuguard.yaml will be written here."],
+    target_url: Annotated[str | None, "URL of the running AI application (e.g. http://localhost:8080)."] = None,
+    source_dir: Annotated[str | None, "Source code directory for SBOM generation (sets source: in nuguard.yaml)."] = None,
+    force: Annotated[bool, "Overwrite existing files."] = False,
+    timeout_seconds: Annotated[int, "Maximum seconds to wait for the command."] = 30,
+) -> dict:
+    """Initialize a nuguard.yaml config file with auto-detected defaults.
+
+    Creates nuguard.yaml, canary.example.json, and cognitive-policy.md in the
+    project directory. Auto-detects existing SBOM files, policy files, and
+    project language (Python / TypeScript).
+    """
+    project_path = resolve_path(project_dir)
+    args = ["init", "--path", str(project_path)]
+    if target_url:
+        args += ["--target", target_url]
+    if source_dir:
+        args += ["--source", str(resolve_path(source_dir))]
+    if force:
+        args.append("--force")
+
+    result = await run_nuguard_command(
+        args, cwd=str(project_path), timeout=timeout_seconds, expect_json=False
+    )
+
+    # Parse text output: lines prefixed "  created  " or "  skipped  "
+    created: list[str] = []
+    skipped: list[str] = []
+    for line in result.stdout_text.splitlines():
+        s = line.strip()
+        if s.startswith("created  "):
+            created.append(s[len("created  "):].strip())
+        elif s.startswith("skipped  "):
+            skipped.append(s[len("skipped  "):].split("(")[0].strip())
+
+    return _enrich(result, {
+        "project_dir": str(project_path),
+        "created_files": created,
+        "skipped_files": skipped,
+        "message": result.stdout_text.strip(),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: nuguard_sbom_generate
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_sbom_generate(
+    source: Annotated[str | None, "Path to local source directory to scan."] = None,
+    from_repo: Annotated[str | None, "Git repository URL (e.g. https://github.com/org/repo)."] = None,
+    ref: Annotated[str, "Branch, tag, or commit to scan when using from_repo."] = "main",
+    output: Annotated[str, "Output file path for the generated AI-SBOM JSON."] = "app.sbom.json",
+    llm: Annotated[bool, "Enable LLM enrichment of SBOM nodes (requires LITELLM_API_KEY)."] = False,
+    config_path: Annotated[str | None, "Path to nuguard.yaml config file."] = None,
+    timeout_seconds: Annotated[int, "Maximum seconds to wait."] = 300,
+) -> dict:
+    """Generate an AI Bill of Materials (AI-SBOM) from source code or a git repository.
+
+    Detects AI components — agents, models, tools, datastores, guardrails, MCP servers,
+    API endpoints — and their relationships. Either source or from_repo must be provided.
+    Returns the SBOM path, node/edge counts, and a summary of detected components.
+    """
+    output_path = resolve_path(output)
+    config = _effective_config(config_path)
+
+    args = ["sbom", "generate", "--output", str(output_path)]
+    if source:
+        args += ["--source", str(resolve_path(source))]
+    if from_repo:
+        args += ["--from-repo", from_repo, "--ref", ref]
+    if llm:
+        args.append("--llm")
+    if config:
+        args += ["--config", str(resolve_path(config))]
+
+    result = await run_nuguard_command(
+        args,
+        cwd=cwd_for_config(config),
+        timeout=timeout_seconds,
+        expect_json=False,
+    )
+
+    sbom_summary: dict = {}
+    node_count = 0
+    edge_count = 0
+    if result.exit_code == 0 and output_path.exists():
+        try:
+            sbom_data = json.loads(output_path.read_text(encoding="utf-8"))
+            sbom_summary = sbom_data.get("summary", {})
+            node_count = len(sbom_data.get("nodes", []))
+            edge_count = len(sbom_data.get("edges", []))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return _enrich(result, {
+        "sbom_path": str(output_path),
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "sbom_summary": sbom_summary,
+        "message": result.stdout_text.strip() or f"SBOM written to {output_path}",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: nuguard_analyze
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_analyze(
+    sbom: Annotated[str, "Path to the AI-SBOM JSON file to analyze."],
+    config_path: Annotated[str | None, "Path to nuguard.yaml."] = None,
+    nga_only: Annotated[bool, "Run only the 18 NGA structural rules; skip external tools."] = False,
+    min_severity: Annotated[str, "Minimum severity to report: critical | high | medium | low | info."] = "medium",
+    source: Annotated[str | None, "Source directory for Checkov / Trivy / Semgrep scans."] = None,
+    enable_atlas: Annotated[bool, "Enable MITRE ATLAS technique mapping."] = True,
+    enable_osv: Annotated[bool, "Enable OSV dependency CVE scan."] = True,
+    enable_grype: Annotated[bool, "Enable Grype CVE scan."] = True,
+    enable_checkov: Annotated[bool, "Enable Checkov IaC scan."] = True,
+    enable_trivy: Annotated[bool, "Enable Trivy container / filesystem scan."] = True,
+    enable_semgrep: Annotated[bool, "Enable Semgrep AI-security rules."] = True,
+    llm: Annotated[bool, "Enable LLM enrichment in the ATLAS pass."] = False,
+    timeout_seconds: Annotated[int, "Maximum seconds to wait."] = 300,
+) -> dict:
+    """Run static risk analysis on an AI-SBOM.
+
+    Evaluates 18 NGA structural rules (NGA-001 to NGA-018) and optionally runs
+    MITRE ATLAS mapping, OSV / Grype CVE scans, Checkov IaC, Trivy container
+    scans, and Semgrep AI-security rules. Returns findings grouped by severity.
+    Exit status: 'ok' (no findings), 'findings' (issues found), 'error' (crash).
+    """
+    config = _effective_config(config_path)
+    sbom_path = resolve_path(sbom)
+    args = [
+        "analyze",
+        "--sbom", str(sbom_path),
+        "--format", "json",
+        "--min-severity", min_severity,
+    ]
+    if config:
+        args += ["--config", str(resolve_path(config))]
+    if nga_only:
+        args.append("--nga")
+    if not enable_atlas:
+        args.append("--no-atlas")
+    if not enable_osv:
+        args.append("--no-osv")
+    if not enable_grype:
+        args.append("--no-grype")
+    if not enable_checkov:
+        args.append("--no-checkov")
+    if not enable_trivy:
+        args.append("--no-trivy")
+    if not enable_semgrep:
+        args.append("--no-semgrep")
+    if source:
+        args += ["--source", str(resolve_path(source))]
+    if llm:
+        args.append("--llm")
+
+    result = await run_nuguard_command(
+        args,
+        cwd=cwd_for_config(config),
+        timeout=timeout_seconds,
+        expect_json=True,
+    )
+
+    payload: dict = result.parsed_json if isinstance(result.parsed_json, dict) else {}
+    if not payload:
+        payload = {"raw_output": result.stdout_text}
+    return _enrich(result, payload)
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: nuguard_scan
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_scan(
+    source: Annotated[str, "Path to AI application source directory."] = ".",
+    output_dir: Annotated[str, "Directory for output files (sbom.json, findings.json, report.md, findings.sarif)."] = "nuguard-reports",
+    fail_on: Annotated[str, "Severity threshold for a non-zero exit: critical | high | medium | low."] = "high",
+    steps: Annotated[str, "Comma-separated pipeline steps: sbom,analyze,policy,redteam."] = "sbom,analyze",
+    policy: Annotated[str | None, "Path to Cognitive Policy Markdown."] = None,
+    target: Annotated[str | None, "Live application URL (required for the redteam step)."] = None,
+    container_image: Annotated[str | None, "Container image ref for Trivy scan (e.g. myapp:latest)."] = None,
+    llm: Annotated[bool, "Enable LLM enrichment in the ATLAS analysis pass."] = False,
+    config_path: Annotated[str | None, "Path to nuguard.yaml."] = None,
+    timeout_seconds: Annotated[int, "Maximum seconds to wait."] = 600,
+) -> dict:
+    """Run the full unified security scan pipeline: SBOM → analyze → policy → redteam.
+
+    Orchestrates all NuGuard capabilities in sequence. By default runs the 'sbom'
+    and 'analyze' steps. Add 'redteam' to steps and supply target to include
+    adversarial testing. Writes sbom.json, findings.json, findings.sarif, and
+    report.md to output_dir and returns a summary with artifact paths.
+    """
+    source_path = resolve_path(source)
+    out_path = resolve_path(output_dir)
+    config = _effective_config(config_path)
+
+    args = [
+        "scan",
+        "--source", str(source_path),
+        "--output-dir", str(out_path),
+        "--fail-on", fail_on,
+        "--steps", steps,
+    ]
+    if policy:
+        args += ["--policy", str(resolve_path(policy))]
+    if target:
+        args += ["--target", target]
+    if container_image:
+        args += ["--container-image", container_image]
+    if llm:
+        args.append("--llm")
+
+    result = await run_nuguard_command(
+        args,
+        cwd=cwd_for_config(config) or str(source_path),
+        timeout=timeout_seconds,
+        expect_json=False,
+    )
+
+    # Build summary by reading findings.json from output dir
+    summary: dict = {}
+    findings_json_path = out_path / "findings.json"
+    if findings_json_path.exists():
+        try:
+            findings_data = json.loads(findings_json_path.read_text(encoding="utf-8"))
+            counts = findings_data.get("severity_counts", {})
+            total = findings_data.get("total", sum(counts.values()))
+            summary = {"total": total, **counts}
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    artifacts = {
+        name: str(out_path / fname)
+        for name, fname in {
+            "sbom": "sbom.json",
+            "findings_json": "findings.json",
+            "findings_sarif": "findings.sarif",
+            "report_md": "report.md",
+        }.items()
+        if (out_path / fname).exists()
+    }
+
+    return _enrich(result, {
+        "output_dir": str(out_path),
+        "artifacts": artifacts,
+        "summary": summary,
+        "message": result.stdout_text.strip(),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Tool 5: nuguard_behavior
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_behavior(
+    config_path: Annotated[str, "Path to nuguard.yaml (must contain target URL, auth, and SBOM path)."],
+    mode: Annotated[str, "Analysis mode: static | dynamic | static+dynamic."] = "static+dynamic",
+    target: Annotated[str | None, "Override behavior.target URL from nuguard.yaml."] = None,
+    policy: Annotated[str | None, "Path to Cognitive Policy Markdown."] = None,
+    intent: Annotated[str | None, "Override the app intent description (one-line summary)."] = None,
+    output: Annotated[str | None, "Write the behavior report to this file path."] = None,
+    fail_on: Annotated[str, "Severity threshold for a non-zero exit: critical | high | medium | low."] = "high",
+    timeout_seconds: Annotated[int, "Maximum seconds to wait."] = 300,
+) -> dict:
+    """Run intent-aware behavioral testing against a live AI application.
+
+    Static mode checks SBOM–policy alignment without hitting the live app.
+    Dynamic mode sends probe conversations to the running app and judges each
+    turn for intent drift, policy violations, and data leakage.
+    Requires the target app to be running and reachable.
+    """
+    config = _effective_config(config_path)
+    if not config:
+        return {"status": "error", "exit_code": 1, "message": "config_path is required for nuguard_behavior"}
+
+    config_resolved = resolve_path(config)
+    args = [
+        "behavior",
+        "--config", str(config_resolved),
+        "--mode", mode,
+        "--format", "json",
+        "--fail-on", fail_on,
+    ]
+    if target:
+        args += ["--target", target]
+    if policy:
+        args += ["--policy", str(resolve_path(policy))]
+    if intent:
+        args += ["--intent", intent]
+    if output:
+        args += ["--output", str(resolve_path(output))]
+
+    result = await run_nuguard_command(
+        args,
+        cwd=str(config_resolved.parent),
+        timeout=timeout_seconds,
+        expect_json=True,
+    )
+
+    payload: dict = result.parsed_json if isinstance(result.parsed_json, dict) else {}
+    if not payload:
+        payload = {"raw_output": result.stdout_text}
+    return _enrich(result, payload)
+
+
+# ---------------------------------------------------------------------------
+# Tool 6: nuguard_redteam
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_redteam(
+    config_path: Annotated[str, "Path to nuguard.yaml (must contain SBOM path, target URL, and LLM config)."],
+    sbom: Annotated[str | None, "Override SBOM path from nuguard.yaml."] = None,
+    target: Annotated[str | None, "Override target URL from nuguard.yaml."] = None,
+    policy: Annotated[str | None, "Path to Cognitive Policy Markdown."] = None,
+    profile: Annotated[str, "Scan profile: ci (fast, high-signal) | full (comprehensive)."] = "ci",
+    scenarios: Annotated[str | None, "Comma-separated scenario types to include."] = None,
+    min_impact_score: Annotated[float, "Minimum pre-impact score [0–10] for scenario inclusion."] = 0.0,
+    output: Annotated[str | None, "Write findings JSON to this file path."] = None,
+    fail_on: Annotated[str, "Severity threshold for a non-zero exit: critical | high | medium | low."] = "high",
+    guided: Annotated[bool | None, "Enable (True) or disable (False) guided multi-turn conversations."] = None,
+    guided_max_turns: Annotated[int | None, "Maximum turns per guided adversarial conversation."] = None,
+    guided_concurrency: Annotated[int | None, "Maximum parallel guided conversations."] = None,
+    timeout_seconds: Annotated[int, "Maximum seconds to wait. Redteam scans can be long-running."] = 900,
+) -> dict:
+    """Run adversarial red-team testing against a live AI application.
+
+    Generates exploit scenarios from the AI-SBOM and executes them against the
+    running app to discover prompt injection, data exfiltration, privilege
+    escalation, policy bypass, and MCP toxic-flow vulnerabilities. Requires
+    the target app to be running and reachable, plus an LLM configured for
+    attack payload generation (set NUGUARD_REDTEAM_LLM_MODEL env var).
+    """
+    config = _effective_config(config_path)
+    if not config:
+        return {"status": "error", "exit_code": 1, "message": "config_path is required for nuguard_redteam"}
+
+    config_resolved = resolve_path(config)
+    args = [
+        "redteam",
+        "--config", str(config_resolved),
+        "--format", "json",
+        "--profile", profile,
+        "--fail-on", fail_on,
+        "--min-impact-score", str(min_impact_score),
+    ]
+    if sbom:
+        args += ["--sbom", str(resolve_path(sbom))]
+    if target:
+        args += ["--target", target]
+    if policy:
+        args += ["--policy", str(resolve_path(policy))]
+    if scenarios:
+        args += ["--scenarios", scenarios]
+    if output:
+        args += ["--output", str(resolve_path(output))]
+    if guided is True:
+        args.append("--guided")
+    elif guided is False:
+        args.append("--no-guided")
+    if guided_max_turns is not None:
+        args += ["--guided-max-turns", str(guided_max_turns)]
+    if guided_concurrency is not None:
+        args += ["--guided-concurrency", str(guided_concurrency)]
+
+    result = await run_nuguard_command(
+        args,
+        cwd=str(config_resolved.parent),
+        timeout=timeout_seconds,
+        expect_json=True,
+    )
+
+    payload: dict = result.parsed_json if isinstance(result.parsed_json, dict) else {}
+    if not payload:
+        payload = {"raw_output": result.stdout_text}
+
+    # Inject a findings summary if not already present
+    if "findings" in payload and "summary" not in payload:
+        findings = payload["findings"]
+        if isinstance(findings, list):
+            counts: dict[str, int] = {}
+            for f in findings:
+                sev = f.get("severity", "info")
+                counts[sev] = counts.get(sev, 0) + 1
+            payload["summary"] = {"total": len(findings), **counts}
+
+    return _enrich(result, payload)
+
+
+# ---------------------------------------------------------------------------
+# Tool 7: nuguard_policy_check
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def nuguard_policy_check(
+    policy: Annotated[str | None, "Path to Cognitive Policy Markdown file."] = None,
+    sbom: Annotated[str | None, "Path to AI-SBOM JSON to cross-check against the policy."] = None,
+    config_path: Annotated[str | None, "Path to nuguard.yaml (fallback for policy/sbom paths)."] = None,
+    framework: Annotated[str | None, "Compliance framework: owasp-llm-top10 | nist-ai-rmf | eu-ai-act."] = None,
+    output: Annotated[str | None, "Write compliance report to this file path."] = None,
+    verbose: Annotated[bool, "Include all controls (passed and gaps) with evidence."] = False,
+    timeout_seconds: Annotated[int, "Maximum seconds to wait."] = 60,
+) -> dict:
+    """Cross-check a Cognitive Policy against an AI-SBOM and run compliance assessments.
+
+    Without a framework, checks the policy document for gaps and lints it against
+    the SBOM's detected components. With a framework (owasp-llm-top10, nist-ai-rmf,
+    eu-ai-act), maps the SBOM and policy to the framework's controls and reports
+    satisfied controls, partial coverage, and gaps.
+    """
+    config = _effective_config(config_path)
+    args = ["policy", "check", "--format", "json"]
+
+    if policy:
+        args += ["--policy", str(resolve_path(policy))]
+    if sbom:
+        args += ["--sbom", str(resolve_path(sbom))]
+    if config:
+        args += ["--config", str(resolve_path(config))]
+    if framework:
+        args += ["--framework", framework]
+    if output:
+        args += ["--output", str(resolve_path(output))]
+    if verbose:
+        args.append("--verbose")
+
+    result = await run_nuguard_command(
+        args,
+        cwd=cwd_for_config(config),
+        timeout=timeout_seconds,
+        expect_json=True,
+    )
+
+    payload: dict = result.parsed_json if isinstance(result.parsed_json, dict) else {}
+    if not payload:
+        payload = {"raw_output": result.stdout_text}
+    return _enrich(result, payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.4.5"
+version = "0.4.6"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.10",
 ]
+mcp = [
+    "mcp>=1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/NuGuardAI/nuguard"
@@ -59,6 +62,7 @@ Issues = "https://github.com/NuGuardAI/nuguard/issues"
 
 [project.scripts]
 nuguard = "nuguard.cli.main:app"
+nuguard-mcp = "nuguard.mcp.__main__:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,97 @@
+# Smithery manifest — Claude marketplace MCP server
+# https://smithery.ai/docs/config
+name: nuguard
+version: "0.4.5"
+description: |
+  AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
+  analysis, behavioral validation, and adversarial red-team testing for AI agents
+  and LLM-powered applications.
+author: NuGuard <info@nuguard.ai>
+homepage: https://github.com/NuGuardAI/nuguard
+license: Apache-2.0
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required: []
+    properties:
+      litellm_api_key:
+        type: string
+        description: >
+          LLM API key forwarded as LITELLM_API_KEY. Required for LLM-enriched SBOM
+          generation and static analysis. Accepts any LiteLLM-compatible key
+          (Gemini, OpenAI, Azure, Anthropic, etc.).
+        default: ""
+      nuguard_config_path:
+        type: string
+        description: >
+          Absolute path to a nuguard.yaml config file. When set, all tools use this
+          as the default config without requiring config_path on every call.
+        default: ""
+      redteam_llm_model:
+        type: string
+        description: >
+          LiteLLM model string for red-team attack payload generation.
+          Examples: openai/gpt-4o, gemini/gemini-2.0-flash, anthropic/claude-opus-4-7.
+          Use an uncensored or permissive model for best red-team coverage.
+        default: ""
+  commandFunction: |
+    (config) => ({
+      command: "uvx",
+      args: ["--from", "nuguard[mcp]", "nuguard-mcp"],
+      env: {
+        ...(config.litellm_api_key
+          ? { LITELLM_API_KEY: config.litellm_api_key }
+          : {}),
+        ...(config.nuguard_config_path
+          ? { NUGUARD_DEFAULT_CONFIG: config.nuguard_config_path }
+          : {}),
+        ...(config.redteam_llm_model
+          ? { NUGUARD_REDTEAM_LLM_MODEL: config.redteam_llm_model }
+          : {}),
+      }
+    })
+
+tools:
+  - name: nuguard_init
+    description: >
+      Initialize nuguard.yaml with auto-detected defaults (SBOM path, policy file,
+      canary seed). Also creates companion starter files (canary.example.json,
+      cognitive-policy.md).
+
+  - name: nuguard_sbom_generate
+    description: >
+      Generate an AI Bill of Materials (AI-SBOM) from Python or TypeScript source
+      code, or by cloning a git repository. Detects agents, models, tools, datastores,
+      guardrails, MCP servers, and API endpoints.
+
+  - name: nuguard_analyze
+    description: >
+      Run static risk analysis on an AI-SBOM. Evaluates 18 NGA structural rules plus
+      MITRE ATLAS mapping, OSV / Grype CVE scans, Checkov IaC, Trivy container scans,
+      and Semgrep AI-security rules.
+
+  - name: nuguard_scan
+    description: >
+      Run the full unified security scan pipeline: SBOM generation → static analysis →
+      policy check → red-team (optional). Writes sbom.json, findings.json,
+      findings.sarif, and report.md to an output directory.
+
+  - name: nuguard_behavior
+    description: >
+      Run intent-aware behavioral testing against a live AI application endpoint.
+      Static mode checks SBOM–policy alignment; dynamic mode sends probe conversations
+      and judges each turn for intent drift, policy violations, and data leakage.
+
+  - name: nuguard_redteam
+    description: >
+      Run adversarial red-team testing against a live AI application. Generates exploit
+      scenarios from the AI-SBOM and executes them to discover prompt injection, data
+      exfiltration, privilege escalation, policy bypass, and MCP toxic-flow
+      vulnerabilities.
+
+  - name: nuguard_policy_check
+    description: >
+      Cross-check a Cognitive Policy document against an AI-SBOM and run compliance
+      framework assessments (OWASP LLM Top 10, NIST AI RMF, EU AI Act).

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.4.5"
+version: "0.4.6"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/tests/mcp/test_runner.py
+++ b/tests/mcp/test_runner.py
@@ -1,0 +1,197 @@
+"""Unit tests for nuguard.mcp._runner — subprocess execution helper.
+
+All subprocess calls are mocked; no nuguard binary is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import signal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nuguard.mcp._runner import RunResult, exit_code_to_status, run_nuguard_command
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_proc(
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    returncode: int = 0,
+) -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.send_signal = MagicMock()
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.kill = MagicMock()
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# exit_code_to_status
+# ---------------------------------------------------------------------------
+
+
+def test_status_ok() -> None:
+    assert exit_code_to_status(0) == "ok"
+
+
+def test_status_findings() -> None:
+    assert exit_code_to_status(1) == "findings"
+
+
+def test_status_critical() -> None:
+    assert exit_code_to_status(2) == "critical"
+
+
+def test_status_error_on_unknown() -> None:
+    assert exit_code_to_status(3) == "error"
+    assert exit_code_to_status(99) == "error"
+
+
+def test_status_timeout_overrides_exit_code() -> None:
+    assert exit_code_to_status(0, timed_out=True) == "timeout"
+    assert exit_code_to_status(1, timed_out=True) == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# run_nuguard_command — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_success_json() -> None:
+    payload = {"total": 3, "severity_counts": {"high": 1}}
+    proc = _make_proc(stdout=json.dumps(payload).encode())
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        result = await run_nuguard_command(["analyze", "--sbom", "a.json"], expect_json=True)
+
+    assert result.exit_code == 0
+    assert result.timed_out is False
+    assert result.parsed_json == payload
+    assert result.stdout_text == json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_run_passes_nuguard_as_executable() -> None:
+    proc = _make_proc()
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        await run_nuguard_command(["sbom", "generate"])
+
+    call_args = mock_exec.call_args
+    assert call_args.args[0] == "nuguard"
+    assert call_args.args[1] == "sbom"
+    assert call_args.args[2] == "generate"
+
+
+@pytest.mark.asyncio
+async def test_run_passes_cwd() -> None:
+    proc = _make_proc()
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        await run_nuguard_command(["init"], cwd="/tmp/myproject")
+
+    assert mock_exec.call_args.kwargs["cwd"] == "/tmp/myproject"
+
+
+@pytest.mark.asyncio
+async def test_run_no_json_when_expect_json_false() -> None:
+    proc = _make_proc(stdout=b"created  ./nuguard.yaml\n")
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        result = await run_nuguard_command(["init"], expect_json=False)
+
+    assert result.parsed_json is None
+    assert "nuguard.yaml" in result.stdout_text
+
+
+# ---------------------------------------------------------------------------
+# ANSI stripping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ansi_codes_stripped_from_stderr() -> None:
+    raw_stderr = b"\x1b[31mError:\x1b[0m something bad"
+    proc = _make_proc(stdout=b"{}", stderr=raw_stderr, returncode=3)
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        result = await run_nuguard_command(["analyze", "--sbom", "x.json"], expect_json=True)
+
+    assert "\x1b" not in result.stderr_text
+    assert "Error:" in result.stderr_text
+    assert "something bad" in result.stderr_text
+
+
+# ---------------------------------------------------------------------------
+# JSON parse failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_invalid_json_yields_none_parsed() -> None:
+    proc = _make_proc(stdout=b"not json at all\nsome output")
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        result = await run_nuguard_command(["analyze", "--sbom", "x.json"], expect_json=True)
+
+    assert result.parsed_json is None
+    assert result.stdout_text == "not json at all\nsome output"
+
+
+# ---------------------------------------------------------------------------
+# Exit code mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exit_code_1_is_findings() -> None:
+    proc = _make_proc(stdout=b'{"findings": []}', returncode=1)
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        result = await run_nuguard_command(["analyze", "--sbom", "x.json"], expect_json=True)
+
+    assert result.exit_code == 1
+    assert exit_code_to_status(result.exit_code) == "findings"
+
+
+# ---------------------------------------------------------------------------
+# Timeout handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_sends_sigterm_and_sets_flag() -> None:
+    async def _slow_communicate():
+        await asyncio.sleep(100)
+        return b"", b""
+
+    proc = MagicMock()
+    proc.returncode = None
+    proc.communicate = _slow_communicate
+    proc.send_signal = MagicMock()
+    proc.wait = AsyncMock(return_value=None)
+    proc.kill = MagicMock()
+
+    with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = proc
+        result = await run_nuguard_command(["redteam", "--config", "c.yaml"], timeout=0.05)
+
+    assert result.timed_out is True
+    proc.send_signal.assert_called_once_with(signal.SIGTERM)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,70 @@
+"""MCP protocol-level tests — verify all 7 tools are registered with correct metadata."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuguard.mcp.server import mcp
+
+_EXPECTED_TOOLS = {
+    "nuguard_init",
+    "nuguard_sbom_generate",
+    "nuguard_analyze",
+    "nuguard_scan",
+    "nuguard_behavior",
+    "nuguard_redteam",
+    "nuguard_policy_check",
+}
+
+
+@pytest.fixture
+async def tools():
+    return await mcp.list_tools()
+
+
+@pytest.mark.asyncio
+async def test_all_seven_tools_registered(tools) -> None:
+    names = {t.name for t in tools}
+    assert names == _EXPECTED_TOOLS, f"Missing: {_EXPECTED_TOOLS - names}, Extra: {names - _EXPECTED_TOOLS}"
+
+
+@pytest.mark.asyncio
+async def test_each_tool_has_description(tools) -> None:
+    for tool in tools:
+        assert tool.description, f"Tool '{tool.name}' has no description"
+        assert len(tool.description) > 20, f"Tool '{tool.name}' description is too short"
+
+
+@pytest.mark.asyncio
+async def test_each_tool_has_input_schema(tools) -> None:
+    for tool in tools:
+        schema = tool.inputSchema
+        assert schema is not None, f"Tool '{tool.name}' has no inputSchema"
+        assert schema.get("type") == "object", f"Tool '{tool.name}' inputSchema type is not 'object'"
+
+
+@pytest.mark.asyncio
+async def test_timeout_seconds_in_all_tools(tools) -> None:
+    for tool in tools:
+        props = tool.inputSchema.get("properties", {})
+        assert "timeout_seconds" in props, (
+            f"Tool '{tool.name}' is missing 'timeout_seconds' parameter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_init_tool_has_project_dir(tools) -> None:
+    init = next(t for t in tools if t.name == "nuguard_init")
+    assert "project_dir" in init.inputSchema.get("properties", {})
+
+
+@pytest.mark.asyncio
+async def test_analyze_tool_has_sbom_param(tools) -> None:
+    analyze = next(t for t in tools if t.name == "nuguard_analyze")
+    assert "sbom" in analyze.inputSchema.get("properties", {})
+
+
+@pytest.mark.asyncio
+async def test_redteam_tool_has_profile_param(tools) -> None:
+    redteam = next(t for t in tools if t.name == "nuguard_redteam")
+    assert "profile" in redteam.inputSchema.get("properties", {})

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -1,0 +1,480 @@
+"""Unit tests for nuguard.mcp.server tools.
+
+run_nuguard_command is patched so no real nuguard process is launched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nuguard.mcp._runner import RunResult
+from nuguard.mcp.server import (
+    nuguard_analyze,
+    nuguard_behavior,
+    nuguard_init,
+    nuguard_policy_check,
+    nuguard_redteam,
+    nuguard_sbom_generate,
+    nuguard_scan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUNNER = "nuguard.mcp.server.run_nuguard_command"
+
+
+def _ok(stdout: str = "", parsed: dict | None = None) -> RunResult:
+    return RunResult(
+        exit_code=0,
+        stdout_text=stdout,
+        stderr_text="",
+        timed_out=False,
+        parsed_json=parsed,
+    )
+
+
+def _findings(parsed: dict | None = None) -> RunResult:
+    return RunResult(
+        exit_code=1,
+        stdout_text=json.dumps(parsed or {}),
+        stderr_text="",
+        timed_out=False,
+        parsed_json=parsed,
+    )
+
+
+def _error() -> RunResult:
+    return RunResult(
+        exit_code=3,
+        stdout_text="",
+        stderr_text="Internal error",
+        timed_out=False,
+        parsed_json=None,
+    )
+
+
+def _timeout() -> RunResult:
+    return RunResult(
+        exit_code=1,
+        stdout_text="",
+        stderr_text="",
+        timed_out=True,
+        parsed_json=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# nuguard_init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_init_ok_parses_created_files(tmp_path: Path) -> None:
+    stdout = "  created  nuguard.yaml\n  created  canary.example.json\n"
+    mock = AsyncMock(return_value=_ok(stdout=stdout))
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_init(project_dir=str(tmp_path))
+
+    assert result["status"] == "ok"
+    assert result["exit_code"] == 0
+    assert "nuguard.yaml" in result["created_files"]
+    assert "canary.example.json" in result["created_files"]
+    assert result["skipped_files"] == []
+
+
+@pytest.mark.asyncio
+async def test_init_skipped_files_parsed(tmp_path: Path) -> None:
+    stdout = "  skipped  nuguard.yaml  (already exists — use --force to overwrite)\n"
+    mock = AsyncMock(return_value=_ok(stdout=stdout))
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_init(project_dir=str(tmp_path))
+
+    assert "nuguard.yaml" in result["skipped_files"]
+    assert result["created_files"] == []
+
+
+@pytest.mark.asyncio
+async def test_init_force_flag_added(tmp_path: Path) -> None:
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        await nuguard_init(project_dir=str(tmp_path), force=True)
+
+    args = mock.call_args.args[0]
+    assert "--force" in args
+
+
+@pytest.mark.asyncio
+async def test_init_target_url_added(tmp_path: Path) -> None:
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        await nuguard_init(project_dir=str(tmp_path), target_url="http://localhost:9000")
+
+    args = mock.call_args.args[0]
+    assert "--target" in args
+    assert "http://localhost:9000" in args
+
+
+@pytest.mark.asyncio
+async def test_init_timeout_propagated(tmp_path: Path) -> None:
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        await nuguard_init(project_dir=str(tmp_path), timeout_seconds=99)
+
+    assert mock.call_args.kwargs["timeout"] == 99
+
+
+# ---------------------------------------------------------------------------
+# nuguard_sbom_generate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sbom_generate_reads_output_file(tmp_path: Path) -> None:
+    sbom_data = {
+        "nodes": [{"id": "a"}, {"id": "b"}],
+        "edges": [{"source": "a", "target": "b"}],
+        "summary": {"frameworks": ["LangChain"]},
+    }
+    sbom_path = tmp_path / "app.sbom.json"
+    sbom_path.write_text(json.dumps(sbom_data))
+
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_sbom_generate(
+            source=str(tmp_path),
+            output=str(sbom_path),
+        )
+
+    assert result["node_count"] == 2
+    assert result["edge_count"] == 1
+    assert result["sbom_summary"] == {"frameworks": ["LangChain"]}
+    assert result["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_sbom_generate_from_repo_args(tmp_path: Path) -> None:
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        await nuguard_sbom_generate(
+            from_repo="https://github.com/org/repo",
+            ref="develop",
+            output=str(tmp_path / "out.json"),
+        )
+
+    args = mock.call_args.args[0]
+    assert "--from-repo" in args
+    assert "https://github.com/org/repo" in args
+    assert "--ref" in args
+    assert "develop" in args
+
+
+@pytest.mark.asyncio
+async def test_sbom_generate_llm_flag(tmp_path: Path) -> None:
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        await nuguard_sbom_generate(source=str(tmp_path), llm=True)
+
+    args = mock.call_args.args[0]
+    assert "--llm" in args
+
+
+# ---------------------------------------------------------------------------
+# nuguard_analyze
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analyze_injects_status_and_exit_code(tmp_path: Path) -> None:
+    sbom = tmp_path / "app.sbom.json"
+    sbom.write_text("{}")
+    parsed = {"total": 2, "findings": [{"severity": "high"}]}
+    mock = AsyncMock(return_value=_findings(parsed=parsed))
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_analyze(sbom=str(sbom))
+
+    assert result["status"] == "findings"
+    assert result["exit_code"] == 1
+    assert result["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_analyze_disabled_tools_add_no_flags(tmp_path: Path) -> None:
+    sbom = tmp_path / "app.sbom.json"
+    sbom.write_text("{}")
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_analyze(
+            sbom=str(sbom),
+            enable_atlas=False,
+            enable_osv=False,
+            enable_grype=False,
+        )
+
+    args = mock.call_args.args[0]
+    assert "--no-atlas" in args
+    assert "--no-osv" in args
+    assert "--no-grype" in args
+    assert "--no-checkov" not in args
+
+
+@pytest.mark.asyncio
+async def test_analyze_nga_only_flag(tmp_path: Path) -> None:
+    sbom = tmp_path / "app.sbom.json"
+    sbom.write_text("{}")
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_analyze(sbom=str(sbom), nga_only=True)
+
+    args = mock.call_args.args[0]
+    assert "--nga" in args
+
+
+@pytest.mark.asyncio
+async def test_analyze_raw_output_on_parse_failure(tmp_path: Path) -> None:
+    sbom = tmp_path / "app.sbom.json"
+    sbom.write_text("{}")
+    mock = AsyncMock(
+        return_value=RunResult(0, "plain text output", "", False, None)
+    )
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_analyze(sbom=str(sbom))
+
+    assert result["raw_output"] == "plain text output"
+    assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# nuguard_scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_reads_findings_json(tmp_path: Path) -> None:
+    out_dir = tmp_path / "reports"
+    out_dir.mkdir()
+    findings_data = {
+        "total": 5,
+        "severity_counts": {"high": 2, "medium": 3},
+    }
+    (out_dir / "findings.json").write_text(json.dumps(findings_data))
+
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_scan(
+            source=str(tmp_path),
+            output_dir=str(out_dir),
+        )
+
+    assert result["summary"]["total"] == 5
+    assert result["summary"]["high"] == 2
+
+
+@pytest.mark.asyncio
+async def test_scan_artifacts_map_includes_existing_files(tmp_path: Path) -> None:
+    out_dir = tmp_path / "reports"
+    out_dir.mkdir()
+    (out_dir / "sbom.json").write_text("{}")
+    (out_dir / "report.md").write_text("# Report")
+
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_scan(source=str(tmp_path), output_dir=str(out_dir))
+
+    assert "sbom" in result["artifacts"]
+    assert "report_md" in result["artifacts"]
+    assert "findings_sarif" not in result["artifacts"]  # file not written
+
+
+@pytest.mark.asyncio
+async def test_scan_optional_flags(tmp_path: Path) -> None:
+    mock = AsyncMock(return_value=_ok())
+
+    with patch(_RUNNER, mock):
+        await nuguard_scan(
+            source=str(tmp_path),
+            policy="/tmp/policy.md",
+            target="http://app:8000",
+            steps="sbom,analyze,redteam",
+            llm=True,
+        )
+
+    args = mock.call_args.args[0]
+    assert "--policy" in args
+    assert "--target" in args
+    assert "http://app:8000" in args
+    assert "--steps" in args
+    assert "sbom,analyze,redteam" in args
+    assert "--llm" in args
+
+
+# ---------------------------------------------------------------------------
+# nuguard_behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_behavior_requires_config() -> None:
+    # With no config_path and no NUGUARD_DEFAULT_CONFIG env var, returns error.
+    env = {k: v for k, v in os.environ.items() if k != "NUGUARD_DEFAULT_CONFIG"}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("nuguard.mcp.server._DEFAULT_CONFIG", ""):
+            result = await nuguard_behavior(config_path="")
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_behavior_passes_mode(tmp_path: Path) -> None:
+    cfg = tmp_path / "nuguard.yaml"
+    cfg.write_text("")
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_behavior(config_path=str(cfg), mode="static")
+
+    args = mock.call_args.args[0]
+    assert "--mode" in args
+    assert "static" in args
+
+
+# ---------------------------------------------------------------------------
+# nuguard_redteam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redteam_guided_true_adds_flag(tmp_path: Path) -> None:
+    cfg = tmp_path / "nuguard.yaml"
+    cfg.write_text("")
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_redteam(config_path=str(cfg), guided=True)
+
+    args = mock.call_args.args[0]
+    assert "--guided" in args
+    assert "--no-guided" not in args
+
+
+@pytest.mark.asyncio
+async def test_redteam_guided_false_adds_no_guided_flag(tmp_path: Path) -> None:
+    cfg = tmp_path / "nuguard.yaml"
+    cfg.write_text("")
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_redteam(config_path=str(cfg), guided=False)
+
+    args = mock.call_args.args[0]
+    assert "--no-guided" in args
+
+
+@pytest.mark.asyncio
+async def test_redteam_injects_summary(tmp_path: Path) -> None:
+    cfg = tmp_path / "nuguard.yaml"
+    cfg.write_text("")
+    findings = [
+        {"severity": "high", "title": "Prompt injection"},
+        {"severity": "high", "title": "Data leak"},
+        {"severity": "medium", "title": "Policy bypass"},
+    ]
+    parsed = {"findings": findings}
+    mock = AsyncMock(return_value=_findings(parsed=parsed))
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_redteam(config_path=str(cfg))
+
+    assert result["summary"]["total"] == 3
+    assert result["summary"]["high"] == 2
+    assert result["summary"]["medium"] == 1
+
+
+@pytest.mark.asyncio
+async def test_redteam_profile_flag(tmp_path: Path) -> None:
+    cfg = tmp_path / "nuguard.yaml"
+    cfg.write_text("")
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_redteam(config_path=str(cfg), profile="full")
+
+    args = mock.call_args.args[0]
+    assert "--profile" in args
+    assert "full" in args
+
+
+@pytest.mark.asyncio
+async def test_redteam_timeout_status(tmp_path: Path) -> None:
+    cfg = tmp_path / "nuguard.yaml"
+    cfg.write_text("")
+    mock = AsyncMock(return_value=_timeout())
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_redteam(config_path=str(cfg))
+
+    assert result["status"] == "timeout"
+    assert result["timed_out"] is True
+
+
+# ---------------------------------------------------------------------------
+# nuguard_policy_check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_policy_check_framework_flag() -> None:
+    mock = AsyncMock(return_value=_ok(parsed={"controls": []}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_policy_check(
+            policy="/tmp/policy.md",
+            framework="owasp-llm-top10",
+        )
+
+    args = mock.call_args.args[0]
+    assert "--framework" in args
+    assert "owasp-llm-top10" in args
+
+
+@pytest.mark.asyncio
+async def test_policy_check_verbose_flag() -> None:
+    mock = AsyncMock(return_value=_ok(parsed={}))
+
+    with patch(_RUNNER, mock):
+        await nuguard_policy_check(policy="/tmp/p.md", verbose=True)
+
+    args = mock.call_args.args[0]
+    assert "--verbose" in args
+
+
+@pytest.mark.asyncio
+async def test_policy_check_raw_fallback() -> None:
+    mock = AsyncMock(return_value=RunResult(0, "No gaps found.", "", False, None))
+
+    with patch(_RUNNER, mock):
+        result = await nuguard_policy_check()
+
+    assert result["raw_output"] == "No gaps found."
+    assert result["status"] == "ok"

--- a/uv.lock
+++ b/uv.lock
@@ -1095,6 +1095,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1554,6 +1563,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1758,7 +1792,7 @@ wheels = [
 
 [[package]]
 name = "nuguard"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -1792,6 +1826,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1815,6 +1852,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.23" },
     { name = "litellm", specifier = ">=1.83.10" },
     { name = "lxml", specifier = ">=6.1.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "networkx", specifier = ">=3.3" },
     { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1" },
@@ -1834,7 +1872,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2230,6 +2268,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2286,6 +2338,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -2710,6 +2787,32 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2996,6 +3099,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR bundles a series of improvements across analysis, redteam/behavior quality, URL resolution, dependency security, and a new MCP plugin for Claude marketplace publication.

### New Features
- **MCP plugin**: Add Claude MCP plugin for Smithery marketplace publication
- **`nuguard analyze`**: `--config` and `--nga` flags; `--sbom` optional via config
- **Analysis output**: Group findings by component with tool source, PURL dedup, and severity ordering
- **Analysis dedup**: Deduplicate findings by CVE/GHSA per component
- **Redteam quality**: Agent-specific warmups and context-aware mutations
- **Behavior quality**: Context-aware probes and diverse happy paths
- **URL resolution**: Auto-resolve static-site URLs; upgrade basic auth to `login_flow` from SBOM

### Bug Fixes
- **Atlas rules**: Resolve NC-001–004 producing 0 findings on real SBOMs
- **Grype**: Increase default timeout to 300 s with 3-retry logic; reduce per-attempt timeout to 180 s
- **NGA rules**: Renumber NGA-001–018, severity-ordered
- **CVEs**: Remediate critical CVEs — litellm, lxml, urllib3, pytest, pip
- **CORS**: Fix CORS by resolving URL before bootstrap and stripping origins from deployment_urls
- **mypy**: Resolve type errors in `target_client_builder` and redteam CLI
- **Lint**: Remove unused import in test_analyze_cli

### Chores
- Bump version to 0.4.6 (pyproject.toml + smithery.yaml)
- Update SBOM artifacts and uv.lock
