### PR TITLE
ci: add temporary Smithery-only publish workflow (one-off fix)

### DIFF
--- a/.github/workflows/publish-smithery-once.yml
+++ b/.github/workflows/publish-smithery-once.yml
@@ -1,0 +1,42 @@
+name: Publish Smithery Only (temporary — one-off fix, remove after use)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-smithery:
+    name: Update Smithery listing
+    runs-on: ubuntu-latest
+    environment:
+      name: smithery
+      url: https://smithery.ai/server/NuGuardAI/nuguard
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js (for smithery CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install smithery CLI
+        run: npm install -g smithery
+
+      - name: Install script dependencies
+        run: pip install pyyaml
+
+      - name: Publish to Smithery
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          python scripts/publish_smithery.py \
+            --skip-pypi \
+            --skip-git-tag \
+            --allow-dirty \
+            --allow-branch


### PR DESCRIPTION
## Summary

v0.8.8's release-triggered publish succeeded on PyPI and npm but failed on Smithery due to the preflight bug fixed in #144. This adds a standalone, temporary workflow to publish just the Smithery listing for v0.8.8 without re-running PyPI/npm (which already succeeded).

- No `build`, `publish-pypi`, or `publish-npm` jobs/steps exist in this file — only the Smithery job.
- The script is invoked with `--skip-pypi` as a second, redundant safeguard.
- `on: workflow_dispatch:` only — never fires automatically.

**To be removed** once used — `publish-pypi.yml` (all three targets together) remains the only permanent publish path going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)