### PR TITLE
fix: distinguish disabled catalog scenarios

### DIFF
--- a/nuguard/redteam/catalog/selector.py
+++ b/nuguard/redteam/catalog/selector.py
@@ -129,9 +129,9 @@ def select_scenarios(
             skipped.append((spec.id, spec.category.value, "profile_capped"))
             continue
 
-        # --- not yet implemented ----
+        # --- explicitly disabled ----
         if not spec.enabled:
-            skipped.append((spec.id, spec.category.value, "builder_pending"))
+            skipped.append((spec.id, spec.category.value, "spec_disabled"))
             continue
 
         # --- guided flag ---

--- a/tests/redteam/test_catalog_capability.py
+++ b/tests/redteam/test_catalog_capability.py
@@ -301,8 +301,10 @@ def test_coverage_report_has_skipped_with_reasons() -> None:
 
     assert len(coverage.skipped) > 0
     reasons = {reason for _, _, reason in coverage.skipped}
-    # Should have capability_missing or builder_pending reasons
+    # Disabled specs have an explicit safety/configuration reason; builder
+    # failures remain distinguishable as builder_pending.
     assert any("capability" in r or "pending" in r for r in reasons)
+    assert "spec_disabled" in reasons
 
 
 def test_ci_profile_returns_fewer_scenarios_than_full() -> None:


### PR DESCRIPTION
Closes #156

Disabled catalog specs are now reported as `spec_disabled` with an explicit `# --- explicitly disabled ---` selector comment. Builder failures that raise `NotImplementedError` still use `builder_pending`, so safety/configuration skips are no longer presented as missing implementations.

I added an assertion for the new reason and verified:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/redteam/test_catalog_capability.py -q` (20 passed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/redteam/test_catalog_loader.py tests/redteam/test_catalog_snapshot.py -q` (163 passed)
- `git diff --check`

The targeted Ruff check still reports three pre-existing unused imports in `test_catalog_capability.py`; none were introduced by this change.
