### PR TITLE
Increase behavior & redteam severity weights with version bump to 0.7.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "category": "security",
       "tags": [
         "ai-security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "nuguard",
   "name": "nuguard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "AI application security for Claude — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications. Slash-command exposure is host-dependent and not claimed by this manifest.",
   "contextFileName": "CLAUDE.md"
 }

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "category": "security",
       "tags": [
         "ai-security",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuguardai/nuguard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/nuguard/behavior/models.py
+++ b/nuguard/behavior/models.py
@@ -361,7 +361,7 @@ class BehaviorAnalysisResult(BaseModel):
     def overall_risk_score(self) -> float:
         """Compute overall risk score (0–100) as the weighted average severity.
 
-        Weights: critical=100, high=70, medium=40, low=10, info=0.
+        Weights: critical=100, high=80, medium=50, low=25, info=0.
         Score = mean of per-finding weights, so volume and mix of severities
         influence the score proportionally. Consistent with red-team scoring.
         """
@@ -371,7 +371,7 @@ class BehaviorAnalysisResult(BaseModel):
         ]
         if not all_findings:
             return 0.0
-        _weights = {"critical": 100.0, "high": 70.0, "medium": 40.0, "low": 10.0, "info": 0.0}
+        _weights = {"critical": 100.0, "high": 80.0, "medium": 50.0, "low": 25.0, "info": 0.0}
 
         def _sev_key(raw: object) -> str:
             # Normalise plain strings ("high", "HIGH") and enum-style strings
@@ -379,7 +379,7 @@ class BehaviorAnalysisResult(BaseModel):
             s = str(raw).lower()
             return s.rsplit(".", 1)[-1] if "." in s else s
 
-        total = sum(_weights.get(_sev_key(f.get("severity", "low")), 10.0) for f in all_findings)
+        total = sum(_weights.get(_sev_key(f.get("severity", "low")), 25.0) for f in all_findings)
         return round(total / len(all_findings), 2)
 
     broken_chains: list[str] = Field(default_factory=list)

--- a/nuguard/behavior/tests/test_models.py
+++ b/nuguard/behavior/tests/test_models.py
@@ -187,8 +187,8 @@ def test_behavior_analysis_result_risk_score():
             {"severity": "high", "title": "Bad thing 2"},
         ],
     )
-    # critical (100) + high (70) = 170; avg: 170 / 2 = 85.0
-    assert result.overall_risk_score == 85.0
+    # critical (100) + high (80) = 180; avg: 180 / 2 = 90.0
+    assert result.overall_risk_score == 90.0
 
 
 def test_behavior_analysis_result_risk_score_medium():
@@ -196,7 +196,7 @@ def test_behavior_analysis_result_risk_score_medium():
         intent=IntentProfile(),
         static_findings=[{"severity": "medium", "title": "medium thing"}],
     )
-    assert result.overall_risk_score == 40.0
+    assert result.overall_risk_score == 50.0
 
 
 def test_behavior_analysis_result_coverage_percentage():

--- a/nuguard/behavior/tests/test_report.py
+++ b/nuguard/behavior/tests/test_report.py
@@ -82,7 +82,7 @@ def test_to_json_with_findings():
         static_findings=[{"severity": "high", "title": "Bad thing"}],
     )
     data = json.loads(to_json(result))
-    assert data["overall_risk_score"] == 70.0
+    assert data["overall_risk_score"] == 80.0
     assert len(data["static_findings"]) == 1
 
 

--- a/nuguard/redteam/report.py
+++ b/nuguard/redteam/report.py
@@ -120,7 +120,7 @@ def to_markdown(
     lines += ["## Summary", ""]
     if meta.scan_profile:
         lines += [f"- **Scan Profile**: {meta.scan_profile}", ""]
-    _WEIGHTS = {"CRITICAL": 100.0, "HIGH": 70.0, "MEDIUM": 40.0, "LOW": 10.0, "INFO": 0.0}
+    _WEIGHTS = {"CRITICAL": 100.0, "HIGH": 80.0, "MEDIUM": 50.0, "LOW": 25.0, "INFO": 0.0}
     if findings:
         _scores = [
             _WEIGHTS.get(

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nuguard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "format": "claude-plugin",
   "source": ".claude-plugin/plugin.json",
   "hostTargets": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.7.3"
+version = "0.7.4"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.7.3"
+version: "0.7.4"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/tests/behavior/test_report.py
+++ b/tests/behavior/test_report.py
@@ -35,29 +35,29 @@ def test_risk_score_single_critical():
 
 def test_risk_score_single_high():
     result = _make_result(dynamic_findings=[_finding("high")])
-    assert result.overall_risk_score == 70.0
+    assert result.overall_risk_score == 80.0
 
 
 def test_risk_score_single_medium():
     result = _make_result(dynamic_findings=[_finding("medium")])
-    assert result.overall_risk_score == 40.0
+    assert result.overall_risk_score == 50.0
 
 
 def test_risk_score_single_low():
     result = _make_result(dynamic_findings=[_finding("low")])
-    assert result.overall_risk_score == 10.0
+    assert result.overall_risk_score == 25.0
 
 
 def test_risk_score_mixed_critical_and_low():
-    # avg(100, 10) = 55.0
+    # avg(100, 25) = 62.5
     result = _make_result(dynamic_findings=[_finding("critical"), _finding("low")])
-    assert result.overall_risk_score == 55.0
+    assert result.overall_risk_score == 62.5
 
 
 def test_risk_score_two_highs_below_10():
-    # avg(70, 70) = 70.0
+    # avg(80, 80) = 80.0
     result = _make_result(dynamic_findings=[_finding("high"), _finding("high")])
-    assert result.overall_risk_score == 70.0
+    assert result.overall_risk_score == 80.0
 
 
 def test_risk_score_uses_static_and_dynamic():
@@ -65,8 +65,8 @@ def test_risk_score_uses_static_and_dynamic():
         static_findings=[_finding("medium")],
         dynamic_findings=[_finding("high")],
     )
-    # avg(40, 70) = 55.0
-    assert result.overall_risk_score == 55.0
+    # avg(50, 80) = 65.0
+    assert result.overall_risk_score == 65.0
 
 
 def test_risk_score_info_counts_as_zero_weight():

--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ wheels = [
 
 [[package]]
 name = "nuguard"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "cyclonedx-bom" },


### PR DESCRIPTION
- feat(risk): increase behavior & redteam severity weights
    Raise the per-finding weights used to compute overall_risk_score (0–100)
    for `nuguard behavior` and `nuguard redteam`:
      HIGH:   70 → 80  (+10)
      MEDIUM: 40 → 50  (+10)
      LOW:    10 → 25  (+15)
      CRITICAL/INFO: unchanged (100 / 0)
- chore: bump version to 0.7.4
