### PR TITLE
chore(release): bump version to 0.8.8

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Track user-facing documentation updates here, especially changes to CLI behavior, workflows, and troubleshooting guidance.
 
+## v0.8.8 - 2026-07-22
+
+### Fixed
+- Redteam remediation advice is now classified by the specific `scenario_type` of the attack (e.g. Approval State Forgery, Agent Impersonation, Memory Poisoning) instead of only the coarse `goal_type`, so distinct attack techniques that previously collapsed into the same generic or mismatched-domain advice now get specific, correctly-scoped guidance.
+- `nuguard redteam --scenarios <SCENARIO_TYPE>` (a specific attack-technique filter, e.g. `APPROVAL_STATE_FORGERY`) no longer silently drops the resulting finding and its remediation from the final report — the post-run filter now matches on `scenario_type` and `title`, not just `goal_type`.
+
 ## v0.7.9 - 2026-06-22
 
 ### Changed

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuguardai/nuguard",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.8.7"
+__version__ = "0.8.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.8.7"
+version = "0.8.8"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.8.7"
+version: "0.8.8"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ wheels = [
 
 [[package]]
 name = "nuguard"
-version = "0.8.7"
+version = "0.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "cyclonedx-bom" },


### PR DESCRIPTION
## Summary

Version bump for the release that includes #141 (scenario_type-based remediation routing fix + scenario_filter bug fix).

- `pyproject.toml`, `nuguard/__init__.py`, `npm/package.json`, `smithery.yaml`, `uv.lock` -> 0.8.8
- `docs/CHANGELOG.md`: added `v0.8.8` entry

## Test plan

- [x] Full suite: 2731 passed, 34 skipped, 0 failed
- [x] ruff and mypy clean across `nuguard/`
- [x] `uv sync --dev` confirms installed package reports `nuguard==0.8.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)