### PR TITLE
Add agents and skills plugin directories to plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "security",
       "tags": [
         "ai-security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "nuguard",
   "name": "nuguard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI application security for Claude — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,5 +24,7 @@
     "mcp"
   ],
   "commands": "./plugin/commands/",
+  "agents": "./plugin/agents/",
+  "skills": "./plugin/skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "nuguard": {
       "type": "stdio",
-      "command": "uvx",
-      "args": ["--from", "nuguard[mcp]", "nuguard-mcp"]
+      "command": "npx",
+      "args": ["-y", "nuguard"]
     }
   }
 }

--- a/docs/mcp-plugin-guide.md
+++ b/docs/mcp-plugin-guide.md
@@ -6,17 +6,133 @@ NuGuard's MCP server exposes AI security tools — SBOM generation, static analy
 
 ## Installation
 
-### Smithery (recommended)
+Choose the method that matches your environment. All methods expose the same seven tools.
 
-The easiest way to install NuGuard for Claude Code or Claude Desktop:
+---
+
+### Claude Code plugin (recommended)
+
+The plugin installs the MCP server and wires slash commands, agents, and skills in one step — no manual config editing required.
+
+**From the Claude Code UI:** open the plugin marketplace, search for **NuGuard**, and click **Install**.
+
+**From the terminal:**
+
+```bash
+claude plugin add NuGuardAI/nuguard
+```
+
+The bundled `.mcp.json` starts the server via `npx -y nuguard`, which auto-detects the best available Python runtime (see [How the launcher picks a runtime](#how-the-launcher-picks-a-runtime) below). No separate tool installation is required if you have Node.js or Python.
+
+After installation, run the configuration wizard once per project:
+
+```
+/nuguard-config
+```
+
+The wizard collects your LLM API key, model, target URL, and auth details, then writes them to `.claude/nuguard.local.md` (project-local, gitignored). Every NuGuard command and the AI security-review skill read this file automatically — you never need to repeat credentials.
+
+---
+
+### pip (fastest if you already have Python)
+
+Install the package once, then the MCP server is available everywhere with no extra tooling:
+
+```bash
+pip install "nuguard[mcp]"
+```
+
+For Claude Desktop, add to your config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "nuguard-mcp",
+      "env": {
+        "LITELLM_API_KEY": "your-api-key-here",
+        "NUGUARD_DEFAULT_CONFIG": "/absolute/path/to/nuguard.yaml"
+      }
+    }
+  }
+}
+```
+
+For Claude Code (project-local), add a `.mcp.json` at your project root:
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "type": "stdio",
+      "command": "nuguard-mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop or reload the Claude Code window after saving. The NuGuard tools appear in the tools panel (hammer icon).
+
+> **Tip:** Using a virtual environment? Activate it first, or point directly to the venv's binary:
+> ```json
+> { "command": "/path/to/.venv/bin/nuguard-mcp" }
+> ```
+
+---
+
+### npx (no Python required)
+
+If you have Node.js (which includes `npx`) but not Python, `npx` downloads and runs the wrapper on first use with no interactive prompts:
+
+For Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "command": "npx",
+      "args": ["-y", "nuguard"],
+      "env": {
+        "LITELLM_API_KEY": "your-api-key-here",
+        "NUGUARD_DEFAULT_CONFIG": "/absolute/path/to/nuguard.yaml"
+      }
+    }
+  }
+}
+```
+
+For Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "nuguard": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "nuguard"]
+    }
+  }
+}
+```
+
+The npm wrapper uses the same runtime detection waterfall as the plugin (see below), so it will use pip-installed nuguard if present, or install it automatically.
+
+---
+
+### Smithery
+
+If you use Smithery to manage your MCP servers:
 
 ```bash
 smithery mcp add NuGuardAI/nuguard
 ```
 
-Or open the listing at [smithery.ai/servers/NuGuardAI/nuguard](https://smithery.ai/servers/NuGuardAI/nuguard) and click **Connect**.
+Or open [smithery.ai/servers/NuGuardAI/nuguard](https://smithery.ai/servers/NuGuardAI/nuguard) and click **Connect**.
 
-During install, Smithery asks for three optional settings:
+During install, Smithery prompts for three optional settings:
 
 | Setting | Description |
 |---|---|
@@ -28,10 +144,9 @@ Secrets are passed as environment variables to the `nuguard-mcp` process and nev
 
 ---
 
-### Manual (Claude Desktop)
+### uvx (uv users)
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or
-`%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+If you use [uv](https://docs.astral.sh/uv/), you can run the MCP server directly without a permanent install:
 
 ```json
 {
@@ -40,61 +155,25 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
       "command": "uvx",
       "args": ["--from", "nuguard[mcp]", "nuguard-mcp"],
       "env": {
-        "LITELLM_API_KEY": "your-api-key-here",
-        "NUGUARD_DEFAULT_CONFIG": "/absolute/path/to/nuguard.yaml"
+        "LITELLM_API_KEY": "your-api-key-here"
       }
     }
   }
 }
 ```
 
-Restart Claude Desktop after saving. The NuGuard tools appear in the tools panel (hammer icon).
-
 ---
 
-### Claude Code Plugin
+### How the launcher picks a runtime
 
-Add NuGuard as a marketplace source, then install:
+When started via `npx -y nuguard` (the plugin default), the launcher checks in order:
 
-```bash
-claude plugin marketplace add NuGuardAI/nuguard
-claude plugin install nuguard
-```
+1. `nuguard-mcp` already on `PATH` — uses it directly (zero setup, fastest)
+2. `python3` / `python` with `nuguard` importable — runs `python -m nuguard.mcp`
+3. `uvx` on `PATH` — runs `uvx --from nuguard[mcp] nuguard-mcp`
+4. Any Python available — runs `pip install nuguard[mcp]` silently, then starts the server
 
-This wires the MCP server automatically via the bundled `.mcp.json` — no manual config editing required.
-
-After installation, run the configuration wizard inside Claude Code to store your credentials for the project:
-
-```
-/nuguard-config
-```
-
-The wizard asks for your LLM API key, model, target URL, and auth details, then writes them to `.claude/nuguard.local.md` (project-local, not committed). All NuGuard commands and the security-review skill read this file automatically so you don't need to repeat credentials on every call.
-
----
-
-### Manual (Claude Code)
-
-Add a `.mcp.json` file at your project root:
-
-```json
-{
-  "mcpServers": {
-    "nuguard": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": ["--from", "nuguard[mcp]", "nuguard-mcp"]
-    }
-  }
-}
-```
-
-Set environment variables in your shell or `.env`:
-
-```bash
-export LITELLM_API_KEY=your-api-key-here
-export NUGUARD_DEFAULT_CONFIG=/absolute/path/to/nuguard.yaml
-```
+Steps 1 and 2 require nothing extra if nuguard is already pip-installed. Step 3 and 4 handle fresh environments automatically.
 
 ---
 
@@ -381,9 +460,28 @@ export NUGUARD_DEFAULT_CONFIG=/home/me/projects/cs-bot/nuguard.yaml
 ## Troubleshooting
 
 **Tools don't appear in Claude Desktop**  
-Restart Claude Desktop after editing `claude_desktop_config.json`. On macOS, Claude Desktop does not inherit shell PATH — use the absolute path to `uvx` if needed:
+Restart Claude Desktop after editing `claude_desktop_config.json`. On macOS and Windows, Claude Desktop does not inherit your shell PATH, so relative command names may not resolve. Use the absolute path to whichever binary you chose:
+
 ```json
-{ "command": "/usr/local/bin/uvx" }
+{ "command": "/usr/local/bin/nuguard-mcp" }
+```
+```json
+{ "command": "/usr/local/bin/npx", "args": ["-y", "nuguard"] }
+```
+
+Find the absolute path with `which nuguard-mcp` (macOS/Linux) or `where nuguard-mcp` (Windows).
+
+**`nuguard-mcp: no suitable Python runtime found`**  
+The `npx` launcher could not find Python or uvx. Install one of:
+```bash
+pip install "nuguard[mcp]"      # recommended — also installs the nuguard-mcp binary
+```
+or install [uv](https://docs.astral.sh/uv/) and the launcher will use `uvx` automatically.
+
+**`nuguard-mcp` not found after `pip install nuguard[mcp]`**  
+pip installed into a virtual environment whose `bin/` directory is not on your PATH. Either activate the venv before starting Claude Desktop, or use the absolute path:
+```json
+{ "command": "/path/to/.venv/bin/nuguard-mcp" }
 ```
 
 **`nuguard_redteam` times out**  
@@ -393,7 +491,7 @@ The default timeout is 900 s. For large `profile=full` scans pass `timeout_secon
 Check the `stderr` field in the response. Common causes: `sbom` path doesn't exist, `config_path` points to a directory, or `LITELLM_API_KEY` is not set when `llm=true`.
 
 **Grype / Checkov / Trivy not running**  
-These are optional. Install them or disable them per-call:
+These are optional external tools. Install them or disable them per-call:
 ```
 nuguard_analyze(sbom="...", enable_grype=false, enable_trivy=false)
 ```

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications. Slash-command exposure is host-dependent and not claimed by this manifest.",
   "contextFileName": "CLAUDE.md"
 }

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "security",
       "tags": [
         "ai-security",

--- a/npm/bin/nuguard-mcp.js
+++ b/npm/bin/nuguard-mcp.js
@@ -1,25 +1,72 @@
 #!/usr/bin/env node
 /**
- * Thin wrapper that launches nuguard-mcp via uvx (uv's tool runner).
- * uv/uvx must be installed: https://docs.astral.sh/uv/getting-started/installation/
+ * Launcher for nuguard-mcp. Tries runners in order of least friction:
+ *   1. nuguard-mcp already on PATH (pip-installed globally or in active venv)
+ *   2. python/python3 -m nuguard.mcp (nuguard installed but scripts not on PATH)
+ *   3. uvx --from nuguard[mcp] nuguard-mcp  (uv available)
+ *   4. pip install nuguard[mcp] then python -m nuguard.mcp  (one-time setup)
  */
-const { spawn } = require("child_process");
+"use strict";
 
-const args = ["--from", "nuguard[mcp]", "nuguard-mcp", ...process.argv.slice(2)];
+const { spawn, spawnSync } = require("child_process");
 
-const child = spawn("uvx", args, { stdio: "inherit" });
+function which(cmd) {
+  const isWin = process.platform === "win32";
+  const r = spawnSync(isWin ? "where" : "which", [cmd], { encoding: "utf8", stdio: "pipe" });
+  return r.status === 0 && r.stdout.trim().length > 0;
+}
 
-child.on("error", (err) => {
-  if (err.code === "ENOENT") {
-    console.error(
-      "Error: 'uvx' not found. Install uv first:\n" +
-      "  curl -LsSf https://astral.sh/uv/install.sh | sh\n" +
-      "  # or: pip install uv"
-    );
-  } else {
-    console.error(`Failed to start nuguard-mcp: ${err.message}`);
+function pyHasNuguardMcp(python) {
+  const r = spawnSync(python, ["-c", "import nuguard.mcp"], { encoding: "utf8", stdio: "pipe" });
+  return r.status === 0;
+}
+
+function run(command, args) {
+  const child = spawn(command, [...args], { stdio: "inherit" });
+  child.on("error", (err) => {
+    process.stderr.write(`nuguard-mcp: failed to start '${command}': ${err.message}\n`);
+    process.exit(1);
+  });
+  child.on("exit", (code) => process.exit(code ?? 0));
+}
+
+const extra = process.argv.slice(2);
+
+// 1. Already pip-installed and on PATH
+if (which("nuguard-mcp")) {
+  return run("nuguard-mcp", extra);
+}
+
+// 2. Python with nuguard already installed
+const python = which("python3") ? "python3" : which("python") ? "python" : null;
+if (python && pyHasNuguardMcp(python)) {
+  return run(python, ["-m", "nuguard.mcp", ...extra]);
+}
+
+// 3. uvx
+if (which("uvx")) {
+  return run("uvx", ["--from", "nuguard[mcp]", "nuguard-mcp", ...extra]);
+}
+
+// 4. pip install then run
+if (python) {
+  process.stderr.write("nuguard-mcp: installing via pip (one-time setup)...\n");
+  const install = spawnSync(
+    python, ["-m", "pip", "install", "--quiet", "nuguard[mcp]"],
+    { stdio: "inherit" }
+  );
+  if (install.status === 0) {
+    return run(python, ["-m", "nuguard.mcp", ...extra]);
   }
+  process.stderr.write("nuguard-mcp: pip install failed — try: pip install nuguard[mcp]\n");
   process.exit(1);
-});
+}
 
-child.on("exit", (code) => process.exit(code ?? 0));
+process.stderr.write(
+  "nuguard-mcp: no suitable Python runtime found.\n" +
+  "Install via one of:\n" +
+  "  pip install nuguard[mcp]\n" +
+  "  uvx --from nuguard[mcp] nuguard-mcp\n" +
+  "See https://github.com/NuGuardAI/nuguard for details.\n"
+);
+process.exit(1);

--- a/npm/bin/nuguard-mcp.test.js
+++ b/npm/bin/nuguard-mcp.test.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Tests for nuguard-mcp.js runner detection logic.
+ *
+ * Run with:  node npm/bin/nuguard-mcp.test.js
+ *
+ * Uses Node's built-in assert module — no external test framework needed.
+ */
+"use strict";
+
+const assert = require("assert");
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WRAPPER = path.resolve(__dirname, "nuguard-mcp.js");
+
+/**
+ * Run the wrapper with a mocked environment via a child node process.
+ * We inject a tiny shim that overrides `which`, `pyHasNuguardMcp`, and
+ * `spawnSync` (for pip install) before the real module logic runs.
+ *
+ * Returns { stdout, stderr, exitCode }.
+ */
+function runWithMocks({ whichResults = {}, pyHasNuguard = false, pipOk = true } = {}) {
+  const shim = `
+"use strict";
+const cp = require("child_process");
+const original_spawnSync = cp.spawnSync.bind(cp);
+
+// Intercept spawnSync used by which() and pip install
+cp.spawnSync = function(cmd, args, opts) {
+  const isWin = process.platform === "win32";
+  const whichCmd = isWin ? "where" : "which";
+
+  if (cmd === whichCmd) {
+    const target = args[0];
+    const found = ${JSON.stringify(whichResults)}[target] === true;
+    return { status: found ? 0 : 1, stdout: found ? target : "", stderr: "" };
+  }
+
+  // python -c "import nuguard.mcp"
+  if (args && args[0] === "-c" && args[1] === "import nuguard.mcp") {
+    return { status: ${pyHasNuguard ? 0 : 1} };
+  }
+
+  // pip install
+  if (args && args[0] === "-m" && args[1] === "pip") {
+    return { status: ${pipOk ? 0 : 1} };
+  }
+
+  return { status: 1, stdout: "", stderr: "" };
+};
+
+// Intercept spawn used by run() — capture what would be launched
+const cp2 = require("child_process");
+const original_spawn = cp2.spawn.bind(cp2);
+cp2.spawn = function(cmd, args, opts) {
+  // Print what would be launched and exit cleanly
+  process.stdout.write(JSON.stringify({ cmd, args }) + "\\n");
+  return {
+    on: function(event, cb) {
+      if (event === "exit") cb(0);
+      if (event === "error") {}
+      return this;
+    }
+  };
+};
+
+require(${JSON.stringify(WRAPPER)});
+`;
+
+  const result = spawnSync(process.execPath, ["--eval", shim], {
+    encoding: "utf8",
+    stdio: "pipe",
+    timeout: 5000,
+  });
+
+  let launched = null;
+  if (result.stdout && result.stdout.trim()) {
+    try { launched = JSON.parse(result.stdout.trim()); } catch (_) {}
+  }
+
+  return {
+    launched,
+    stderr: result.stderr || "",
+    exitCode: result.status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+console.log("\nnuguard-mcp.js runner detection\n");
+
+// 1. nuguard-mcp already on PATH → run it directly
+test("uses nuguard-mcp directly when it is on PATH", () => {
+  const { launched } = runWithMocks({ whichResults: { "nuguard-mcp": true } });
+  assert.ok(launched, "should have launched something");
+  assert.strictEqual(launched.cmd, "nuguard-mcp");
+  assert.deepStrictEqual(launched.args, []);
+});
+
+// 2. python3 with nuguard installed → python3 -m nuguard.mcp
+test("uses python3 -m nuguard.mcp when nuguard-mcp not on PATH but python3 has it", () => {
+  const { launched } = runWithMocks({
+    whichResults: { python3: true },
+    pyHasNuguard: true,
+  });
+  assert.ok(launched);
+  assert.strictEqual(launched.cmd, "python3");
+  assert.ok(launched.args.includes("-m"), "should include -m flag");
+  assert.ok(launched.args.includes("nuguard.mcp"), "should target nuguard.mcp");
+});
+
+// 3. python (not python3) with nuguard installed
+test("falls back to python (not python3) when python3 not available", () => {
+  const { launched } = runWithMocks({
+    whichResults: { python: true },
+    pyHasNuguard: true,
+  });
+  assert.ok(launched);
+  assert.strictEqual(launched.cmd, "python");
+});
+
+// 4. uvx available, nuguard not pip-installed
+test("uses uvx when nuguard not pip-installed but uvx is available", () => {
+  const { launched } = runWithMocks({
+    whichResults: { uvx: true },
+    pyHasNuguard: false,
+  });
+  assert.ok(launched);
+  assert.strictEqual(launched.cmd, "uvx");
+  assert.ok(launched.args.includes("--from"));
+  assert.ok(launched.args.includes("nuguard[mcp]"));
+  assert.ok(launched.args.includes("nuguard-mcp"));
+});
+
+// 5. pip install fallback when python available but nuguard not installed
+test("pip-installs nuguard then launches python -m nuguard.mcp when only python present", () => {
+  const { launched, stderr } = runWithMocks({
+    whichResults: { python3: true },
+    pyHasNuguard: false,
+    pipOk: true,
+  });
+  assert.ok(launched, "should launch after pip install");
+  assert.strictEqual(launched.cmd, "python3");
+  assert.ok(launched.args.includes("nuguard.mcp"));
+  assert.ok(stderr.includes("installing via pip"), "should mention pip install");
+});
+
+// 6. No Python, no uvx → exit 1 with helpful message
+test("exits with code 1 and helpful message when no runtime found", () => {
+  const { launched, stderr, exitCode } = runWithMocks({
+    whichResults: {},
+    pyHasNuguard: false,
+  });
+  assert.strictEqual(launched, null, "should not launch anything");
+  assert.ok(stderr.includes("pip install") || stderr.includes("Python"), "stderr should contain install hint");
+});
+
+// 7. pip install fails → exit 1
+test("exits with code 1 when pip install fails", () => {
+  const { launched } = runWithMocks({
+    whichResults: { python3: true },
+    pyHasNuguard: false,
+    pipOk: false,
+  });
+  assert.strictEqual(launched, null, "should not launch after failed pip install");
+});
+
+// 8. nuguard-mcp takes precedence over python + uvx
+test("nuguard-mcp on PATH takes precedence over python and uvx", () => {
+  const { launched } = runWithMocks({
+    whichResults: { "nuguard-mcp": true, python3: true, uvx: true },
+    pyHasNuguard: true,
+  });
+  assert.ok(launched);
+  assert.strictEqual(launched.cmd, "nuguard-mcp", "nuguard-mcp should win over python/uvx");
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/nuguard/mcp/__main__.py
+++ b/nuguard/mcp/__main__.py
@@ -4,7 +4,7 @@ from nuguard.mcp.server import mcp
 
 
 def main() -> None:
-    mcp.run()
+    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/nuguard/mcp/_runner.py
+++ b/nuguard/mcp/_runner.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import re
 import signal
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -45,7 +46,7 @@ async def run_nuguard_command(
     blocked. Kills the process on timeout (SIGTERM → 2 s → SIGKILL).
     """
     proc = await asyncio.create_subprocess_exec(
-        "nuguard",
+        sys.executable, "-m", "nuguard.cli.main",
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nuguard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "format": "claude-plugin",
   "source": ".claude-plugin/plugin.json",
   "hostTargets": ["claude-code", "openclaw"]

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -15,7 +15,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "security",
       "tags": [
         "ai-security",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral testing, and adversarial red-teaming for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/plugin/skills/ai-security-review/SKILL.md
+++ b/plugin/skills/ai-security-review/SKILL.md
@@ -3,7 +3,7 @@ name: AI Application Security Review
 description: >
   Activate when the user asks to audit, review, scan, or assess the security of an AI
   application, agent, chatbot, or LLM-powered system. Also activate when the user mentions prompt injection, data exfiltration, guardrail bypass, red-teaming, AI SBOM, cognitive policy, OWASP LLM Top 10, NIST AI RMF, or EU AI Act compliance.
-version: 0.5.0
+version: 0.5.1
 ---
 
 You are conducting an AI application security review using NuGuard's pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.5.0"
+version = "0.5.1"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.5.0"
+version: "0.5.1"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/tests/mcp/test_runner.py
+++ b/tests/mcp/test_runner.py
@@ -82,7 +82,9 @@ async def test_run_success_json() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_passes_nuguard_as_executable() -> None:
+async def test_run_uses_sys_executable() -> None:
+    """Subprocess must use sys.executable so nuguard CLI is always reachable,
+    even inside a uvx-isolated environment where 'nuguard' is not on PATH."""
     proc = _make_proc()
 
     with patch("nuguard.mcp._runner.asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
@@ -90,9 +92,12 @@ async def test_run_passes_nuguard_as_executable() -> None:
         await run_nuguard_command(["sbom", "generate"])
 
     call_args = mock_exec.call_args
-    assert call_args.args[0] == "nuguard"
-    assert call_args.args[1] == "sbom"
-    assert call_args.args[2] == "generate"
+    import sys as _sys
+    assert call_args.args[0] == _sys.executable
+    assert call_args.args[1] == "-m"
+    assert call_args.args[2] == "nuguard.cli.main"
+    assert call_args.args[3] == "sbom"
+    assert call_args.args[4] == "generate"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from nuguard.mcp.server import mcp
+from nuguard.mcp.__main__ import main
 
 _EXPECTED_TOOLS = {
     "nuguard_init",
@@ -68,3 +71,17 @@ async def test_analyze_tool_has_sbom_param(tools) -> None:
 async def test_redteam_tool_has_profile_param(tools) -> None:
     redteam = next(t for t in tools if t.name == "nuguard_redteam")
     assert "profile" in redteam.inputSchema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# Transport — main() must call mcp.run with transport="stdio"
+# ---------------------------------------------------------------------------
+
+def test_main_calls_run_with_stdio_transport() -> None:
+    """main() must explicitly request stdio transport so Smithery / Claude Code
+    don't accidentally fall through to an SSE or HTTP listener."""
+    from unittest.mock import patch, MagicMock
+    mock_run = MagicMock()
+    with patch("nuguard.mcp.server.mcp.run", mock_run):
+        main()
+    mock_run.assert_called_once_with(transport="stdio")


### PR DESCRIPTION
## Summary
Extended the plugin configuration to support agents and skills as first-class plugin types alongside the existing commands and MCP servers.

## Changes
- Added `"agents"` field pointing to `./plugin/agents/` directory
- Added `"skills"` field pointing to `./plugin/skills/` directory

These new plugin directories follow the same pattern as the existing `"commands"` directory, enabling the plugin system to discover and load agent and skill modules from their respective locations.

https://claude.ai/code/session_01Qe3WSgPdBZG8gAgYZ4TKbH