### PR TITLE
fix(scripts): publish_smithery preflight wrongly failed on release-triggered runs

### DIFF
--- a/scripts/publish_smithery.py
+++ b/scripts/publish_smithery.py
@@ -157,7 +157,7 @@ def _git_commits_ahead_of_origin() -> int:
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 
-def preflight(version: str, allow_dirty: bool, allow_branch: bool) -> list[str]:
+def preflight(version: str, allow_dirty: bool, allow_branch: bool, skip_git_tag: bool) -> list[str]:
     errors: list[str] = []
     warnings: list[str] = []
 
@@ -200,12 +200,16 @@ def preflight(version: str, allow_dirty: bool, allow_branch: bool) -> list[str]:
                 "  Pass --allow-branch to skip this check."
             )
 
-    # Git tag collision
-    tag = f"v{version}"
-    if _git_tag_exists(tag):
-        errors.append(
-            f"Git tag {tag!r} already exists. Bump the version first."
-        )
+    # Git tag collision — only relevant if this run will try to create the
+    # tag itself. When --skip-git-tag is passed (e.g. the release-triggered
+    # CI path, where creating the GitHub Release is what created the tag),
+    # the tag already existing is expected, not a collision.
+    if not skip_git_tag:
+        tag = f"v{version}"
+        if _git_tag_exists(tag):
+            errors.append(
+                f"Git tag {tag!r} already exists. Bump the version first."
+            )
 
     for w in warnings:
         print(f"  WARNING: {w}")
@@ -406,7 +410,7 @@ def main() -> int:
 
     # Pre-flight
     print("Pre-flight checks …")
-    errors = preflight(version, args.allow_dirty, args.allow_branch)
+    errors = preflight(version, args.allow_dirty, args.allow_branch, args.skip_git_tag)
     if errors:
         print()
         for e in errors:


### PR DESCRIPTION
## Summary

The v0.8.8 release exposed a real bug: `publish-pypi.yml`'s "Update Smithery listing" job failed on the `release`-triggered path, after PyPI and npm had already succeeded.

Root cause: `preflight()`'s git-tag-collision check ran unconditionally, even when `--skip-git-tag` was passed. On the `release`-triggered path, `--skip-git-tag` is passed *because* the tag is expected to already exist (creating the GitHub Release is what created it) — but the check couldn't tell that apart from a genuine collision, so it always failed:

```
FAIL: Git tag 'v0.8.8' already exists. Bump the version first.
```

This is likely why releases drifted to manual `workflow_dispatch` instead of GitHub Releases in the first place — that path also passes `--skip-git-tag`, but never hit this check because no tag existed yet at dispatch time.

## Fix

Threads `skip_git_tag` into `preflight()` so the collision check only runs when the invocation would actually try to create the tag itself.

## Test plan

- [x] Verified locally against the real `v0.8.8` tag (fetched from origin): without `--skip-git-tag`, still correctly fails with the collision error; with `--skip-git-tag`, now passes cleanly and proceeds to build the bundle
- [x] `ruff check scripts/publish_smithery.py`: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)