### PR TITLE
fix: ignore tests/apps/claude-cookbooks in pytest collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ include = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--import-mode=importlib --ignore=tests/apps/contact-center-ai-samples --ignore=tests/apps/blissful-store --ignore=tests/apps/ai-agents-google-adk/test_bedrock_haiku.py --ignore=tests/apps/ai-agents-google-adk/test_openai_gpt.py"
+addopts = "--import-mode=importlib --ignore=tests/apps/contact-center-ai-samples --ignore=tests/apps/blissful-store --ignore=tests/apps/claude-cookbooks --ignore=tests/apps/ai-agents-google-adk/test_bedrock_haiku.py --ignore=tests/apps/ai-agents-google-adk/test_openai_gpt.py"
 testpaths = ["tests", "nuguard/sbom/tests"]
 markers = [
     "redteam_e2e: E2E redteam scan against a live fixture app (opt-in: NUGUARD_REDTEAM_E2E=1)",


### PR DESCRIPTION
## What

Add `--ignore=tests/apps/claude-cookbooks` to `addopts` in `pyproject.toml`, alongside the existing ignores for `contact-center-ai-samples` and `blissful-store`.

## Why

`make test` (`uv run pytest tests/ -v`, per the Makefile and `CONTRIBUTING.md`) fails on a clean clone before running a single test — pytest tries to collect `tests/apps/claude-cookbooks/`, a submodule added in #112 for one SBOM adapter test. That submodule's own test files aren't self-contained outside its own environment, producing 12 collection errors (`ModuleNotFoundError` for `utils`/`calc`/`src`/`memory_tool`/`tests.notebook_tests`, plus a pytest plugin-registration clash between the submodule's `conftest.py` and the repo's own). Full details in #192.

CI itself never hits this, since `pr-tests.yml` runs `uv run pytest nuguard/ -q`, not the Makefile's `pytest tests/ -v` — so the documented local dev workflow and what CI actually validates had quietly diverged.

## How validated

- `make test` — before: 12 collection errors, 0 tests run. After: `1950 passed, 33 skipped` in ~105s.
- `make lint` — `ruff check nuguard/` and `mypy nuguard/` both clean.
- `make precommit-run` — all hooks pass.
- Change is a single line in `pyproject.toml`; no code paths affected.

Closes #192
