### PR TITLE
docs: update endpoint resolution plan status to completed (#165)

### DIFF
--- a/documentation/docs/endpoint-resolution-precedence-plan.md
+++ b/documentation/docs/endpoint-resolution-precedence-plan.md
@@ -1,6 +1,6 @@
 # Endpoint Resolution Patch Plan (Config Must Win)
 
-Status: Planned
+Status: Completed
 
 Scope: `validate`, `behavior`, and `redteam` endpoint resolution for target chat paths.
 


### PR DESCRIPTION
Closes #165

### Summary
Updates the status in `documentation/docs/endpoint-resolution-precedence-plan.md` from `Planned` to `Completed` as the endpoint resolution fix has already shipped.