### PR TITLE
chore: remove stray worktree gitlink and ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ canary.local.json
 # Plugin user config — contains credentials, never commit
 .claude/*.local.md
 
+# Agent worktree snapshots — local scratch state, not repo history
+.claude/worktrees/
+
 # Test run artifacts (E2E outputs, scan reports)
 tests/output/
 /reports/


### PR DESCRIPTION
## Summary

- Removes the gitlink at `.claude/worktrees/agent-abfc3ebf`, which had no `.gitmodules` entry.
- Adds `.claude/worktrees/` to `.gitignore` so agent worktree scratch state doesn't get committed again.

## Why

Verified this is currently broken on `main`: any submodule command hits it.

```
$ git submodule status
fatal: no submodule mapping found in .gitmodules for path '.claude/worktrees/agent-abfc3ebf'
```

This affects `git submodule update --init`, `git submodule status`, and `git clone --recurse-submodules` for anyone cloning the repo.

## Test plan

- [x] `git grep agent-abfc3ebf` across the repo: zero references — nothing depends on this path
- [x] Checked out this branch and confirmed `git submodule status` now runs clean, correctly showing only the real registered submodule (`tests/apps/claude-cookbooks`)
- [x] `tests/redteam/` + `tests/remediation/` suites: 1025 passed, 0 failed — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)