### PR TITLE
docs: clarify Postgres db backend is planned, not yet implemented

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ nuguard/
 ├── analysis/       # Static SBOM analysis — detector plugins
 ├── policy/         # Cognitive Policy parsing and violation checking
 ├── models/         # Shared Pydantic models (AttackGraph, ExploitChain, Scan, Finding, Policy)
-├── db/             # SQLite (default) or Postgres (async SQLAlchemy)
+├── db/             # SQLite (default); Postgres planned (async SQLAlchemy, not yet implemented)
 ├── output/         # SARIF / JSON / Markdown report generators
 ├── cli/            # Typer app — main.py wires sub-commands from commands/
 ├── config.py       # nuguard.yaml loader with ${ENV_VAR} interpolation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ nuguard/
 ├── policy/         # Cognitive Policy parsing and violation checking
 ├── remediation/    # Shared remediation-artefact synthesis (behavior, redteam, analysis)
 ├── models/         # Shared Pydantic models (AttackGraph, ExploitChain, Scan, Finding, Policy)
-├── db/             # SQLite (default) or Postgres (async SQLAlchemy)
+├── db/             # SQLite (default); Postgres planned (async SQLAlchemy, not yet implemented)
 ├── output/         # SARIF / JSON / Markdown report generators
 ├── cli/            # Typer app — main.py wires sub-commands from commands/
 ├── config.py       # nuguard.yaml loader with ${ENV_VAR} interpolation


### PR DESCRIPTION
The `db/` directory description in CLAUDE.md and .github/copilot-instructions.md claimed Postgres support, but `nuguard/db/postgres.py` is an empty stub with only TODO comments — no engine or session factory exists.

This updates both files to note that Postgres is planned, not yet implemented.

- CLAUDE.md: line 55
- .github/copilot-instructions.md: line 39

Fixes #154