### PR TITLE
remediation: route by scenario_type; fix scenario_filter dropping findings

### DIFF
--- a/nuguard/models/finding.py
+++ b/nuguard/models/finding.py
@@ -24,6 +24,7 @@ class Finding(BaseModel):
     references: list[str] = Field(default_factory=list)
     # Redteam-specific fields
     goal_type: str | None = None
+    scenario_type: str | None = None
     sbom_path: list[str] = Field(default_factory=list)
     sbom_path_descriptions: list[str] = Field(default_factory=list)
     policy_clauses_violated: list[str] = Field(default_factory=list)

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -109,6 +109,36 @@ def _scenario_matches_filter(scenario: AttackScenario, filters: set[str]) -> boo
     )
 
 
+def finding_matches_scenario_filter(finding: Finding, filters: set[str]) -> bool:
+    """Post-run counterpart to :func:`_scenario_matches_filter`.
+
+    ``run_redteam()`` re-checks the scenario_filter against the *findings*
+    it got back (a defensive re-check after the orchestrator's own,
+    already-correct pre-run filtering) — but findings only carry
+    ``goal_type``/``scenario_type``/``title`` as plain strings, not an
+    ``AttackScenario``, so this mirrors the same three-field, both-directions
+    substring rule rather than sharing code directly with
+    :func:`_scenario_matches_filter`.
+
+    A finding with no ``goal_type`` at all always passes (preserves prior
+    behaviour for findings from paths that don't set it, e.g. non-redteam
+    origins reusing this same filter).
+    """
+    if not filters:
+        return True
+    if not finding.goal_type:
+        return True
+    goal = _normalize_scenario_token(finding.goal_type)
+    scenario_type = _normalize_scenario_token(finding.scenario_type) if finding.scenario_type else ""
+    title = _normalize_scenario_token(finding.title or "")
+    return any(
+        token in goal or goal in token
+        or (scenario_type and (token in scenario_type or scenario_type in token))
+        or (title and token in title)
+        for token in filters
+    )
+
+
 def _known_scenario_filter_tokens() -> set[str]:
     """Normalized set of every valid GoalType and ScenarioType value.
 

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -2006,6 +2006,7 @@ class RedteamOrchestrator:
         # Fields shared by every Finding produced from this scenario/chain.
         _base: dict = dict(
             goal_type=scenario.goal_type,
+            scenario_type=scenario.scenario_type,
             chain_id=chain.chain_id,
             sbom_path=chain.sbom_path,
             sbom_path_descriptions=sbom_path_descriptions,

--- a/nuguard/redteam/public_api.py
+++ b/nuguard/redteam/public_api.py
@@ -170,6 +170,9 @@ async def _build_remediation_plan(
                 "affected_component": f.affected_component or "unknown",
                 "severity": f.severity.value if hasattr(f.severity, "value") else str(f.severity),
                 "goal_type": f.goal_type or "",
+                "scenario_type": f.scenario_type or "",
+                "evidence_quote": f.evidence_quote or "",
+                "reasoning": f.reasoning or "",
             }
             for f in findings
         ]

--- a/nuguard/redteam/public_api.py
+++ b/nuguard/redteam/public_api.py
@@ -29,7 +29,10 @@ from nuguard.config import RedteamFindingTriggers
 from nuguard.models.finding import Finding
 from nuguard.models.health_report import TargetHealthReport
 from nuguard.models.token_usage import TokenUsage
-from nuguard.redteam.executor.orchestrator import RedteamOrchestrator
+from nuguard.redteam.executor.orchestrator import (
+    RedteamOrchestrator,
+    finding_matches_scenario_filter,
+)
 from nuguard.redteam.target.canary import CanaryConfig
 from nuguard.remediation.backfill import backfill_finding_remediation
 from nuguard.remediation.models import RemediationArtefact
@@ -281,18 +284,17 @@ async def run_redteam(
         except Exception:  # noqa: BLE001
             pass
 
-    # Mirrors nuguard/cli/commands/redteam.py:_run_orchestrator's post-run
-    # scenario_filter re-application verbatim.
+    # Defensive re-check of scenario_filter against the returned findings —
+    # the orchestrator's own pre-run filtering (_scenario_matches_filter,
+    # which checks goal_type, scenario_type, AND title) is what actually
+    # decides which scenarios execute; this only needs to be consistent with
+    # it. Previously checked goal_type alone, so a scenario-type-level
+    # filter (e.g. "APPROVAL_STATE_FORGERY") would pass the orchestrator's
+    # pre-run filter but then have its resulting finding silently dropped
+    # here, since the token is never a substring of the finding's goal_type.
     if request.scenario_filter:
-        findings = [
-            f
-            for f in findings
-            if not f.goal_type
-            or any(
-                s.lower().replace("-", "_") in (f.goal_type or "").lower()
-                for s in request.scenario_filter
-            )
-        ]
+        _filters = {s.strip().lower().replace("-", "_") for s in request.scenario_filter if s and s.strip()}
+        findings = [f for f in findings if finding_matches_scenario_filter(f, _filters)]
 
     remediation_plan = await _build_remediation_plan(
         findings, sbom=sbom, policy=policy, llm_client=remediation_llm_client or eval_llm

--- a/nuguard/remediation/synthesizer.py
+++ b/nuguard/remediation/synthesizer.py
@@ -257,6 +257,182 @@ _GOAL_TYPE_DTYPE: dict[str, str] = {
     "policy_violation": "policy_violation_generic",
     "mcp_toxic_flow": "restricted_action_reachable",
     "api_attack": "privilege_escalation",
+    "agentic_trust_abuse": "agentic_trust_boundary",
+    "recon_inference": "policy_violation_generic",
+}
+
+# Redteam ``ScenarioType`` → synthesizer dtype. Checked before ``goal_type``
+# in ``_classify_finding`` because it identifies the *specific* attack
+# technique rather than the coarse goal family (e.g. PROMPT_DRIVEN_THREAT
+# spans everything from system-prompt extraction to approval forgery, which
+# need different remediation). Closed, exact-match dict — no keyword or
+# substring matching — so an unrecognised value falls straight through to
+# the goal_type/heuristic fallback below rather than guessing.
+#
+# Exhaustiveness over every ScenarioType member is enforced by
+# tests/remediation/test_synthesizer.py so a newly added ScenarioType that's
+# never assigned a bucket fails CI instead of silently falling back.
+_SCENARIO_TYPE_DTYPE: dict[str, str] = {
+    # -- blocked_topics_missing: content/topic-boundary & jailbreak techniques
+    "SYSTEM_PROMPT_EXTRACTION": "blocked_topics_missing",
+    "GUARDRAIL_BYPASS": "blocked_topics_missing",
+    "INDIRECT_INJECTION": "blocked_topics_missing",
+    "MULTI_TURN_REDIRECTION": "blocked_topics_missing",
+    "CONTEXT_FLOODING": "blocked_topics_missing",
+    "STRUCTURAL_INJECTION": "blocked_topics_missing",
+    "MANY_SHOT_JAILBREAK": "blocked_topics_missing",
+    "CRESCENDO": "blocked_topics_missing",
+    "SKELETON_KEY": "blocked_topics_missing",
+    "PAYLOAD_SPLITTING": "blocked_topics_missing",
+    "ENCODING_EVASION": "blocked_topics_missing",
+    "MULTI_LANGUAGE_BYPASS": "blocked_topics_missing",
+    "HOMOGLYPH_LEETSPEAK": "blocked_topics_missing",
+    "PREMISE_INJECTION": "blocked_topics_missing",
+    "FICTIONAL_FRAMING_BYPASS": "blocked_topics_missing",
+    "FALSE_POLICY_PREMISE": "blocked_topics_missing",
+    "OUT_OF_DOMAIN_ADVICE": "blocked_topics_missing",
+    "AUTHORITY_BIAS_PHISHING": "blocked_topics_missing",
+    "MULTIMODAL_INJECTION": "blocked_topics_missing",
+    # -- hitl_gate_missing: approval / authorization-claim integrity
+    "HITL_BYPASS": "hitl_gate_missing",
+    "APPROVAL_SPOOF": "hitl_gate_missing",
+    "UPSTREAM_APPROVAL_FABRICATION": "hitl_gate_missing",
+    "APPROVAL_SUMMARY_MISMATCH": "hitl_gate_missing",
+    "CONSENT_LAUNDERING": "hitl_gate_missing",
+    "PARTIAL_APPROVAL_OVERREACH": "hitl_gate_missing",
+    "FAUX_REASONING_INJECTION": "hitl_gate_missing",
+    "POLICY_PATCHING": "hitl_gate_missing",
+    "APPROVAL_STATE_FORGERY": "hitl_gate_missing",
+    "SESSION_METADATA_FORGERY": "hitl_gate_missing",
+    # -- privilege_escalation: authorization / privilege-scope failures
+    "PRIVILEGE_CHAIN": "privilege_escalation",
+    "AUTH_BYPASS": "privilege_escalation",
+    "BOLA_READ": "privilege_escalation",
+    "BOLA_WRITE": "privilege_escalation",
+    "BFLA": "privilege_escalation",
+    "RBAC_OVERRIDE": "privilege_escalation",
+    "HANDOFF_PRIVILEGE_ESCALATION": "privilege_escalation",
+    "OAUTH_SCOPE_ESCALATION": "privilege_escalation",
+    "TOKEN_REPLAY": "privilege_escalation",
+    "SCHEMA_IDENTITY_OVERRIDE": "privilege_escalation",
+    # -- data_leak: data/PII exfiltration, including covert channels
+    "DIRECT_PII_EXTRACTION": "data_leak",
+    "CROSS_TENANT_EXFILTRATION": "data_leak",
+    "COVERT_ENCODING": "data_leak",
+    "DATASTORE_PROBE": "data_leak",
+    "BULK_DATA_EXPORT": "data_leak",
+    "ACCOUNT_ID_PROBE": "data_leak",
+    "PRIVATE_DOC_EXTRACTION": "data_leak",
+    "RAG_CITATION_OVERREACH": "data_leak",
+    "AGGREGATED_PII": "data_leak",
+    "SENSITIVE_HISTORY_DISCLOSURE": "data_leak",
+    "CROSS_SESSION_LEAK": "data_leak",
+    "MARKDOWN_IMAGE_EXFIL": "data_leak",
+    "MARKDOWN_LINK_EXFIL": "data_leak",
+    "URL_ENCODING_EXFIL": "data_leak",
+    "STRUCTURED_FIELD_SMUGGLING": "data_leak",
+    "METADATA_SMUGGLING": "data_leak",
+    "INVISIBLE_UNICODE": "data_leak",
+    "TELEMETRY_PRETEXT_EXFIL": "data_leak",
+    "MCP_CROSS_SERVER_EXFIL": "data_leak",
+    "RAG_ACL_BYPASS": "data_leak",
+    "RAG_CHUNK_SMUGGLING": "data_leak",
+    "RAG_NAMESPACE_BLEED": "data_leak",
+    "RAG_NEAREST_NEIGHBOR_ENUM": "data_leak",
+    "STREAMING_EXFIL": "data_leak",
+    "DIRECT_DATASTORE_ACCESS": "data_leak",
+    # -- restricted_action_reachable: destructive / restricted tool actions
+    "RESTRICTED_ACTION": "restricted_action_reachable",
+    "MCP_WEB_FETCH": "restricted_action_reachable",
+    "MCP_EMAIL": "restricted_action_reachable",
+    "MCP_GITHUB": "restricted_action_reachable",
+    "MCP_RAG": "restricted_action_reachable",
+    "MCP_TOOL_INJECTION": "restricted_action_reachable",
+    "MCP_SHADOW_TOOL": "restricted_action_reachable",
+    "UNAUTHORIZED_MESSAGE_SEND": "restricted_action_reachable",
+    "DESTRUCTIVE_RECORD_MUTATION": "restricted_action_reachable",
+    "UNSAFE_NAVIGATION_ACTION": "restricted_action_reachable",
+    "UNSAFE_DEVICE_COMMAND": "restricted_action_reachable",
+    "UNAUTHORIZED_TRANSACTION": "restricted_action_reachable",
+    "MASS_NOTIFICATION": "restricted_action_reachable",
+    "DISABLE_SAFETY_CONTROL": "restricted_action_reachable",
+    "PERSISTENT_TASK_CREATION": "restricted_action_reachable",
+    "TOOL_CHAIN_EXPLOIT": "restricted_action_reachable",
+    "FRAUD_WORKFLOW": "restricted_action_reachable",
+    "HIDDEN_ACTION_PAYLOAD": "restricted_action_reachable",
+    "EXCESSIVE_AGENCY": "restricted_action_reachable",
+    # -- risky_tool: injection into a tool/backend call
+    "SQL_INJECTION": "risky_tool",
+    "SSRF": "risky_tool",
+    "MASS_ASSIGNMENT": "risky_tool",
+    "IDOR": "risky_tool",
+    "DATASTORE_SQL_INJECTION": "risky_tool",
+    "SHELL_INJECTION": "risky_tool",
+    "SANDBOX_ESCAPE": "risky_tool",
+    # -- policy_violation_generic: safe default — no confident domain-specific
+    # fit yet (mostly RAG-pipeline/architectural and reconnaissance/oracle
+    # techniques); _patch_generic_violation embeds the finding's own
+    # description rather than a mismatched specific claim.
+    "RAG_POISONING": "policy_violation_generic",
+    "REFUSAL_ORACLE": "policy_violation_generic",
+    "FALSE_VERIFICATION": "policy_violation_generic",
+    "DEBUG_ADMIN_EXPOSURE": "policy_violation_generic",
+    "TOOL_DISCOVERY_LEAK": "policy_violation_generic",
+    "UNEXPECTED_CODE_GENERATION": "policy_violation_generic",
+    "FALSE_ACTION_CLAIM": "policy_violation_generic",
+    "RESOURCE_EXHAUSTION": "policy_violation_generic",
+    "HALLUCINATED_AUTHORITY": "policy_violation_generic",
+    "RAG_DOCUMENT_POISONING": "policy_violation_generic",
+    "RAG_EMBEDDING_HIJACK": "policy_violation_generic",
+    "CODE_GEN_ESCALATION": "policy_violation_generic",
+    "RAG_STALE_RETRIEVAL": "policy_violation_generic",
+    "RAG_CITATION_LAUNDERING": "policy_violation_generic",
+    "RESPONSE_SCHEMA_PROBE": "policy_violation_generic",
+    "SCHEMA_TYPE_CONFUSION": "policy_violation_generic",
+    "BOUNDARY_SELF_PROBE": "policy_violation_generic",
+    # -- agentic_trust_boundary: trust boundaries BETWEEN agents/sub-agents
+    "CONFUSED_DEPUTY": "agentic_trust_boundary",
+    "MULTI_AGENT_TRUST": "agentic_trust_boundary",
+    "GOAL_HIJACKING": "agentic_trust_boundary",
+    "SUBAGENT_OUTPUT_INJECTION": "agentic_trust_boundary",
+    "AGENT_IMPERSONATION": "agentic_trust_boundary",
+    "PLANNER_EXECUTOR_MISMATCH": "agentic_trust_boundary",
+    "INTENT_ROUTING_CONFUSION": "agentic_trust_boundary",
+    "CROSS_AGENT_INJECTION": "agentic_trust_boundary",
+    "OWNERLESS_AGENT_ACTION": "agentic_trust_boundary",
+    "CROSS_AGENT_CRED_BLEED": "agentic_trust_boundary",
+    "DELEGATED_IDENTITY_CONFUSION": "agentic_trust_boundary",
+    # -- memory_session_integrity: persistent memory / session state integrity
+    "MEMORY_POISONING": "memory_session_integrity",
+    "PROFILE_FIELD_POISONING": "memory_session_integrity",
+    "CROSS_SESSION_BACKDOOR": "memory_session_integrity",
+    "FALSE_IDENTITY_MEMORY": "memory_session_integrity",
+    "SUMMARY_POISONING": "memory_session_integrity",
+    "MEMORY_AUTH_DRIFT": "memory_session_integrity",
+    "CREDENTIAL_PERSISTENCE": "memory_session_integrity",
+    "SESSION_FIXATION": "memory_session_integrity",
+    # -- output_handling: model output used unsafely downstream (code/SQL/URL/config)
+    "OUTPUT_XSS_INJECTION": "output_handling",
+    "OUTPUT_TOOL_ARG_INJECTION": "output_handling",
+    "OUTPUT_SQL_TENANT_BYPASS": "output_handling",
+    "OUTPUT_SSRF": "output_handling",
+    "OUTPUT_CONFIG_INJECTION": "output_handling",
+    "OUTPUT_FILE_CONFUSION": "output_handling",
+    "PARAM_CONFUSION_INJECTION": "output_handling",
+    "STRUCTURED_OUTPUT_COERCION": "output_handling",
+    # -- supply_chain_secrets: CI/CD, secrets, and supply-chain probing
+    "CREDENTIAL_OVERREACH": "supply_chain_secrets",
+    "REPO_PROMPT_INJECTION": "supply_chain_secrets",
+    "SECRET_FILE_READ": "supply_chain_secrets",
+    "DELAYED_CI_EXFIL": "supply_chain_secrets",
+    "VERIFIER_SABOTAGE": "supply_chain_secrets",
+    "ENV_VAR_PROBE": "supply_chain_secrets",
+    "CI_SECRET_PROBE": "supply_chain_secrets",
+    "CLOUD_METADATA_SSRF": "supply_chain_secrets",
+    "DEPENDENCY_CVE_PROBE": "supply_chain_secrets",
+    "QUALITY_GATE_INFERENCE": "supply_chain_secrets",
+    "ARTIFACT_INTEGRITY_PROBE": "supply_chain_secrets",
+    "CROSS_ENV_CREDENTIAL_REUSE": "supply_chain_secrets",
 }
 
 # dtypes whose primary SYSTEM_PROMPT_PATCH artefact gets its patch_text
@@ -273,10 +449,25 @@ _PROMPT_TEXT_UPGRADE_DTYPES = {
 
 def _classify_finding(finding: dict) -> str:
     """Return a string category for the finding."""
-    # Redteam shortcut: if the finding carries a ``goal_type`` (set by the
+    # Redteam shortcut #1 (checked first): if the finding carries a
+    # ``scenario_type`` (set by the RedteamOrchestrator from
+    # AttackScenario.scenario_type), trust it — it identifies the specific
+    # attack technique rather than the coarse goal family, so it produces
+    # more accurate routing than ``goal_type`` alone (e.g. PROMPT_DRIVEN_THREAT
+    # spans both system-prompt extraction and approval forgery, which need
+    # different remediation).
+    scenario_type = str(finding.get("scenario_type", "") or "").strip().upper()
+    if scenario_type:
+        mapped = _SCENARIO_TYPE_DTYPE.get(scenario_type)
+        if mapped:
+            return mapped
+
+    # Redteam shortcut #2: if the finding carries a ``goal_type`` (set by the
     # RedteamOrchestrator when it builds Finding objects), trust it.  This
     # keeps redteam findings from being misclassified by the behavior-module
     # heuristic classifier below, which was tuned for ``BA-*`` finding IDs.
+    # Also the fallback for redteam findings with no ``scenario_type`` (e.g.
+    # data predating this field).
     goal_type = str(finding.get("goal_type", "") or "").strip().lower()
     if goal_type:
         mapped = _GOAL_TYPE_DTYPE.get(goal_type)
@@ -320,6 +511,38 @@ def _classify_finding(finding: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _artefact_dedup_key(art: RemediationArtefact) -> str:
+    """Cross-finding dedup identity for one artefact.
+
+    Two artefacts collapse to the same key only if they'd tell the reader
+    the same thing — i.e. their actual instructive content (and rationale)
+    matches — not merely because they share a component-derived display
+    label. ``patch_section``/``guardrail_name``/``change_description`` are
+    often a pure function of ``component`` alone (e.g.
+    ``f"Out of Scope — {component}"``), so keying on them collapses
+    genuinely distinct findings on the same component before they ever
+    reach :func:`_merge_artefacts`, silently dropping one finding's
+    remediation entirely instead of merging it.
+
+    ``rationale`` is included alongside the instruction fields because a
+    generic fallback template can produce byte-identical ``patch_text``/
+    guardrail spec for two different findings while ``rationale`` (usually
+    sourced from the finding's own description) still differs — content
+    alone isn't sufficient to prove two artefacts are really duplicates.
+    """
+    if art.artefact_type == RemediationArtefactType.SYSTEM_PROMPT_PATCH:
+        content = art.patch_text or art.patch_section or ""
+    elif art.artefact_type == RemediationArtefactType.ARCHITECTURAL_CHANGE:
+        content = art.change_detail or art.change_description or ""
+    else:  # INPUT_GUARDRAIL / OUTPUT_GUARDRAIL
+        content = (
+            f"{art.guardrail_type}|{art.guardrail_trigger}|{art.guardrail_action}"
+            if (art.guardrail_type or art.guardrail_trigger or art.guardrail_action)
+            else (art.guardrail_name or "")
+        )
+    return f"{art.component}:{art.artefact_type.value}:{content}:{art.rationale}"
+
+
 def _merge_artefacts(artefacts: list[RemediationArtefact]) -> list[RemediationArtefact]:
     """Merge artefacts that target the same (component, artefact_type).
 
@@ -339,10 +562,13 @@ def _merge_artefacts(artefacts: list[RemediationArtefact]) -> list[RemediationAr
         # Merge patch texts
         finding_ids: list[str] = []
         patch_parts: list[str] = []
+        rationale_parts: list[str] = []
         for a in group:
             finding_ids.extend(a.finding_ids)
             if a.patch_text:
                 patch_parts.append(a.patch_text)
+            if a.rationale:
+                rationale_parts.append(a.rationale)
         base = group[0]
         merged.append(RemediationArtefact(
             finding_ids=finding_ids,
@@ -353,7 +579,12 @@ def _merge_artefacts(artefacts: list[RemediationArtefact]) -> list[RemediationAr
             patch_location=base.patch_location,
             patch_section="Security Rules",
             patch_text="\n\n".join(patch_parts),
-            rationale=f"Merged {len(group)} system prompt patches for {comp}",
+            # Preserve each artefact's own rationale (deduped, order kept)
+            # instead of discarding them behind a content-free "Merged N..."
+            # placeholder — the specific reasons still need to reach the
+            # report even when several findings land on the same patch.
+            rationale="\n".join(dict.fromkeys(rationale_parts))
+            or f"Merged {len(group)} system prompt patches for {comp}",
         ))
 
     # Sort by priority
@@ -422,7 +653,7 @@ class RemediationSynthesizer:
                 _log.debug("synthesize_findings_async: one finding failed: %s", batch)
                 continue
             for art in batch:
-                key = f"{art.component}:{art.artefact_type.value}:{(art.patch_section or art.guardrail_name or art.change_description or '')[:60]}"
+                key = _artefact_dedup_key(art)
                 if key not in seen_keys:
                     seen_keys.add(key)
                     artefacts.append(art)
@@ -480,6 +711,14 @@ class RemediationSynthesizer:
             return self._add_input_guardrail_risky(component, node, finding, finding_id, priority)
         if dtype == "policy_violation_generic":
             return self._patch_generic_violation(component, node, finding, finding_id, priority)
+        if dtype == "agentic_trust_boundary":
+            return self._remediate_agentic_trust_boundary(component, node, finding, finding_id, priority)
+        if dtype == "memory_session_integrity":
+            return self._remediate_memory_session_integrity(component, node, finding, finding_id, priority)
+        if dtype == "output_handling":
+            return self._add_output_handling_guardrail(component, node, finding, finding_id, priority)
+        if dtype == "supply_chain_secrets":
+            return self._add_input_guardrail_supply_chain(component, node, finding, finding_id, priority)
         # generic — produce a minimal system_prompt_patch
         return self._patch_generic_violation(component, node, finding, finding_id, priority)
 
@@ -493,7 +732,17 @@ class RemediationSynthesizer:
         """Best-effort: replace patch_text/rationale on *artefacts* in place
         with LLM-authored surgical text. Leaves template text on any failure
         or when the LLM is unavailable/returns a canned response."""
-        evidence = str(finding.get("description") or finding.get("title") or "")[:300]
+        # Prefer the specific, technique-grounded evidence (the exact
+        # substring of the agent's response that proves the breach, or the
+        # evaluator's one-sentence reasoning) over the generic telemetry
+        # text in description/title ("Attack scenario 'X' succeeded...").
+        evidence = str(
+            finding.get("evidence_quote")
+            or finding.get("reasoning")
+            or finding.get("description")
+            or finding.get("title")
+            or ""
+        )[:300]
         for artefact in artefacts:
             if (
                 artefact.artefact_type == RemediationArtefactType.SYSTEM_PROMPT_PATCH
@@ -546,7 +795,7 @@ class RemediationSynthesizer:
         for finding in findings:
             produced = self._synthesize_one(finding)
             for art in produced:
-                key = f"{art.component}:{art.artefact_type.value}:{(art.patch_section or art.guardrail_name or art.change_description or '')[:60]}"
+                key = _artefact_dedup_key(art)
                 if key not in seen_keys:
                     seen_keys.add(key)
                     artefacts.append(art)
@@ -1347,6 +1596,147 @@ class RemediationSynthesizer:
             patch_text=patch_text,
             rationale=desc or title,
         )]
+
+    # ------------------------------------------------------------------
+    # 8. Agentic trust boundary — confused deputy, sub-agent/handoff trust,
+    #    cross-agent injection, identity/credential confusion
+    # ------------------------------------------------------------------
+
+    def _remediate_agentic_trust_boundary(
+        self,
+        component: str,
+        node: "Node | None",
+        finding: dict,
+        finding_id: str,
+        priority: str,
+    ) -> list[RemediationArtefact]:
+        desc = finding.get("description", "")
+        title = finding.get("title", "")
+        return [
+            RemediationArtefact(
+                finding_ids=[finding_id],
+                component=component,
+                component_type=_node_type(node) if node else "AGENT",
+                artefact_type=RemediationArtefactType.ARCHITECTURAL_CHANGE,
+                priority=priority,
+                change_description=f"Verify agent/sub-agent identity and re-validate trust boundary for {component}",
+                change_detail=(
+                    "Do not treat content received from another agent, sub-agent, or "
+                    "planner/executor handoff as trusted instructions by default:\n"
+                    "- Verify the sender's identity (signed/authenticated agent ID) before "
+                    "acting on delegated instructions or a claimed peer approval.\n"
+                    "- Re-validate that an executor's action actually matches the plan/intent "
+                    "handed to it, rather than trusting the executor's own report of what it did.\n"
+                    "- Treat sub-agent OUTPUT as untrusted data, not as directives, unless it "
+                    "passes the same input validation applied to direct user input."
+                ),
+                rationale=desc or title or "Cross-agent trust boundary was not enforced.",
+            ),
+        ]
+
+    # ------------------------------------------------------------------
+    # 9. Memory / session integrity — memory poisoning, cross-session
+    #    backdoors, false identity/session metadata carried across turns
+    # ------------------------------------------------------------------
+
+    def _remediate_memory_session_integrity(
+        self,
+        component: str,
+        node: "Node | None",
+        finding: dict,
+        finding_id: str,
+        priority: str,
+    ) -> list[RemediationArtefact]:
+        desc = finding.get("description", "")
+        title = finding.get("title", "")
+        return [
+            RemediationArtefact(
+                finding_ids=[finding_id],
+                component=component,
+                component_type=_node_type(node) if node else "AGENT",
+                artefact_type=RemediationArtefactType.ARCHITECTURAL_CHANGE,
+                priority=priority,
+                change_description=f"Validate persisted memory/session state before reuse for {component}",
+                change_detail=(
+                    "Persisted memory, profile fields, and session metadata must be treated as "
+                    "untrusted once written by a prior turn or session:\n"
+                    "- Re-validate identity/role/authorization claims stored in memory or "
+                    "session state at the point of use, not just at write time.\n"
+                    "- Scope memory writes to the account/session that produced them; reject "
+                    "or flag memory content that contradicts the authenticated user's own record.\n"
+                    "- Do not let a summarization or compaction step silently introduce new "
+                    "claims (e.g. approval status, identity) that were not in the original "
+                    "transcript."
+                ),
+                rationale=desc or title or "Persisted memory/session state was trusted without re-validation.",
+            ),
+        ]
+
+    # ------------------------------------------------------------------
+    # 10. Output handling — model output consumed downstream as code, SQL,
+    #     URLs, or config without validation
+    # ------------------------------------------------------------------
+
+    def _add_output_handling_guardrail(
+        self,
+        component: str,
+        node: "Node | None",
+        finding: dict,
+        finding_id: str,
+        priority: str,
+    ) -> list[RemediationArtefact]:
+        desc = finding.get("description", "")
+        return [
+            RemediationArtefact(
+                finding_ids=[finding_id],
+                component=component,
+                component_type=_node_type(node) if node else "TOOL",
+                artefact_type=RemediationArtefactType.OUTPUT_GUARDRAIL,
+                priority=priority,
+                guardrail_name=f"output_validator_{component.lower().replace(' ', '_')[:20]}",
+                guardrail_type="output_redactor",
+                guardrail_trigger=(
+                    r"<script|javascript:|on\w+\s*=|['\"]\s*;\s*--|\bunion\s+select\b|"
+                    r"file://|\.\./"
+                ),
+                guardrail_action="BLOCK",
+                guardrail_message="Response withheld: output failed structural validation before downstream use.",
+                rationale=desc or "Model output was consumed downstream (code/SQL/URL/config) without validation.",
+            ),
+        ]
+
+    # ------------------------------------------------------------------
+    # 11. Supply chain / secrets hygiene — CI, env var, cloud metadata,
+    #     dependency, and artifact-integrity probing
+    # ------------------------------------------------------------------
+
+    def _add_input_guardrail_supply_chain(
+        self,
+        component: str,
+        node: "Node | None",
+        finding: dict,
+        finding_id: str,
+        priority: str,
+    ) -> list[RemediationArtefact]:
+        desc = finding.get("description", "")
+        return [
+            RemediationArtefact(
+                finding_ids=[finding_id],
+                component=component,
+                component_type=_node_type(node) if node else "TOOL",
+                artefact_type=RemediationArtefactType.INPUT_GUARDRAIL,
+                priority=priority,
+                guardrail_name=f"secrets_probe_guard_{component.lower().replace(' ', '_')[:20]}",
+                guardrail_type="regex",
+                guardrail_trigger=(
+                    r"\b(env(ironment)?\s*var|\.env\b|api[_-]?key|secret|token|"
+                    r"169\.254\.169\.254|metadata\.google|ci[_-]?secret|credential)\b"
+                ),
+                guardrail_action="BLOCK",
+                guardrail_message="I can't retrieve environment variables, credentials, or CI/deployment secrets.",
+                rationale=desc or "Request probed for environment/CI secrets or a cloud metadata endpoint.",
+            ),
+        ]
 
     # ------------------------------------------------------------------
     # LLM call helpers

--- a/tests/redteam/test_public_api.py
+++ b/tests/redteam/test_public_api.py
@@ -6,7 +6,10 @@ Focuses on: (1) JSON round-tripping of the new request/result models,
 request's fields plus the separately-passed collaborators and reads back the
 orchestrator's instance attributes into RedteamRunResult, proving no
 functionality is lost relative to the CLI's `_run_orchestrator`, and (3) the
-duplicated post-run scenario_filter block matches the CLI's copy.
+post-run scenario_filter re-check (run_redteam() is the single
+implementation — the CLI calls it directly, it isn't duplicated) matches
+findings on goal_type, scenario_type, and title, the same as the
+orchestrator's own pre-run filter.
 """
 from __future__ import annotations
 
@@ -26,13 +29,14 @@ from nuguard.redteam.public_api import RedteamRunRequest, RedteamRunResult, run_
 from nuguard.redteam.target.canary import CanaryConfig
 
 
-def _finding(goal_type: str = "prompt_driven_threat") -> Finding:
+def _finding(goal_type: str = "prompt_driven_threat", scenario_type: str | None = None) -> Finding:
     return Finding(
         finding_id="f1",
         title="t",
         severity=Severity.HIGH,
         description="d",
         goal_type=goal_type,
+        scenario_type=scenario_type,
     )
 
 
@@ -208,9 +212,7 @@ async def test_run_redteam_passes_config_scalar_and_embedded_model_fields():
 
 
 @pytest.mark.asyncio
-async def test_run_redteam_applies_scenario_filter_post_run_like_cli():
-    """Regression test tying the duplicated scenario_filter block to the CLI's
-    copy (nuguard/cli/commands/redteam.py:_run_orchestrator)."""
+async def test_run_redteam_applies_scenario_filter_post_run():
     findings = [_finding("prompt_driven_threat"), _finding("data_exfiltration")]
     mock_instance = _make_mock_orchestrator(findings)
 
@@ -221,6 +223,28 @@ async def test_run_redteam_applies_scenario_filter_post_run_like_cli():
 
     assert len(result.findings) == 1
     assert result.findings[0].goal_type == "prompt_driven_threat"
+
+
+@pytest.mark.asyncio
+async def test_run_redteam_scenario_type_level_filter_does_not_drop_finding():
+    """Regression test for the bug where a scenario-type-level filter (e.g.
+    "APPROVAL_STATE_FORGERY") correctly selected which scenario ran, via the
+    orchestrator's own pre-run filter, but then had its resulting finding
+    silently dropped by this post-run re-check — because the re-check only
+    ever compared the filter token against goal_type, never scenario_type."""
+    findings = [
+        _finding("prompt_driven_threat", scenario_type="APPROVAL_STATE_FORGERY"),
+        _finding("data_exfiltration", scenario_type="DIRECT_PII_EXTRACTION"),
+    ]
+    mock_instance = _make_mock_orchestrator(findings)
+
+    with patch("nuguard.redteam.public_api.RedteamOrchestrator") as mock_cls:
+        mock_cls.return_value = mock_instance
+        request = RedteamRunRequest(target_url="http://target", scenario_filter=["APPROVAL_STATE_FORGERY"])
+        result = await run_redteam(request, sbom=MagicMock())
+
+    assert len(result.findings) == 1
+    assert result.findings[0].scenario_type == "APPROVAL_STATE_FORGERY"
 
 
 @pytest.mark.asyncio

--- a/tests/redteam/test_scenario_filter.py
+++ b/tests/redteam/test_scenario_filter.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import pytest
 
 from nuguard.models.exploit_chain import GoalType, ScenarioType
+from nuguard.models.finding import Finding
 from nuguard.redteam.executor.orchestrator import (
     _normalize_scenario_token,
     _scenario_matches_filter,
+    finding_matches_scenario_filter,
     validate_scenario_filter,
 )
 from nuguard.redteam.scenarios.scenario_types import AttackScenario
@@ -84,3 +86,72 @@ class TestValidateScenarioFilter:
     def test_scenario_type_token_is_recognized(self):
         # ScenarioType values (not just GoalType) should also be accepted.
         assert validate_scenario_filter(["guardrail-bypass"]) == []
+
+
+def _make_finding(
+    *,
+    goal_type: str | None,
+    scenario_type: str | None = None,
+    title: str = "Unrelated Test Finding Title",
+) -> Finding:
+    return Finding(
+        finding_id="f1",
+        title=title,
+        severity="high",
+        description="test",
+        goal_type=goal_type,
+        scenario_type=scenario_type,
+    )
+
+
+class TestFindingMatchesScenarioFilter:
+    """finding_matches_scenario_filter() is run_redteam()'s post-run
+    re-check against the findings the orchestrator actually returned. It
+    must accept everything the orchestrator's own pre-run filter
+    (_scenario_matches_filter) would have let through, or a scenario that
+    was correctly selected to run ends up having its finding silently
+    dropped from the final output — the exact bug this covers."""
+
+    def test_regression_scenario_type_level_filter_no_longer_drops_finding(self) -> None:
+        # The exact reported bug: goal_type is PROMPT_DRIVEN_THREAT (not a
+        # substring match for the filter token below), but scenario_type is
+        # the specific technique the user actually filtered for.
+        finding = _make_finding(goal_type="PROMPT_DRIVEN_THREAT", scenario_type="APPROVAL_STATE_FORGERY")
+        assert finding_matches_scenario_filter(finding, {"approval_state_forgery"}) is True
+
+    def test_goal_type_level_filter_still_works(self) -> None:
+        finding = _make_finding(goal_type="PROMPT_DRIVEN_THREAT", scenario_type="APPROVAL_STATE_FORGERY")
+        assert finding_matches_scenario_filter(finding, {"prompt_driven_threat"}) is True
+
+    def test_title_level_filter_still_works(self) -> None:
+        # Title matching only normalizes hyphens/case, not spaces (mirroring
+        # _scenario_matches_filter exactly) — so a matching token must use
+        # spaces the same way the title does, not underscores.
+        finding = _make_finding(
+            goal_type="PROMPT_DRIVEN_THREAT",
+            scenario_type="SYSTEM_PROMPT_EXTRACTION",
+            title="Guided System Prompt Leak - Support Agent",
+        )
+        assert finding_matches_scenario_filter(finding, {"system prompt leak"}) is True
+
+    def test_unrelated_scenario_type_filter_does_not_match(self) -> None:
+        finding = _make_finding(goal_type="DATA_EXFILTRATION", scenario_type="DIRECT_PII_EXTRACTION")
+        assert finding_matches_scenario_filter(finding, {"approval_state_forgery"}) is False
+
+    def test_no_filter_matches_everything(self) -> None:
+        finding = _make_finding(goal_type="PROMPT_DRIVEN_THREAT", scenario_type="APPROVAL_STATE_FORGERY")
+        assert finding_matches_scenario_filter(finding, set()) is True
+
+    def test_finding_without_goal_type_always_matches(self) -> None:
+        # Preserves the pre-fix behaviour: a finding that never set goal_type
+        # (e.g. from a non-redteam origin reusing this same filter) must not
+        # be dropped just because it can't be matched against anything.
+        finding = _make_finding(goal_type=None, scenario_type=None)
+        assert finding_matches_scenario_filter(finding, {"approval_state_forgery"}) is True
+
+    def test_finding_without_scenario_type_falls_back_to_goal_type_and_title(self) -> None:
+        # Pre-scenario_type data (or behavior/analysis findings, which never
+        # set it) must still work via goal_type/title alone, unchanged.
+        finding = _make_finding(goal_type="DATA_EXFILTRATION", scenario_type=None)
+        assert finding_matches_scenario_filter(finding, {"data_exfiltration"}) is True
+        assert finding_matches_scenario_filter(finding, {"approval_state_forgery"}) is False

--- a/tests/remediation/test_synthesizer.py
+++ b/tests/remediation/test_synthesizer.py
@@ -1,0 +1,382 @@
+"""Tests for RemediationSynthesizer's finding classification.
+
+Covers the scenario_type-first classification fix: redteam findings now
+carry AttackScenario.scenario_type, which identifies the specific attack
+technique rather than the coarse goal_type family, so remediation routing
+no longer collapses e.g. "Approval State Forgery" and "System Prompt
+Extraction" (both PROMPT_DRIVEN_THREAT) into the same template.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nuguard.models.exploit_chain import ScenarioType
+from nuguard.remediation.models import RemediationArtefactType
+from nuguard.remediation.synthesizer import (
+    _GOAL_TYPE_DTYPE,
+    _SCENARIO_TYPE_DTYPE,
+    RemediationSynthesizer,
+    _classify_finding,
+    _merge_artefacts,
+)
+
+
+class TestScenarioTypeExhaustiveness:
+    def test_every_scenario_type_has_a_bucket(self) -> None:
+        missing = [s.value for s in ScenarioType if s.value not in _SCENARIO_TYPE_DTYPE]
+        assert not missing, f"ScenarioType values with no remediation bucket: {missing}"
+
+    def test_no_unknown_scenario_type_keys(self) -> None:
+        # Catches typos/stale entries: every dict key must be a real enum value.
+        valid = {s.value for s in ScenarioType}
+        stale = [k for k in _SCENARIO_TYPE_DTYPE if k not in valid]
+        assert not stale, f"_SCENARIO_TYPE_DTYPE keys with no matching ScenarioType: {stale}"
+
+
+class TestScenarioTypeTakesPriorityOverGoalType:
+    def test_approval_state_forgery_routes_to_hitl_not_blocked_topics(self) -> None:
+        # The motivating bug: this finding's goal_type is PROMPT_DRIVEN_THREAT
+        # (which maps to blocked_topics_missing), but its scenario_type is the
+        # much more specific APPROVAL_STATE_FORGERY, which must win.
+        finding = {
+            "finding_id": "f1",
+            "title": "Approval State Forgery — ManagerBot",
+            "description": "Attacker injected a fake HUMAN APPROVAL RECEIVED marker.",
+            "goal_type": "prompt_driven_threat",
+            "scenario_type": "APPROVAL_STATE_FORGERY",
+        }
+        assert _classify_finding(finding) == "hitl_gate_missing"
+
+    def test_unmapped_scenario_type_falls_back_to_goal_type(self) -> None:
+        finding = {
+            "finding_id": "f1",
+            "title": "Some future technique",
+            "description": "n/a",
+            "goal_type": "data_exfiltration",
+            "scenario_type": "SOME_FUTURE_TYPE_NOT_YET_MAPPED",
+        }
+        assert _classify_finding(finding) == "data_leak"
+
+
+class TestBackwardCompatNoScenarioType:
+    """Findings without scenario_type (pre-change data, or behavior/analysis
+    findings which never populate it) must classify identically to before
+    this change — goal_type -> heuristic, unaffected by scenario_type."""
+
+    @pytest.mark.parametrize("goal_type,expected_dtype", list(_GOAL_TYPE_DTYPE.items()))
+    def test_goal_type_only_matches_existing_mapping(self, goal_type, expected_dtype) -> None:
+        finding = {
+            "finding_id": "f1",
+            "title": "x",
+            "description": "x",
+            "goal_type": goal_type,
+        }
+        assert _classify_finding(finding) == expected_dtype
+
+    def test_missing_scenario_type_key_entirely_does_not_error(self) -> None:
+        finding = {"finding_id": "f1", "title": "x", "description": "x", "goal_type": "risky_tool_typo"}
+        # Unknown goal_type and no scenario_type -> falls through to heuristics.
+        assert _classify_finding(finding) == "generic"
+
+
+class TestNewBucketHandlers:
+    @pytest.mark.asyncio
+    async def test_agentic_trust_boundary_produces_architectural_change(self) -> None:
+        finding = {
+            "finding_id": "f1",
+            "title": "Cross-Agent Injection",
+            "description": "Sub-agent output was treated as a trusted instruction.",
+            "affected_component": "PlannerAgent",
+            "severity": "high",
+            "scenario_type": "CROSS_AGENT_INJECTION",
+        }
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async([finding])
+        assert artefacts
+        assert artefacts[0].artefact_type == RemediationArtefactType.ARCHITECTURAL_CHANGE
+
+    @pytest.mark.asyncio
+    async def test_memory_session_integrity_produces_architectural_change(self) -> None:
+        finding = {
+            "finding_id": "f1",
+            "title": "Memory Poisoning",
+            "description": "Attacker-controlled content persisted into agent memory.",
+            "affected_component": "SupportAgent",
+            "severity": "high",
+            "scenario_type": "MEMORY_POISONING",
+        }
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async([finding])
+        assert artefacts
+        assert artefacts[0].artefact_type == RemediationArtefactType.ARCHITECTURAL_CHANGE
+
+    @pytest.mark.asyncio
+    async def test_output_handling_produces_output_guardrail(self) -> None:
+        finding = {
+            "finding_id": "f1",
+            "title": "Output XSS Injection",
+            "description": "Model output rendered unsanitized in the client UI.",
+            "affected_component": "SupportAgent",
+            "severity": "high",
+            "scenario_type": "OUTPUT_XSS_INJECTION",
+        }
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async([finding])
+        assert artefacts
+        assert artefacts[0].artefact_type == RemediationArtefactType.OUTPUT_GUARDRAIL
+
+    @pytest.mark.asyncio
+    async def test_supply_chain_secrets_produces_input_guardrail(self) -> None:
+        finding = {
+            "finding_id": "f1",
+            "title": "Env Var Probe",
+            "description": "Agent disclosed the value of an environment variable.",
+            "affected_component": "CIAgent",
+            "severity": "medium",
+            "scenario_type": "ENV_VAR_PROBE",
+        }
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async([finding])
+        assert artefacts
+        assert artefacts[0].artefact_type == RemediationArtefactType.INPUT_GUARDRAIL
+
+
+class TestMergeArtefactsPreservesRationale:
+    def test_two_artefacts_same_component_and_type_keep_both_rationales(self) -> None:
+        # Exercises _merge_artefacts() directly, isolated from the
+        # pre-merge content-based dedup in synthesize_findings_async
+        # (covered separately in TestContentBasedDedup below).
+        from nuguard.remediation.models import RemediationArtefact
+
+        a1 = RemediationArtefact(
+            finding_ids=["f1"],
+            component="SupportAgent",
+            component_type="AGENT",
+            artefact_type=RemediationArtefactType.SYSTEM_PROMPT_PATCH,
+            priority="high",
+            patch_text="text1",
+            rationale="Agent disclosed its full system prompt verbatim.",
+        )
+        a2 = RemediationArtefact(
+            finding_ids=["f2"],
+            component="SupportAgent",
+            component_type="AGENT",
+            artefact_type=RemediationArtefactType.SYSTEM_PROMPT_PATCH,
+            priority="high",
+            patch_text="text2",
+            rationale="Multi-turn escalation reached restricted territory.",
+        )
+        merged = _merge_artefacts([a1, a2])
+        assert len(merged) == 1
+        assert "Agent disclosed its full system prompt verbatim." in merged[0].rationale
+        assert "Multi-turn escalation reached restricted territory." in merged[0].rationale
+        assert "Merged 2 system prompt patches" not in merged[0].rationale
+
+
+def test_merge_artefacts_dedupes_identical_rationale() -> None:
+    from nuguard.remediation.models import RemediationArtefact
+
+    a1 = RemediationArtefact(
+        finding_ids=["f1"],
+        component="Agent",
+        component_type="AGENT",
+        artefact_type=RemediationArtefactType.SYSTEM_PROMPT_PATCH,
+        priority="high",
+        patch_text="text1",
+        rationale="same rationale",
+    )
+    a2 = RemediationArtefact(
+        finding_ids=["f2"],
+        component="Agent",
+        component_type="AGENT",
+        artefact_type=RemediationArtefactType.SYSTEM_PROMPT_PATCH,
+        priority="high",
+        patch_text="text2",
+        rationale="same rationale",
+    )
+    merged = _merge_artefacts([a1, a2])
+    assert len(merged) == 1
+    assert merged[0].rationale == "same rationale"
+
+
+class TestContentBasedDedup:
+    """The pre-merge dedup in synthesize_findings_async/synthesize_findings
+    used to key on component:artefact_type:patch_section — for
+    _patch_blocked_topics and _patch_generic_violation, patch_section is a
+    pure function of component alone, so a second distinct finding on the
+    same component produced an identical key and was silently dropped
+    before ever reaching _merge_artefacts. _artefact_dedup_key() fixes this
+    by keying on the artefact's actual instructive content + rationale
+    instead of its display label."""
+
+    @pytest.mark.asyncio
+    async def test_distinct_findings_same_component_both_survive_async(self) -> None:
+        # Two different blocked_topics_missing findings on the same agent:
+        # same patch_section ("Out of Scope — SupportAgent") for both, but
+        # genuinely different rationale. Previously the second was dropped
+        # by the label-keyed dedup before _merge_artefacts ever ran.
+        findings = [
+            {
+                "finding_id": "f1",
+                "title": "System Prompt Extraction",
+                "description": "Agent disclosed its full system prompt verbatim.",
+                "affected_component": "SupportAgent",
+                "severity": "high",
+                "scenario_type": "SYSTEM_PROMPT_EXTRACTION",
+            },
+            {
+                "finding_id": "f2",
+                "title": "Crescendo",
+                "description": "Multi-turn escalation reached restricted territory.",
+                "affected_component": "SupportAgent",
+                "severity": "high",
+                "scenario_type": "CRESCENDO",
+            },
+        ]
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async(findings)
+        patches = [
+            a for a in artefacts
+            if a.component == "SupportAgent" and a.artefact_type == RemediationArtefactType.SYSTEM_PROMPT_PATCH
+        ]
+        assert len(patches) == 1, "expected both findings' artefacts to survive and merge into one"
+        assert "Agent disclosed its full system prompt verbatim." in patches[0].rationale
+        assert "Multi-turn escalation reached restricted territory." in patches[0].rationale
+
+    def test_distinct_findings_same_component_both_survive_sync(self) -> None:
+        # Same scenario via the sync entry point (synthesize_findings), which
+        # had the identical bug duplicated in its own copy of the dedup loop.
+        findings = [
+            {
+                "finding_id": "f1",
+                "title": "System Prompt Extraction",
+                "description": "Agent disclosed its full system prompt verbatim.",
+                "affected_component": "SupportAgent",
+                "severity": "high",
+                "scenario_type": "SYSTEM_PROMPT_EXTRACTION",
+            },
+            {
+                "finding_id": "f2",
+                "title": "Crescendo",
+                "description": "Multi-turn escalation reached restricted territory.",
+                "affected_component": "SupportAgent",
+                "severity": "high",
+                "scenario_type": "CRESCENDO",
+            },
+        ]
+        synth = RemediationSynthesizer()
+        artefacts = synth.synthesize_findings(findings)
+        patches = [
+            a for a in artefacts
+            if a.component == "SupportAgent" and a.artefact_type == RemediationArtefactType.SYSTEM_PROMPT_PATCH
+        ]
+        assert len(patches) == 1
+        assert "Agent disclosed its full system prompt verbatim." in patches[0].rationale
+        assert "Multi-turn escalation reached restricted territory." in patches[0].rationale
+
+    @pytest.mark.asyncio
+    async def test_true_duplicate_content_still_collapses_to_one(self) -> None:
+        # Two findings that happen to produce byte-identical artefact
+        # content AND rationale (e.g. re-processing, or two findings whose
+        # descriptions happen to coincide) should still collapse to one
+        # artefact rather than doubling up redundant text.
+        findings = [
+            {
+                "finding_id": "f1",
+                "title": "Env Var Probe",
+                "description": "Agent disclosed an environment variable value.",
+                "affected_component": "CIAgent",
+                "severity": "medium",
+                "scenario_type": "ENV_VAR_PROBE",
+            },
+            {
+                "finding_id": "f2",
+                "title": "Env Var Probe",
+                "description": "Agent disclosed an environment variable value.",
+                "affected_component": "CIAgent",
+                "severity": "medium",
+                "scenario_type": "ENV_VAR_PROBE",
+            },
+        ]
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async(findings)
+        guardrails = [a for a in artefacts if a.component == "CIAgent"]
+        assert len(guardrails) == 1
+        assert guardrails[0].finding_ids == ["f1"]
+
+
+class TestCrossComponentIsolation:
+    """component is the first field in both the dedup key
+    (_artefact_dedup_key) and the merge grouping key (_merge_artefacts) —
+    these tests make that isolation explicit rather than leaving it implicit
+    in the key/grouping design, since a regression here would silently leak
+    one agent's remediation rationale into an unrelated agent's artefact."""
+
+    def test_merge_artefacts_keeps_different_components_separate(self) -> None:
+        from nuguard.remediation.models import RemediationArtefact
+
+        a1 = RemediationArtefact(
+            finding_ids=["f1"],
+            component="AgentA",
+            component_type="AGENT",
+            artefact_type=RemediationArtefactType.SYSTEM_PROMPT_PATCH,
+            priority="high",
+            patch_text="patch for A",
+            rationale="AgentA-specific rationale",
+        )
+        a2 = RemediationArtefact(
+            finding_ids=["f2"],
+            component="AgentB",
+            component_type="AGENT",
+            artefact_type=RemediationArtefactType.SYSTEM_PROMPT_PATCH,
+            priority="high",
+            patch_text="patch for B",
+            rationale="AgentB-specific rationale",
+        )
+        merged = _merge_artefacts([a1, a2])
+
+        assert len(merged) == 2
+        by_component = {a.component: a for a in merged}
+        assert by_component["AgentA"].rationale == "AgentA-specific rationale"
+        assert by_component["AgentB"].rationale == "AgentB-specific rationale"
+        # No cross-contamination: each component's artefact must not carry
+        # the other component's rationale or patch text.
+        assert "AgentB" not in by_component["AgentA"].rationale
+        assert "patch for B" not in by_component["AgentA"].patch_text
+        assert "AgentA" not in by_component["AgentB"].rationale
+        assert "patch for A" not in by_component["AgentB"].patch_text
+
+    @pytest.mark.asyncio
+    async def test_full_pipeline_keeps_different_components_separate(self) -> None:
+        # Same scenario_type, same dtype (so they'd share a component-derived
+        # display label if component weren't part of the dedup/merge keys),
+        # but two different agents — must produce two independent artefacts.
+        findings = [
+            {
+                "finding_id": "f1",
+                "title": "System Prompt Extraction — AgentA",
+                "description": "AgentA disclosed its system prompt to the attacker.",
+                "affected_component": "AgentA",
+                "severity": "high",
+                "scenario_type": "SYSTEM_PROMPT_EXTRACTION",
+            },
+            {
+                "finding_id": "f2",
+                "title": "System Prompt Extraction — AgentB",
+                "description": "AgentB disclosed its system prompt to the attacker.",
+                "affected_component": "AgentB",
+                "severity": "high",
+                "scenario_type": "SYSTEM_PROMPT_EXTRACTION",
+            },
+        ]
+        synth = RemediationSynthesizer()
+        artefacts = await synth.synthesize_findings_async(findings)
+        patches = [a for a in artefacts if a.artefact_type == RemediationArtefactType.SYSTEM_PROMPT_PATCH]
+
+        assert len(patches) == 2, "expected one independent artefact per component, not merged"
+        by_component = {a.component: a for a in patches}
+        assert set(by_component) == {"AgentA", "AgentB"}
+        assert "AgentA disclosed" in by_component["AgentA"].rationale
+        assert "AgentB disclosed" not in by_component["AgentA"].rationale
+        assert "AgentB disclosed" in by_component["AgentB"].rationale
+        assert "AgentA disclosed" not in by_component["AgentB"].rationale

--- a/tests/remediation/test_synthesizer_prompts.py
+++ b/tests/remediation/test_synthesizer_prompts.py
@@ -109,3 +109,75 @@ async def test_no_llm_client_produces_template_only():
 
     patch = next(a for a in artefacts if a.artefact_type == RemediationArtefactType.SYSTEM_PROMPT_PATCH)
     assert "Out of Scope" in patch.patch_text
+
+
+class TestEvidencePriorityInLLMEnrichment:
+    """_enrich_artefacts_async() builds its `evidence` string as
+    evidence_quote -> reasoning -> description -> title (synthesizer.py, the
+    scenario_type-routing fix's Step 3) so the LLM prompt is grounded in the
+    specific proof of breach rather than generic telemetry text like "Attack
+    scenario 'X' succeeded: success signals detected in N step(s)."."""
+
+    @pytest.mark.asyncio
+    async def test_evidence_quote_used_over_generic_description_system_prompt_patch(self) -> None:
+        llm = _FakeLLM(response="patched")
+        synth = RemediationSynthesizer(llm_client=llm)
+        finding = {
+            **_blocked_topics_finding(),
+            "description": "Attack scenario 'X' succeeded: success signals detected in 1 step(s).",
+            "evidence_quote": "SPECIFIC_PROOF_STRING_12345",
+        }
+
+        await synth.synthesize_findings_async([finding])
+
+        prompts = [c["prompt"] for c in llm.calls if c["system"] == SYSTEM_PROMPT_PATCH_SYSTEM]
+        assert prompts, "expected a SYSTEM_PROMPT_PATCH_SYSTEM call"
+        assert any("SPECIFIC_PROOF_STRING_12345" in p for p in prompts)
+        assert not any("success signals detected" in p for p in prompts)
+
+    @pytest.mark.asyncio
+    async def test_reasoning_used_over_generic_description_guardrail_rationale(self) -> None:
+        llm = _FakeLLM(response="rationale text")
+        synth = RemediationSynthesizer(llm_client=llm)
+        finding = {
+            **_data_leak_finding(),
+            "description": "Attack scenario 'Y' succeeded: success signals detected in 1 step(s).",
+            "reasoning": "SPECIFIC_REASONING_STRING_67890",
+        }
+
+        await synth.synthesize_findings_async([finding])
+
+        prompts = [c["prompt"] for c in llm.calls if c["system"] == GUARDRAIL_RATIONALE_SYSTEM]
+        assert prompts, "expected a GUARDRAIL_RATIONALE_SYSTEM call"
+        assert any("SPECIFIC_REASONING_STRING_67890" in p for p in prompts)
+        assert not any("success signals detected" in p for p in prompts)
+
+    @pytest.mark.asyncio
+    async def test_evidence_quote_takes_priority_over_reasoning(self) -> None:
+        llm = _FakeLLM(response="rationale text")
+        synth = RemediationSynthesizer(llm_client=llm)
+        finding = {
+            **_data_leak_finding(),
+            "evidence_quote": "EVIDENCE_QUOTE_WINS",
+            "reasoning": "REASONING_SHOULD_NOT_APPEAR",
+        }
+
+        await synth.synthesize_findings_async([finding])
+
+        prompts = [c["prompt"] for c in llm.calls if c["system"] == GUARDRAIL_RATIONALE_SYSTEM]
+        assert any("EVIDENCE_QUOTE_WINS" in p for p in prompts)
+        assert not any("REASONING_SHOULD_NOT_APPEAR" in p for p in prompts)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_description_when_no_evidence_quote_or_reasoning(self) -> None:
+        # Regression guard: findings without the new fields (pre-existing
+        # data, or behavior/analysis findings which never populate them)
+        # must keep working exactly as before this change.
+        llm = _FakeLLM(response="patched")
+        synth = RemediationSynthesizer(llm_client=llm)
+        finding = _blocked_topics_finding()  # no evidence_quote/reasoning keys at all
+
+        await synth.synthesize_findings_async([finding])
+
+        prompts = [c["prompt"] for c in llm.calls if c["system"] == SYSTEM_PROMPT_PATCH_SYSTEM]
+        assert any(finding["description"] in p for p in prompts)


### PR DESCRIPTION
## Summary

- **Root cause**: `Finding` only carried the coarse `goal_type` (7 values -> 6 dtype buckets), so remediation classification collapsed genuinely distinct attack techniques into the same template — e.g. an Approval State Forgery (HITL bypass) finding got advice about blocking system-prompt text.
- Threads `AttackScenario.scenario_type` onto `Finding` and classifies by it first, via a closed, exact-match dict covering all 146 `ScenarioType` values (exhaustiveness-tested). Reuses existing handlers where the domain fits; adds 4 new ones (`agentic_trust_boundary`, `memory_session_integrity`, `output_handling`, `supply_chain_secrets`) where it doesn't.
- Fixes two related bugs found while testing: `_merge_artefacts` discarding rationale behind a content-free placeholder, and a pre-merge dedup key based on component-derived display labels that silently dropped distinct findings sharing a label.
- Separately: fixes `run_redteam()`'s post-run `scenario_filter` re-check, which matched only `goal_type` (not `scenario_type`), silently dropping findings from `--scenarios <SPECIFIC_SCENARIO_TYPE>`-filtered scans with no error or warning.

## Test plan

- [x] Unit tests: 27 new tests in `tests/remediation/test_synthesizer.py` + `test_synthesizer_prompts.py` — exhaustiveness over all 146 `ScenarioType` values, the motivating Approval-State-Forgery case, backward compatibility (no `scenario_type` set), all 4 new handlers, merge/dedup fixes, LLM evidence-priority (`evidence_quote` > `reasoning` > `description`), cross-component isolation
- [x] Unit + integration tests for the `scenario_filter` fix in `tests/redteam/test_scenario_filter.py` and `test_public_api.py`, including a mocked `run_redteam()` regression test reproducing the exact reported bug
- [x] Full suite: 2731 passed, 34 skipped, 0 failed; ruff and mypy clean across `nuguard/`
- [x] Offline dry-run against the real pinnacle-bank-app SBOM: all 5 representative findings (motivating case + all 4 new buckets) route to the correct domain
- [x] Live run against pinnacle-bank-app: confirmed the orchestrator genuinely detects the Approval State Forgery finding live, independent of the scenario_filter fix
- [x] Full unscoped live run against Gemini-Auto-app: 20 real findings, naturally hit all 4 new buckets + the HITL bucket, all rendered with specific, technique-grounded remediation text — 0 occurrences of the old generic fallback or the original wrong-domain text pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)