### PR TITLE
feat: Smithery CLI publish via .mcpb bundle + README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ If these tools are not installed, the corresponding checks can be skipped or may
 
 ## Installation
 
-For production use, install the package from PyPI with: 
+**MCP server (Claude / Cursor / Windsurf):** [smithery.ai/servers/NuGuardAI/nuguard](https://smithery.ai/servers/NuGuardAI/nuguard)
+
+```bash
+smithery mcp add NuGuardAI/nuguard
+```
+
+**Python CLI:**
 
 ```bash
 pip install nuguard


### PR DESCRIPTION
## Summary

- Replaced REST API Smithery publish with `smithery mcp publish ./server.mcpb` — the script now builds a `.mcpb` zip bundle from `smithery.yaml` at publish time and delegates to the official CLI (handles server creation, releases, and deployment status automatically)
- CI `publish-smithery` job updated to install the `smithery` npm package before running
- `server.mcpb` added to `.gitignore` as a build artifact
- Added Smithery MCP server link (`https://smithery.ai/servers/NuGuardAI/nuguard`) and `smithery mcp add NuGuardAI/nuguard` to README Installation section

## Test plan

- [x] Dry-run verified: `python scripts/publish_smithery.py --dry-run --skip-pypi --skip-git-tag --allow-branch --allow-dirty`
- [x] Live publish succeeded: `smithery mcp publish ./server.mcpb -n NuGuardAI/nuguard` → release accepted, server live at https://smithery.ai/servers/NuGuardAI/nuguard

🤖 Generated with [Claude Code](https://claude.com/claude-code)