### PR TITLE
feat(sbom): add .go file extension and go.mod/go.sum dependency scann…

### DIFF
--- a/nuguard/sbom/config.py
+++ b/nuguard/sbom/config.py
@@ -91,6 +91,7 @@ class AiSbomConfig(BaseModel):
     include_extensions: set[str] = Field(
         default_factory=lambda: {
             ".py",
+            ".go",
             ".pyw",
             ".ts",
             ".tsx",

--- a/nuguard/sbom/deps.py
+++ b/nuguard/sbom/deps.py
@@ -200,6 +200,7 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
         "go_mod": _root_first_sorted(root, go_mod_paths, "go.mod"),
     }
 
+
 def _to_go_purl(module: str, version: str) -> str:
     """Build a ``pkg:go/`` PURL for a Go module."""
     module_clean = module.strip()
@@ -465,88 +466,94 @@ class DependencyScanner:
         return deps
 
     def _scan_go_mod(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
-            """Parse ``go.mod`` and ``go.sum`` files and return Go module dependencies.
+        """Parse ``go.mod`` and ``go.sum`` files and return Go module dependencies.
 
-            Parses both single-line require directives:
-                require github.com/gin-gonic/gin v1.9.1
-            And block require directives:
-                require (
-                    github.com/google/uuid v1.3.0
-                )
-            Also parses ``go.sum`` for exact pinned module versions.
-            """
-            if candidate_paths is None:
-                candidate_paths = _collect_manifest_candidates(root)["go_mod"]
+        Parses both single-line require directives:
+            require github.com/gin-gonic/gin v1.9.1
+        And block require directives:
+            require (
+                github.com/google/uuid v1.3.0
+            )
+        Also parses ``go.sum`` for exact pinned module versions.
+        """
+        if candidate_paths is None:
+            candidate_paths = _collect_manifest_candidates(root)["go_mod"]
 
-            deps: list[PackageDep] = []
-            for path in candidate_paths:
-                src = str(path.relative_to(root))
-                try:
-                    content = path.read_text(encoding="utf-8")
-                except OSError:
-                    continue
+        # Ensure go.sum paths are processed before go.mod so exact version pins win
+        sorted_candidates = sorted(
+            candidate_paths,
+            key=lambda p: 0 if p.name == "go.sum" else 1
+        )
 
-                # Parse go.sum
-                if path.name == "go.sum":
-                    for line in content.splitlines():
-                        parts = line.strip().split()
-                        if len(parts) >= 2:
-                            mod, ver = parts[0], parts[1].split("/go.mod")[0]
-                            deps.append(
-                                PackageDep(
-                                    name=mod,
-                                    version_spec=f"=={ver}",
-                                    purl=_to_go_purl(mod, ver),
-                                    group="runtime",
-                                    source_file=src,
-                                )
-                            )
-                    continue
+        deps: list[PackageDep] = []
+        for path in sorted_candidates:
+            src = str(path.relative_to(root))
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
 
-                # Parse go.mod
-                in_require_block = False
+            # Parse go.sum
+            if path.name == "go.sum":
                 for line in content.splitlines():
-                    line = line.strip()
-                    if not line or line.startswith("//"):
-                        continue
-
-                    if line == "require (" or line.startswith("require ("):
-                        in_require_block = True
-                        continue
-
-                    if in_require_block:
-                        if line == ")":
-                            in_require_block = False
-                            continue
-                        parts = line.split()
-                        if len(parts) >= 2:
-                            mod, ver = parts[0], parts[1]
-                            group = "runtime" if "// indirect" not in line else "optional:indirect"
-                            deps.append(
-                                PackageDep(
-                                    name=mod,
-                                    version_spec=f"=={ver}",
-                                    purl=_to_go_purl(mod, ver),
-                                    group=group,
-                                    source_file=src,
-                                )
+                    parts = line.strip().split()
+                    if len(parts) >= 2:
+                        mod, ver = parts[0], parts[1].split("/go.mod")[0]
+                        deps.append(
+                            PackageDep(
+                                name=mod,
+                                version_spec=f"=={ver}",
+                                purl=_to_go_purl(mod, ver),
+                                group="runtime",
+                                source_file=src,
                             )
-                    elif line.startswith("require "):
-                        parts = line.split()
-                        if len(parts) >= 3:
-                            mod, ver = parts[1], parts[2]
-                            group = "runtime" if "// indirect" not in line else "optional:indirect"
-                            deps.append(
-                                PackageDep(
-                                    name=mod,
-                                    version_spec=f"=={ver}",
-                                    purl=_to_go_purl(mod, ver),
-                                    group=group,
-                                    source_file=src,
-                                )
-                            )
+                        )
+                continue
 
-            return deps
+            # Parse go.mod
+            in_require_block = False
+            for line in content.splitlines():
+                line = line.strip()
+                if not line or line.startswith("//"):
+                    continue
+
+                if line == "require (" or line.startswith("require ("):
+                    in_require_block = True
+                    continue
+
+                if in_require_block:
+                    if line == ")":
+                        in_require_block = False
+                        continue
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        mod, ver = parts[0], parts[1]
+                        group = "runtime" if "// indirect" not in line else "optional:indirect"
+                        deps.append(
+                            PackageDep(
+                                name=mod,
+                                version_spec=f"=={ver}",
+                                purl=_to_go_purl(mod, ver),
+                                group=group,
+                                source_file=src,
+                            )
+                        )
+                elif line.startswith("require "):
+                    parts = line.split()
+                    if len(parts) >= 3:
+                        mod, ver = parts[1], parts[2]
+                        group = "runtime" if "// indirect" not in line else "optional:indirect"
+                        deps.append(
+                            PackageDep(
+                                name=mod,
+                                version_spec=f"=={ver}",
+                                purl=_to_go_purl(mod, ver),
+                                group=group,
+                                source_file=src,
+                            )
+                        )
+
+        return deps
     # ------------------------------------------------------------------
     # Supply-chain extensions — no changes to existing scan() interface
     # ------------------------------------------------------------------

--- a/nuguard/sbom/deps.py
+++ b/nuguard/sbom/deps.py
@@ -170,6 +170,7 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
     requirements_paths: list[Path] = []
     setup_cfg_paths: list[Path] = []
     package_json_paths: list[Path] = []
+    go_mod_paths: list[Path] = []
 
     for current_root, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in _MANIFEST_SKIP_DIRS]
@@ -184,6 +185,8 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
                 setup_cfg_paths.append(path)
             elif filename == "package.json":
                 package_json_paths.append(path)
+            elif filename in ("go.mod", "go.sum"):
+                go_mod_paths.append(path)
             elif filename.endswith(".txt") and (
                 filename.startswith("requirements") or in_requirements_dir
             ):
@@ -194,8 +197,16 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
         "requirements": sorted(set(requirements_paths)),
         "setup_cfg": _root_first_sorted(root, setup_cfg_paths, "setup.cfg"),
         "package_json": _root_first_sorted(root, package_json_paths, "package.json"),
+        "go_mod": _root_first_sorted(root, go_mod_paths, "go.mod"),
     }
 
+def _to_go_purl(module: str, version: str) -> str:
+    """Build a ``pkg:go/`` PURL for a Go module."""
+    module_clean = module.strip()
+    ver_clean = version.strip()
+    if ver_clean:
+        return f"pkg:go/{module_clean}@{ver_clean}"
+    return f"pkg:go/{module_clean}"
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -230,6 +241,7 @@ class DependencyScanner:
             *self._scan_requirements(root, manifest_candidates["requirements"]),
             *self._scan_setup_cfg(root, manifest_candidates["setup_cfg"]),
             *self._scan_package_json(root, manifest_candidates["package_json"]),
+            *self._scan_go_mod(root, manifest_candidates["go_mod"]),
         ]:
             # Strip version from PURL for dedup key so pkg:pypi/foo and
             # pkg:npm/foo are treated as distinct entries.
