### PR TITLE
Add exclude-paths to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    exclude-paths:
+      - "tests/apps/**"
     ignore:
       # test fixture apps are deliberately pinned / vendored — see .gitattributes
       - dependency-name: "*"
@@ -41,3 +43,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    exclude-paths:
+      - "tests/apps/**"


### PR DESCRIPTION
The apps being run as test apps for internal demos do not need to be scanned, as they are not part of the Nuguard package. 