### PR TITLE
docs: fix stale nuguard-oss links and dead /workspaces/ paths

### DIFF
--- a/documentation/docs/doc.html
+++ b/documentation/docs/doc.html
@@ -321,7 +321,7 @@
             <li><a href="index.html#quickstart">Quickstart</a></li>
             <li><a href="index.html#frameworks">Frameworks</a></li>
             <li><a href="doc.html?page=quick-start" class="active">Docs</a></li>
-            <li><a href="https://github.com/NuGuardAI/nuguard-oss" class="nav-cta">GitHub ↗</a></li>
+            <li><a href="https://github.com/NuGuardAI/nuguard" class="nav-cta">GitHub ↗</a></li>
         </ul>
     </nav>
 
@@ -369,8 +369,8 @@
             </div>
             <ul class="footer-links">
                 <li><a href="doc.html?page=quick-start">Getting Started</a></li>
-                <li><a href="https://github.com/NuGuardAI/nuguard-oss">GitHub</a></li>
-                <li><a href="https://github.com/NuGuardAI/nuguard-oss/issues">Issues</a></li>
+                <li><a href="https://github.com/NuGuardAI/nuguard">GitHub</a></li>
+                <li><a href="https://github.com/NuGuardAI/nuguard/issues">Issues</a></li>
             </ul>
             <span class="footer-copy">· Built by NuGuard AI</span>
         </div>

--- a/documentation/docs/index.html
+++ b/documentation/docs/index.html
@@ -801,7 +801,7 @@ jobs:
             <ul class="footer-links">
                 <li><a href="doc.html?page=quick-start">Quick Start</a></li>
                 <li><a href="doc.html?page=plugin-guide">Plugin Guide</a></li>
-                <li><a href="https://github.com/NuGuardAI/nuguard-oss" class="icon-link" aria-label="GitHub"><svg width="15"
+                <li><a href="https://github.com/NuGuardAI/nuguard" class="icon-link" aria-label="GitHub"><svg width="15"
                             height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                             <path
                                 d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />

--- a/documentation/docs/llms.txt
+++ b/documentation/docs/llms.txt
@@ -345,8 +345,8 @@ json_str = AiSbomSerializer.to_json(doc)
 
 ## Community & Support
 
-- GitHub: https://github.com/NuGuardAI/nuguard-oss
-- Issues: https://github.com/NuGuardAI/nuguard-oss/issues
+- GitHub: https://github.com/NuGuardAI/nuguard
+- Issues: https://github.com/NuGuardAI/nuguard/issues
 - Discord: https://discord.gg/EF99Ck7a
 - NuGuard AI: https://nuguard.ai/
 

--- a/documentation/docs/policy-engine-guide.md
+++ b/documentation/docs/policy-engine-guide.md
@@ -269,7 +269,7 @@ Common issues:
 
 Related docs:
 
-- [docs/quick-start.md](/workspaces/nuguard-oss/docs/quick-start.md)
-- [docs/cli-reference.md](/workspaces/nuguard-oss/docs/cli-reference.md)
-- [docs/troubleshooting.md](/workspaces/nuguard-oss/docs/troubleshooting.md)
-- [docs/sbom-schema.md](/workspaces/nuguard-oss/docs/sbom-schema.md)
+- [docs/quick-start.md](quick-start.md)
+- [docs/cli-reference.md](cli-reference.md)
+- [docs/troubleshooting.md](troubleshooting.md)
+- [docs/sbom-schema.md](sbom-schema.md)

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -101,8 +101,8 @@ nuguard sbom validate --file app.sbom.json
 
 If you need a minimal known-good example, compare against:
 
-- [docs/sample-sbom.json](/workspaces/nuguard-oss/docs/sample-sbom.json)
-- [docs/sbom-schema.md](/workspaces/nuguard-oss/docs/sbom-schema.md)
+- [docs/sample-sbom.json](sample-sbom.json)
+- [docs/sbom-schema.md](sbom-schema.md)
 
 ## Static Analysis
 
@@ -296,7 +296,7 @@ This repo’s packaging config excludes:
 
 If artifact contents drift, inspect:
 
-- [pyproject.toml](/workspaces/nuguard-oss/pyproject.toml)
+- [pyproject.toml](../../pyproject.toml)
 
 ## GitHub Actions and Trusted Publishing
 
@@ -335,7 +335,7 @@ Check the publisher registration in PyPI or TestPyPI:
 For this repo, expected values are:
 
 - project: `nuguard`
-- repo: `nuguard-oss`
+- repo: `nuguard`
 
 ## Git Issues
 
@@ -349,7 +349,7 @@ Be careful not to remove the lock while another git operation is genuinely activ
 
 ## More References
 
-- [docs/quick-start.md](/workspaces/nuguard-oss/docs/quick-start.md)
-- [docs/cli-reference.md](/workspaces/nuguard-oss/docs/cli-reference.md)
-- [docs/sbom-schema.md](/workspaces/nuguard-oss/docs/sbom-schema.md)
-- [README.md](/workspaces/nuguard-oss/README.md)
+- [docs/quick-start.md](quick-start.md)
+- [docs/cli-reference.md](cli-reference.md)
+- [docs/sbom-schema.md](sbom-schema.md)
+- [README.md](../../.github/README.md)


### PR DESCRIPTION
## What

Replace stale `nuguard-oss` references and dead `/workspaces/nuguard-oss/...` absolute paths across the docs with the current repo name and proper relative links.

## Why

The repo was renamed `nuguard-oss` → `nuguard` at some point, but it wasn't fully propagated through the docs:

- `troubleshooting.md` and `policy-engine-guide.md` linked to `/workspaces/nuguard-oss/docs/...` — an absolute devcontainer-style path that doesn't resolve to anything in this repo, so these render as dead links (404) when GitHub renders the markdown.
- `llms.txt` and the published docs site (`doc.html`, `index.html`) linked to `github.com/NuGuardAI/nuguard-oss` — GitHub redirects that URL today, but it's stale and non-canonical.
- `troubleshooting.md`'s PyPI Trusted Publisher checklist said `repo: nuguard-oss`, which no longer matches.

Confirmed `nuguard-oss` isn't a live config value anywhere — `pyproject.toml`'s `[project.urls]` already correctly points at `github.com/NuGuardAI/nuguard`, and no workflow file references the old name.

**Out of scope, left untouched on purpose**: `documentation/docs/llm-runs/` has the same stale references, but that directory looks like internal working notes rather than published docs (not linked from the site nav) — flagging that separately rather than folding it into this PR. Also left `sample-sbom.json`'s `"target"` field alone since it's illustrative fixture data, not a navigation link.

## How validated

- `make lint` — clean (ruff + mypy).
- `make precommit-run` — clean.
- Grepped the full repo after the change to confirm every remaining `/workspaces/` and `nuguard-oss` reference is confined to the two files intentionally left out of scope.
- Docs-only change; no code paths affected, `make test` not applicable.