@@ -452,6 +464,89 @@ class DependencyScanner:
                     )
         return deps
 
+    def _scan_go_mod(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
+            """Parse ``go.mod`` and ``go.sum`` files and return Go module dependencies.
+
+            Parses both single-line require directives:
+                require github.com/gin-gonic/gin v1.9.1
+            And block require directives:
+                require (
+                    github.com/google/uuid v1.3.0
+                )
+            Also parses ``go.sum`` for exact pinned module versions.
+            """
+            if candidate_paths is None:
+                candidate_paths = _collect_manifest_candidates(root)["go_mod"]
+
+            deps: list[PackageDep] = []
+            for path in candidate_paths:
+                src = str(path.relative_to(root))
+                try:
+                    content = path.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+
+                # Parse go.sum
+                if path.name == "go.sum":
+                    for line in content.splitlines():
+                        parts = line.strip().split()
+                        if len(parts) >= 2:
+                            mod, ver = parts[0], parts[1].split("/go.mod")[0]
+                            deps.append(
+                                PackageDep(
+                                    name=mod,
+                                    version_spec=f"=={ver}",
+                                    purl=_to_go_purl(mod, ver),
+                                    group="runtime",
+                                    source_file=src,
+                                )
+                            )
+                    continue
+
+                # Parse go.mod
+                in_require_block = False
+                for line in content.splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("//"):
+                        continue
+
+                    if line == "require (" or line.startswith("require ("):
+                        in_require_block = True
+                        continue
+
+                    if in_require_block:
+                        if line == ")":
+                            in_require_block = False
+                            continue
+                        parts = line.split()
+                        if len(parts) >= 2:
+                            mod, ver = parts[0], parts[1]
+                            group = "runtime" if "// indirect" not in line else "optional:indirect"
+                            deps.append(
+                                PackageDep(
+                                    name=mod,
+                                    version_spec=f"=={ver}",
+                                    purl=_to_go_purl(mod, ver),
+                                    group=group,
+                                    source_file=src,
+                                )
+                            )
+                    elif line.startswith("require "):
+                        parts = line.split()
+                        if len(parts) >= 3:
+                            mod, ver = parts[1], parts[2]
+                            group = "runtime" if "// indirect" not in line else "optional:indirect"
+                            deps.append(
+                                PackageDep(
+                                    name=mod,
+                                    version_spec=f"=={ver}",
+                                    purl=_to_go_purl(mod, ver),
+                                    group=group,
+                                    source_file=src,
+                                )
+                            )
+
+            return deps
     # ------------------------------------------------------------------
     # Supply-chain extensions — no changes to existing scan() interface
     # ------------------------------------------------------------------

--- a/nuguard/sbom/tests/test_deps.py
+++ b/nuguard/sbom/tests/test_deps.py
@@ -467,7 +467,7 @@ class TestEdgeCases:
 class TestGoModScanner:
     """Tests for Go module parsing from go.mod and go.sum files."""
 
-    def test_scan_go_mod_single_and_block_require(self, tmp_path: Path):
+    def test_scan_go_mod_single_and_block_require(self, tmp_path: Path) -> None:
         go_mod_content = """
 module github.com/myorg/myapp
 
@@ -498,7 +498,7 @@ require (
         direct_dep = next(d for d in deps if d.name == "github.com/gin-gonic/gin")
         assert direct_dep.group == "runtime"
 
-    def test_scan_go_sum_pins(self, tmp_path: Path):
+    def test_scan_go_sum_pins(self, tmp_path: Path) -> None:
         go_sum_content = """
 github.com/gin-gonic/gin v1.9.1 h1:4A3XlY04t2a
 github.com/gin-gonic/gin v1.9.1/go.mod h1:A0A3XlY04t2a

--- a/nuguard/sbom/tests/test_deps.py
+++ b/nuguard/sbom/tests/test_deps.py
@@ -463,3 +463,53 @@ class TestEdgeCases:
         assert "openai" in names
         # pywin32 may or may not be included depending on marker stripping,
         # but it should not cause a crash
+
+class TestGoModScanner:
+    """Tests for Go module parsing from go.mod and go.sum files."""
+
+    def test_scan_go_mod_single_and_block_require(self, tmp_path: Path):
+        go_mod_content = """
+module github.com/myorg/myapp
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.1
+
+require (
+    github.com/google/uuid v1.3.0
+    golang.org/x/crypto v0.14.0 // indirect
+)
+"""
+        go_mod_path = tmp_path / "go.mod"
+        go_mod_path.write_text(go_mod_content, encoding="utf-8")
+
+        scanner = DependencyScanner()
+        deps = scanner.scan(tmp_path)
+
+        purls = {d.purl for d in deps}
+        assert "pkg:go/github.com/gin-gonic/gin@v1.9.1" in purls
+        assert "pkg:go/github.com/google/uuid@v1.3.0" in purls
+        assert "pkg:go/golang.org/x/crypto@v0.14.0" in purls
+
+        # Verify group mapping for indirect vs direct dependencies
+        indirect_dep = next(d for d in deps if d.name == "golang.org/x/crypto")
+        assert indirect_dep.group == "optional:indirect"
+
+        direct_dep = next(d for d in deps if d.name == "github.com/gin-gonic/gin")
+        assert direct_dep.group == "runtime"
+
+    def test_scan_go_sum_pins(self, tmp_path: Path):
+        go_sum_content = """
+github.com/gin-gonic/gin v1.9.1 h1:4A3XlY04t2a
+github.com/gin-gonic/gin v1.9.1/go.mod h1:A0A3XlY04t2a
+github.com/google/uuid v1.3.0 h1:t6JiO
+"""
+        go_sum_path = tmp_path / "go.sum"
+        go_sum_path.write_text(go_sum_content, encoding="utf-8")
+
+        scanner = DependencyScanner()
+        deps = scanner.scan(tmp_path)
+
+        purls = {d.purl for d in deps}
+        assert "pkg:go/github.com/gin-gonic/gin@v1.9.1" in purls
+        assert "pkg:go/github.com/google/uuid@v1.3.0" in purls


### PR DESCRIPTION
Closes #173

Adds Golang language support to the NuGuard SBOM pipeline by whitelisting .go source files and introducing go.mod / go.sum manifest scanning.
Changes Included:

    Whitelisted .go Extension: Added ".go" to include_extensions in nuguard/sbom/config.py so Go source files are visible during project file-system traversals.

    Manifest Collection: Added "go_mod" bucket support to _collect_manifest_candidates() in nuguard/sbom/deps.py to pick up go.mod and go.sum files.

    Go Dependency Parser: Implemented DependencyScanner._scan_go_mod() to parse single-line and block require directives in go.mod as well as exact version pins in go.sum.

    PURL Generation: Emits pkg:go/<module>@<version> PURLs (mapping // indirect dependencies to the optional:indirect group and direct dependencies to runtime).

How verified

    [x] Executed test suite (pytest -p asyncio nuguard/sbom/tests/test_deps.py).

    [x] Added unit tests under TestGoModScanner verifying:

        Parsing single-line require statements in go.mod.

        Parsing multiline block require (...) directives in go.mod.

        Handling // indirect dependency annotations.

        Extracting pinned module versions from go.sum.

Notes

    Downstream OSV Compatibility: The OSV client in NuGuard already contains "go": "Go" ecosystem mapping (osv_client.py). Emitting pkg:go/ PURLs seamlessly enables downstream vulnerability scanning for Go dependencies against OSV/Grype without further OSV mapping changes.