### PR TITLE
feat: discovery-driven context-sensitive tests, destructive scenario ordering, npm MCP package (v0.4.8)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -53,6 +53,32 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  publish-npm:
+    name: Publish to npm
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/nuguard
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        working-directory: npm/
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-smithery:
     name: Update Smithery listing
     needs: publish-pypi

--- a/docs/mcp-plugin-guide.md
+++ b/docs/mcp-plugin-guide.md
@@ -21,6 +21,10 @@ The NuGuard MCP plugin exposes NuGuard's AI security capabilities — SBOM gener
 
 ## Installation
 
+Choose the installation method that best fits your environment:
+
+### Python (pip / uvx)
+
 The MCP server is bundled in the `nuguard` package as the optional `mcp` extra.
 
 ```bash
@@ -37,6 +41,25 @@ Or run directly without installing (using `uvx`):
 
 ```bash
 uvx --from "nuguard[mcp]" nuguard-mcp
+```
+
+### Node.js (npm / npx)
+
+A thin npm wrapper is available for environments where Node.js is preferred or where Smithery requires an npm-backed entry point. It delegates to `uvx` internally, so `uv` must be installed ([astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/)).
+
+```bash
+# Run without installing (recommended for one-off use)
+npx nuguard nuguard-mcp
+
+# Or install globally
+npm install -g nuguard
+nuguard-mcp
+```
+
+Install `uv` if it is not already present:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 ---
@@ -117,6 +140,24 @@ If you prefer not to install nuguard globally:
 }
 ```
 
+### Using npx (Node.js)
+
+If Node.js and `uv` are available but Python is not on your PATH:
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "npx",
+      "args": ["nuguard", "nuguard-mcp"],
+      "env": {
+        "LITELLM_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
 ---
 
 ## Claude Code Plugin
@@ -165,7 +206,21 @@ The agent calls `nuguard_init` → `nuguard_sbom_generate` → `nuguard_analyze`
 
 ## Smithery (Claude Marketplace)
 
-NuGuard is published on [Smithery](https://smithery.ai/), the Claude marketplace for MCP servers. Install it with one click, then configure:
+NuGuard is published on [Smithery](https://smithery.ai/server/NuGuardAI/nuguard) as an npm-backed MCP server. The Smithery listing launches `nuguard-mcp` via the `nuguard` npm package, which delegates to `uvx` internally — no manual Python setup required on the host.
+
+### Install via Smithery CLI
+
+```bash
+# Add to Claude Code
+smithery mcp add NuGuardAI/nuguard --client claude-code
+
+# Add to Claude Desktop
+smithery mcp add NuGuardAI/nuguard --client claude
+```
+
+### Install via Smithery UI
+
+Open the [NuGuard listing](https://smithery.ai/server/NuGuardAI/nuguard) and click **Connect**. Configure the optional settings:
 
 | Setting | Description |
 |---|---|

--- a/npm/bin/nuguard-mcp.js
+++ b/npm/bin/nuguard-mcp.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * Thin wrapper that launches nuguard-mcp via uvx (uv's tool runner).
+ * uv/uvx must be installed: https://docs.astral.sh/uv/getting-started/installation/
+ */
+const { spawn } = require("child_process");
+
+const args = ["--from", "nuguard[mcp]", "nuguard-mcp", ...process.argv.slice(2)];
+
+const child = spawn("uvx", args, { stdio: "inherit" });
+
+child.on("error", (err) => {
+  if (err.code === "ENOENT") {
+    console.error(
+      "Error: 'uvx' not found. Install uv first:\n" +
+      "  curl -LsSf https://astral.sh/uv/install.sh | sh\n" +
+      "  # or: pip install uv"
+    );
+  } else {
+    console.error(`Failed to start nuguard-mcp: ${err.message}`);
+  }
+  process.exit(1);
+});
+
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "nuguard",
+  "version": "0.4.7",
+  "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
+  "keywords": [
+    "mcp",
+    "ai-security",
+    "sbom",
+    "red-team",
+    "llm",
+    "ai-agents"
+  ],
+  "homepage": "https://github.com/NuGuardAI/nuguard",
+  "bugs": {
+    "url": "https://github.com/NuGuardAI/nuguard/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NuGuardAI/nuguard.git"
+  },
+  "license": "Apache-2.0",
+  "author": "NuGuard <info@nuguard.ai>",
+  "bin": {
+    "nuguard-mcp": "bin/nuguard-mcp.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.4.7"
+version = "0.4.8"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.4.7"
+version: "0.4.8"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents


### PR DESCRIPTION
## Summary

- **Pre-scan discovery improvements**: Extended name extraction patterns (greeting, possessive, contextual), added explicit name-confirmation turn, fixed early-exit to require both name and IDs before stopping
- **Discovery used in behavior tests**: `BehaviorRunner.discover()` runs before scenario generation; discovered profile injected into LLM prompts via `{golden_id}`/`{golden_name}` tokens; token substitution applied at send time
- **Discovery used in redteam tests**: Console visibility added for discovery step; `{golden_name}` fallback to "the authenticated user" when name missing
- **Destructive scenario ordering**: Cancellations, deletions, and account-closure scenarios deferred to end of run in both behavior and redteam pipelines to prevent data destruction before other scenarios execute
- **Per-scenario session isolation**: `isolate_scenarios: bool = True` added to `BehaviorConfig`; each behavior scenario gets a fresh auth session to prevent cross-scenario state contamination
- **npm MCP package**: Thin Node.js wrapper (`npm/`) that invokes `uvx --from nuguard[mcp] nuguard-mcp`; CI publish step added to `publish-pypi.yml`
- **Version bump**: 0.4.7 → 0.4.8

## Test plan

- [x] `uv run pytest tests/ -v` — 866 passed, 33 skipped
- [ ] Verify npm publish succeeds on next release (requires `NPM_TOKEN` secret in repo settings)
- [ ] Re-run agentic test against OpenAI CS Agents demo to confirm discovered IDs appear in sent payloads and destructive scenarios run last

🤖 Generated with [Claude Code](https://claude.ai/claude-code)