### PR TITLE
feat(sbom): add structured Go parser

### DIFF
--- a/nuguard/sbom/core/go_parser.py
+++ b/nuguard/sbom/core/go_parser.py
@@ -800,9 +800,63 @@ def _parse_with_regex(
         )
         for item in strings
         if (item.line, item.value) not in import_keys
+        and not _is_regex_struct_tag(masked, item.start)
     ]
 
     return result
+
+
+def _is_regex_struct_tag(
+    masked: str,
+    position: int,
+) -> bool:
+    """Return whether a scanned string is a Go struct tag.
+
+    The fallback scanner has already replaced comments and string contents
+    with spaces. A string is treated as a tag when it follows field syntax on
+    the same line and the nearest unmatched opening brace starts a struct body.
+    """
+    line_start = (
+        masked.rfind(
+            "\n",
+            0,
+            position,
+        )
+        + 1
+    )
+
+    if not masked[line_start:position].strip():
+        return False
+
+    nested_braces = 0
+
+    for index in range(
+        position - 1,
+        -1,
+        -1,
+    ):
+        char = masked[index]
+
+        if char == "}":
+            nested_braces += 1
+            continue
+
+        if char != "{":
+            continue
+
+        if nested_braces:
+            nested_braces -= 1
+            continue
+
+        return (
+            re.search(
+                r"\bstruct\s*$",
+                masked[:index],
+            )
+            is not None
+        )
+
+    return False
 
 
 def _regex_imports(content: str) -> list[GoImport]:

--- a/nuguard/sbom/core/go_parser.py
+++ b/nuguard/sbom/core/go_parser.py
@@ -1,0 +1,1325 @@
+"""Structured Go source parsing for SBOM and AI-framework extraction.
+
+The parser prefers ``tree_sitter_go`` for accurate syntax-tree extraction and
+falls back to a best-effort regex parser when the optional grammar cannot be
+loaded. It extracts imports, struct/constructor instantiations, calls, and
+string literals while preserving partial results for malformed source.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+try:
+    import tree_sitter
+    import tree_sitter_go
+
+    HAS_TREE_SITTER = True
+except ImportError:
+    tree_sitter = None  # type: ignore[assignment]
+    tree_sitter_go = None  # type: ignore[assignment]
+    HAS_TREE_SITTER = False
+
+
+@dataclass
+class GoImport:
+    """Information about one Go import specification."""
+
+    path: str
+    alias: str | None
+    line: int
+
+    @property
+    def module(self) -> str:
+        """Return the import path using the shared parser terminology."""
+
+        return self.path
+
+
+@dataclass
+class GoInstantiation:
+    """A named struct literal or conventional ``New*`` constructor call."""
+
+    class_name: str
+    args: dict[str, Any] = field(default_factory=dict)
+    positional_args: list[Any] = field(default_factory=list)
+    assigned_to: str | None = None
+    line: int = 0
+    line_end: int = 0
+    kind: str = "struct_literal"
+    source_snippet: str | None = None
+
+
+@dataclass
+class GoFunctionCall:
+    """Information about a Go function or method call."""
+
+    function_name: str
+    receiver: str | None = None
+    args: dict[str, Any] = field(default_factory=dict)
+    positional_args: list[Any] = field(default_factory=list)
+    assigned_to: str | None = None
+    line: int = 0
+    line_end: int = 0
+    source_snippet: str | None = None
+
+    @property
+    def full_name(self) -> str:
+        """Return the receiver-qualified function name."""
+
+        if self.receiver:
+            return f"{self.receiver}.{self.function_name}"
+        return self.function_name
+
+
+@dataclass
+class GoStringLiteral:
+    """A raw or interpreted Go string literal."""
+
+    value: str
+    line: int
+    context: str | None = None
+    assigned_to: str | None = None
+    is_raw: bool = False
+
+
+@dataclass
+class GoParseResult:
+    """Structured information extracted from one Go source file."""
+
+    imports: list[GoImport] = field(default_factory=list)
+    instantiations: list[GoInstantiation] = field(default_factory=list)
+    function_calls: list[GoFunctionCall] = field(default_factory=list)
+    string_literals: list[GoStringLiteral] = field(default_factory=list)
+    source: str = ""
+    file_path: str = ""
+    parse_error: str | None = None
+    used_tree_sitter: bool = False
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.imports or self.instantiations or self.function_calls or self.string_literals
+        )
+
+
+_GO_LANGUAGE: Any | None = None
+_NAMED_TYPE_NODES = {"type_identifier", "qualified_type", "generic_type"}
+_STRING_NODES = {"interpreted_string_literal", "raw_string_literal"}
+_ASSIGNMENT_NODES = {
+    "assignment_statement",
+    "short_var_declaration",
+    "const_spec",
+    "var_spec",
+}
+_WRAPPER_NODES = {
+    "expression_list",
+    "parenthesized_expression",
+    "unary_expression",
+}
+
+
+def get_go_parser() -> Any | None:
+    """Return a tree-sitter Go parser, or ``None`` when unavailable."""
+
+    global _GO_LANGUAGE
+
+    if not HAS_TREE_SITTER:
+        return None
+
+    assert tree_sitter is not None
+    assert tree_sitter_go is not None
+
+    if _GO_LANGUAGE is None:
+        _GO_LANGUAGE = tree_sitter.Language(tree_sitter_go.language())
+
+    return tree_sitter.Parser(_GO_LANGUAGE)
+
+
+def parse_go(content: str, file_path: str = "") -> GoParseResult:
+    """Parse Go source into a structured :class:`GoParseResult`.
+
+    Tree-sitter is attempted first. If the bindings are missing or parser
+    initialization fails, a best-effort regex parser is used instead.
+    """
+
+    parser_error: str | None = None
+
+    try:
+        parser = get_go_parser()
+    except Exception as exc:  # pragma: no cover - platform-specific binding failures
+        parser = None
+        parser_error = f"tree-sitter initialization failed: {exc}"
+
+    if parser is not None:
+        try:
+            return _parse_with_tree_sitter(content, file_path, parser)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            parser_error = f"tree-sitter parsing failed: {exc}"
+
+    result = _parse_with_regex(content, file_path)
+
+    if parser_error:
+        result.parse_error = parser_error
+
+    return result
+
+
+def _parse_with_tree_sitter(
+    content: str,
+    file_path: str,
+    parser: Any,
+) -> GoParseResult:
+    source = content.encode("utf-8")
+    tree = parser.parse(source)
+    root = tree.root_node
+    symbols = _build_symbol_table(root, source)
+
+    result = GoParseResult(
+        source=content,
+        file_path=file_path,
+        used_tree_sitter=True,
+    )
+
+    for node in _walk(root):
+        if node.type == "import_spec":
+            imported = _tree_sitter_import(node, source)
+            if imported is not None:
+                result.imports.append(imported)
+
+        elif node.type == "composite_literal":
+            instantiation = _tree_sitter_struct_literal(
+                node,
+                source,
+                symbols,
+            )
+            if instantiation is not None:
+                result.instantiations.append(instantiation)
+
+        elif node.type == "call_expression":
+            call = _tree_sitter_call(node, source, symbols)
+
+            if call is not None:
+                result.function_calls.append(call)
+
+                if call.function_name.startswith("New"):
+                    result.instantiations.append(
+                        GoInstantiation(
+                            class_name=call.full_name,
+                            args=dict(call.args),
+                            positional_args=list(call.positional_args),
+                            assigned_to=call.assigned_to,
+                            line=call.line,
+                            line_end=call.line_end,
+                            kind="constructor_call",
+                            source_snippet=call.source_snippet,
+                        )
+                    )
+
+        elif node.type in _STRING_NODES and not _is_non_value_string(node):
+            result.string_literals.append(_tree_sitter_string(node, source))
+
+    if root.has_error:
+        error_line = _first_error_line(root)
+        result.parse_error = f"Go syntax error near line {error_line}"
+
+    return result
+
+
+def _walk(node: Any) -> Iterator[Any]:
+    yield node
+
+    for child in node.children:
+        yield from _walk(child)
+
+
+def _node_text(node: Any | None, source: bytes) -> str:
+    if node is None:
+        return ""
+
+    return source[node.start_byte : node.end_byte].decode(
+        "utf-8",
+        errors="replace",
+    )
+
+
+def _line(node: Any) -> int:
+    return int(node.start_point[0]) + 1
+
+
+def _line_end(node: Any) -> int:
+    return int(node.end_point[0]) + 1
+
+
+def _named_children(node: Any | None) -> list[Any]:
+    if node is None:
+        return []
+
+    return list(node.named_children)
+
+
+def _children_by_field_name(
+    node: Any,
+    field_name: str,
+) -> list[Any]:
+    method = getattr(node, "children_by_field_name", None)
+
+    if callable(method):
+        return list(method(field_name))
+
+    child = node.child_by_field_name(field_name)
+    return [child] if child is not None else []
+
+
+def _tree_sitter_import(
+    node: Any,
+    source: bytes,
+) -> GoImport | None:
+    path_node = node.child_by_field_name("path")
+
+    if path_node is None:
+        return None
+
+    alias_node = node.child_by_field_name("name")
+
+    path = _decode_go_string(
+        _node_text(path_node, source),
+        is_raw=path_node.type == "raw_string_literal",
+    )
+
+    alias = _node_text(alias_node, source) or None
+
+    return GoImport(
+        path=path,
+        alias=alias,
+        line=_line(node),
+    )
+
+
+def _tree_sitter_struct_literal(
+    node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> GoInstantiation | None:
+    type_node = node.child_by_field_name("type")
+    body_node = node.child_by_field_name("body")
+
+    if type_node is None or body_node is None or type_node.type not in _NAMED_TYPE_NODES:
+        return None
+
+    type_name = _node_text(type_node, source)
+
+    args, positional_args = _literal_body_values(
+        body_node,
+        source,
+        symbols,
+    )
+
+    return GoInstantiation(
+        class_name=type_name,
+        args=args,
+        positional_args=positional_args,
+        assigned_to=_assignment_target(node, source),
+        line=_line(node),
+        line_end=_line_end(node),
+        kind="struct_literal",
+        source_snippet=_node_text(node, source),
+    )
+
+
+def _tree_sitter_call(
+    node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> GoFunctionCall | None:
+    function_node = node.child_by_field_name("function")
+    arguments_node = node.child_by_field_name("arguments")
+
+    if function_node is None or arguments_node is None:
+        return None
+
+    callee = _node_text(function_node, source)
+    receiver, function_name = _split_callee(callee)
+
+    positional_args = [
+        _extract_value(child, source, symbols) for child in _named_children(arguments_node)
+    ]
+
+    return GoFunctionCall(
+        function_name=function_name,
+        receiver=receiver,
+        positional_args=positional_args,
+        assigned_to=_assignment_target(node, source),
+        line=_line(node),
+        line_end=_line_end(node),
+        source_snippet=_node_text(node, source),
+    )
+
+
+def _tree_sitter_string(
+    node: Any,
+    source: bytes,
+) -> GoStringLiteral:
+    raw_text = _node_text(node, source)
+
+    return GoStringLiteral(
+        value=_decode_go_string(
+            raw_text,
+            is_raw=node.type == "raw_string_literal",
+        ),
+        line=_line(node),
+        context=_enclosing_context(node, source),
+        assigned_to=_assignment_target(node, source),
+        is_raw=node.type == "raw_string_literal",
+    )
+
+
+def _split_callee(callee: str) -> tuple[str | None, str]:
+    normalized = re.sub(
+        r"\[[^\]]*\]$",
+        "",
+        callee.strip(),
+    )
+
+    if "." not in normalized:
+        return None, normalized
+
+    receiver, function_name = normalized.rsplit(".", 1)
+    return receiver, function_name
+
+
+def _literal_body_values(
+    body_node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> tuple[dict[str, Any], list[Any]]:
+    args: dict[str, Any] = {}
+    positional_args: list[Any] = []
+
+    for child in _named_children(body_node):
+        child = _unwrap_literal_element(child)
+
+        if child.type == "keyed_element":
+            key_node = child.child_by_field_name("key")
+            value_node = child.child_by_field_name("value")
+
+            if key_node is not None and value_node is not None:
+                args[_node_text(key_node, source)] = _extract_value(
+                    value_node,
+                    source,
+                    symbols,
+                )
+        else:
+            positional_args.append(_extract_value(child, source, symbols))
+
+    return args, positional_args
+
+
+def _unwrap_literal_element(node: Any) -> Any:
+    if node.type == "literal_element" and len(node.named_children) == 1:
+        return node.named_children[0]
+
+    return node
+
+
+def _extract_value(
+    node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> Any:
+    node = _unwrap_literal_element(node)
+    text = _node_text(node, source).strip()
+
+    if node.type == "interpreted_string_literal":
+        return _decode_go_string(text, is_raw=False)
+
+    if node.type == "raw_string_literal":
+        return _decode_go_string(text, is_raw=True)
+
+    if node.type == "int_literal":
+        return _parse_int(text)
+
+    if node.type == "float_literal":
+        try:
+            return float(text.replace("_", ""))
+        except ValueError:
+            return text
+
+    if node.type == "true":
+        return True
+
+    if node.type == "false":
+        return False
+
+    if node.type == "nil":
+        return None
+
+    if node.type == "identifier":
+        return symbols.get(text, f"${text}")
+
+    if node.type == "parenthesized_expression" and node.named_children:
+        return _extract_value(
+            node.named_children[0],
+            source,
+            symbols,
+        )
+
+    if node.type == "unary_expression" and node.named_children:
+        value = _extract_value(
+            node.named_children[-1],
+            source,
+            symbols,
+        )
+
+        if text.startswith("-") and isinstance(value, int | float):
+            return -value
+
+        return value
+
+    if node.type == "composite_literal":
+        type_node = node.child_by_field_name("type")
+        body_node = node.child_by_field_name("body")
+
+        if body_node is not None:
+            args, positional_args = _literal_body_values(
+                body_node,
+                source,
+                symbols,
+            )
+
+            structured: dict[str, Any] = {}
+
+            if type_node is not None:
+                structured["$type"] = _node_text(
+                    type_node,
+                    source,
+                )
+
+            if args:
+                structured.update(args)
+
+            if positional_args:
+                structured["$items"] = positional_args
+
+            return structured
+
+    if node.type == "literal_value":
+        args, positional_args = _literal_body_values(
+            node,
+            source,
+            symbols,
+        )
+
+        if args and not positional_args:
+            return args
+
+        if not args:
+            return positional_args
+
+        return {
+            **args,
+            "$items": positional_args,
+        }
+
+    return f"${text}" if text else None
+
+
+def _parse_int(text: str) -> int | str:
+    normalized = text.replace("_", "")
+
+    try:
+        if re.fullmatch(r"0[0-7]+", normalized):
+            return int(normalized, 8)
+
+        return int(normalized, 0)
+    except ValueError:
+        return text
+
+
+def _decode_go_string(
+    text: str,
+    *,
+    is_raw: bool,
+) -> str:
+    if len(text) < 2:
+        return text
+
+    if is_raw:
+        return text[1:-1].replace("\r", "")
+
+    try:
+        value = ast.literal_eval(text)
+
+        if isinstance(value, str):
+            return value
+
+        return text[1:-1]
+    except (SyntaxError, ValueError):
+        return text[1:-1]
+
+
+def _build_symbol_table(
+    root: Any,
+    source: bytes,
+) -> dict[str, Any]:
+    symbols: dict[str, Any] = {}
+
+    for node in _walk(root):
+        if node.type not in _ASSIGNMENT_NODES:
+            continue
+
+        if node.type in {"const_spec", "var_spec"}:
+            names = [
+                child
+                for child in _children_by_field_name(node, "name")
+                if child.type == "identifier"
+            ]
+            value_container = node.child_by_field_name("value")
+        else:
+            left = node.child_by_field_name("left")
+            names = [child for child in _named_children(left) if child.type == "identifier"]
+            value_container = node.child_by_field_name("right")
+
+        values = _named_children(value_container)
+
+        for name_node, value_node in zip(names, values):
+            name = _node_text(name_node, source)
+            symbols[name] = _extract_value(
+                value_node,
+                source,
+                symbols,
+            )
+
+    return symbols
+
+
+def _assignment_target(
+    node: Any,
+    source: bytes,
+) -> str | None:
+    current = node
+    parent = current.parent
+
+    while parent is not None and parent.type in _WRAPPER_NODES:
+        current = parent
+        parent = parent.parent
+
+    if parent is None or parent.type not in _ASSIGNMENT_NODES:
+        return None
+
+    if parent.type in {"const_spec", "var_spec"}:
+        name_nodes = _children_by_field_name(parent, "name")
+    else:
+        left = parent.child_by_field_name("left")
+        name_nodes = _named_children(left)
+
+    if not name_nodes:
+        return None
+
+    return _node_text(name_nodes[0], source) or None
+
+
+def _enclosing_context(
+    node: Any,
+    source: bytes,
+) -> str | None:
+    parent = node.parent
+
+    while parent is not None:
+        if parent.type in {
+            "function_declaration",
+            "method_declaration",
+        }:
+            name_node = parent.child_by_field_name("name")
+            return _node_text(name_node, source) or None
+
+        parent = parent.parent
+
+    return None
+
+
+def _is_non_value_string(node: Any) -> bool:
+    parent = node.parent
+
+    while parent is not None:
+        if parent.type in {
+            "import_spec",
+            "field_declaration",
+        }:
+            return True
+
+        if parent.type in {
+            "source_file",
+            "function_declaration",
+            "method_declaration",
+        }:
+            return False
+
+        parent = parent.parent
+
+    return False
+
+
+def _first_error_line(root: Any) -> int:
+    for node in _walk(root):
+        if node.type == "ERROR" or node.is_missing:
+            return _line(node)
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Regex fallback
+# ---------------------------------------------------------------------------
+
+_IMPORT_SINGLE_RE = re.compile(
+    r"(?m)^\s*import\s+"
+    r"(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"
+    r'(?P<path>"(?:\\.|[^"\\])*")\s*(?://.*)?$'
+)
+
+_IMPORT_BLOCK_RE = re.compile(r"(?ms)^\s*import\s*\((?P<body>.*?)^\s*\)")
+
+_IMPORT_SPEC_RE = re.compile(
+    r"(?m)^\s*"
+    r"(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"
+    r'(?P<path>"(?:\\.|[^"\\])*")\s*(?://.*)?$'
+)
+
+_CALL_RE = re.compile(
+    r"\b"
+    r"(?P<callee>"
+    r"[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\.[A-Za-z_][A-Za-z0-9_]*)*"
+    r")\s*\("
+)
+
+_STRUCT_RE = re.compile(
+    r"\b"
+    r"(?P<type>"
+    r"[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\.[A-Za-z_][A-Za-z0-9_]*)*"
+    r")\s*\{"
+)
+
+_SYMBOL_RE = re.compile(
+    r"(?m)^\s*"
+    r"(?:const|var)?\s*"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:\s+[A-Za-z_][A-Za-z0-9_.\[\]*]*)?"
+    r"\s*(?::=|=)\s*"
+    r"(?P<value>"
+    r"`[^`]*`|"
+    r'"(?:\\.|[^"\\])*"|'
+    r"true|false|nil|[-+]?\d[\d_]*"
+    r")\s*$"
+)
+
+_SKIP_CALL_NAMES = {
+    "append",
+    "cap",
+    "clear",
+    "close",
+    "complex",
+    "copy",
+    "defer",
+    "delete",
+    "for",
+    "func",
+    "go",
+    "if",
+    "imag",
+    "import",
+    "len",
+    "make",
+    "max",
+    "min",
+    "new",
+    "panic",
+    "print",
+    "println",
+    "real",
+    "recover",
+    "return",
+    "select",
+    "switch",
+}
+
+
+@dataclass
+class _ScannedString:
+    value: str
+    start: int
+    end: int
+    line: int
+    is_raw: bool
+
+
+def _parse_with_regex(
+    content: str,
+    file_path: str,
+) -> GoParseResult:
+    result = GoParseResult(
+        source=content,
+        file_path=file_path,
+        used_tree_sitter=False,
+    )
+
+    result.imports = _regex_imports(content)
+    symbols = _regex_symbols(content)
+    masked, strings = _mask_non_code(content)
+
+    result.instantiations = _regex_struct_literals(
+        content,
+        masked,
+        symbols,
+    )
+
+    calls, constructors = _regex_calls(
+        content,
+        masked,
+        symbols,
+    )
+
+    result.function_calls = calls
+    result.instantiations.extend(constructors)
+
+    import_keys = {(item.line, item.path) for item in result.imports}
+
+    result.string_literals = [
+        GoStringLiteral(
+            value=item.value,
+            line=item.line,
+            assigned_to=_regex_assignment_target(
+                content,
+                item.start,
+            ),
+            is_raw=item.is_raw,
+        )
+        for item in strings
+        if (item.line, item.value) not in import_keys
+    ]
+
+    return result
+
+
+def _regex_imports(content: str) -> list[GoImport]:
+    imports: list[GoImport] = []
+
+    for match in _IMPORT_SINGLE_RE.finditer(content):
+        imports.append(
+            GoImport(
+                path=_decode_go_string(
+                    match.group("path"),
+                    is_raw=False,
+                ),
+                alias=match.group("alias"),
+                line=content.count(
+                    "\n",
+                    0,
+                    match.start(),
+                )
+                + 1,
+            )
+        )
+
+    for block in _IMPORT_BLOCK_RE.finditer(content):
+        body = block.group("body")
+        body_start = block.start("body")
+
+        for match in _IMPORT_SPEC_RE.finditer(body):
+            imports.append(
+                GoImport(
+                    path=_decode_go_string(
+                        match.group("path"),
+                        is_raw=False,
+                    ),
+                    alias=match.group("alias"),
+                    line=content.count(
+                        "\n",
+                        0,
+                        body_start + match.start("path"),
+                    )
+                    + 1,
+                )
+            )
+
+    return sorted(
+        imports,
+        key=lambda item: item.line,
+    )
+
+
+def _regex_symbols(content: str) -> dict[str, Any]:
+    symbols: dict[str, Any] = {}
+
+    for match in _SYMBOL_RE.finditer(content):
+        symbols[match.group("name")] = _parse_value_text(
+            match.group("value"),
+            symbols,
+        )
+
+    return symbols
+
+
+def _regex_struct_literals(
+    content: str,
+    masked: str,
+    symbols: dict[str, Any],
+) -> list[GoInstantiation]:
+    instantiations: list[GoInstantiation] = []
+    seen: set[tuple[int, int]] = set()
+
+    for match in _STRUCT_RE.finditer(masked):
+        type_name = match.group("type")
+
+        if not type_name.rsplit(".", 1)[-1][:1].isupper():
+            continue
+
+        open_brace = match.end() - 1
+        close_brace = _find_matching(
+            masked,
+            open_brace,
+            "{",
+            "}",
+        )
+
+        if close_brace is None or (match.start(), close_brace) in seen:
+            continue
+
+        seen.add((match.start(), close_brace))
+
+        args, positional_args = _parse_regex_literal_body(
+            content[open_brace + 1 : close_brace],
+            symbols,
+        )
+
+        instantiations.append(
+            GoInstantiation(
+                class_name=type_name,
+                args=args,
+                positional_args=positional_args,
+                assigned_to=_regex_assignment_target(
+                    content,
+                    match.start(),
+                ),
+                line=content.count(
+                    "\n",
+                    0,
+                    match.start(),
+                )
+                + 1,
+                line_end=content.count(
+                    "\n",
+                    0,
+                    close_brace,
+                )
+                + 1,
+                kind="struct_literal",
+                source_snippet=content[match.start() : close_brace + 1],
+            )
+        )
+
+    return instantiations
+
+
+def _regex_calls(
+    content: str,
+    masked: str,
+    symbols: dict[str, Any],
+) -> tuple[
+    list[GoFunctionCall],
+    list[GoInstantiation],
+]:
+    calls: list[GoFunctionCall] = []
+    constructors: list[GoInstantiation] = []
+    seen: set[tuple[int, int]] = set()
+
+    for match in _CALL_RE.finditer(masked):
+        if _looks_like_function_declaration(
+            masked,
+            match.start(),
+        ):
+            continue
+
+        callee = match.group("callee")
+        receiver, function_name = _split_callee(callee)
+
+        if receiver is None and function_name in _SKIP_CALL_NAMES:
+            continue
+
+        open_paren = match.end() - 1
+        close_paren = _find_matching(
+            masked,
+            open_paren,
+            "(",
+            ")",
+        )
+
+        if close_paren is None or (match.start(), close_paren) in seen:
+            continue
+
+        seen.add((match.start(), close_paren))
+
+        positional_args = [
+            _parse_value_text(argument, symbols)
+            for argument in _split_top_level(content[open_paren + 1 : close_paren])
+            if argument.strip()
+        ]
+
+        call = GoFunctionCall(
+            function_name=function_name,
+            receiver=receiver,
+            positional_args=positional_args,
+            assigned_to=_regex_assignment_target(
+                content,
+                match.start(),
+            ),
+            line=content.count(
+                "\n",
+                0,
+                match.start(),
+            )
+            + 1,
+            line_end=content.count(
+                "\n",
+                0,
+                close_paren,
+            )
+            + 1,
+            source_snippet=content[match.start() : close_paren + 1],
+        )
+
+        calls.append(call)
+
+        if function_name.startswith("New"):
+            constructors.append(
+                GoInstantiation(
+                    class_name=call.full_name,
+                    positional_args=list(call.positional_args),
+                    assigned_to=call.assigned_to,
+                    line=call.line,
+                    line_end=call.line_end,
+                    kind="constructor_call",
+                    source_snippet=call.source_snippet,
+                )
+            )
+
+    return calls, constructors
+
+
+def _parse_regex_literal_body(
+    body: str,
+    symbols: dict[str, Any],
+) -> tuple[dict[str, Any], list[Any]]:
+    args: dict[str, Any] = {}
+    positional_args: list[Any] = []
+
+    for element in _split_top_level(body):
+        if not element.strip():
+            continue
+
+        key_value = _split_top_level_key_value(element)
+
+        if key_value is None:
+            positional_args.append(_parse_value_text(element, symbols))
+        else:
+            key, value = key_value
+            args[key.strip()] = _parse_value_text(
+                value,
+                symbols,
+            )
+
+    return args, positional_args
+
+
+def _parse_value_text(
+    text: str,
+    symbols: dict[str, Any],
+) -> Any:
+    value = text.strip()
+
+    while value.startswith(("&", "*")):
+        value = value[1:].strip()
+
+    if len(value) >= 2 and value[0] == value[-1] == "`":
+        return _decode_go_string(value, is_raw=True)
+
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return _decode_go_string(value, is_raw=False)
+
+    if value == "true":
+        return True
+
+    if value == "false":
+        return False
+
+    if value == "nil":
+        return None
+
+    if re.fullmatch(r"[-+]?\d[\d_]*", value):
+        sign = -1 if value.startswith("-") else 1
+        unsigned = value.lstrip("+-")
+        parsed = _parse_int(unsigned)
+
+        if isinstance(parsed, int):
+            return sign * parsed
+
+        return value
+
+    if re.fullmatch(
+        r"[-+]?"
+        r"(?:"
+        r"\d[\d_]*\.\d[\d_]*|"
+        r"\d[\d_]*[eE][-+]?\d+"
+        r")",
+        value,
+    ):
+        try:
+            return float(value.replace("_", ""))
+        except ValueError:
+            return value
+
+    if re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*",
+        value,
+    ):
+        return symbols.get(value, f"${value}")
+
+    return f"${value}" if value else None
+
+
+def _mask_non_code(
+    content: str,
+) -> tuple[str, list[_ScannedString]]:
+    masked = list(content)
+    strings: list[_ScannedString] = []
+    index = 0
+    line = 1
+
+    def blank(start: int, end: int) -> None:
+        for position in range(start, end):
+            if masked[position] != "\n":
+                masked[position] = " "
+
+    while index < len(content):
+        if content.startswith("//", index):
+            end = content.find("\n", index)
+            end = len(content) if end == -1 else end
+            blank(index, end)
+            index = end
+            continue
+
+        if content.startswith("/*", index):
+            end = content.find("*/", index + 2)
+            end = len(content) if end == -1 else end + 2
+            line += content.count("\n", index, end)
+            blank(index, end)
+            index = end
+            continue
+
+        if content[index] in {'"', "`", "'"}:
+            quote = content[index]
+            start = index
+            start_line = line
+            index += 1
+
+            while index < len(content):
+                if quote != "`" and content[index] == "\\":
+                    index += 2
+                    continue
+
+                if content[index] == quote:
+                    index += 1
+                    break
+
+                if content[index] == "\n":
+                    line += 1
+
+                index += 1
+
+            raw = content[start:index]
+
+            if quote != "'":
+                strings.append(
+                    _ScannedString(
+                        value=_decode_go_string(
+                            raw,
+                            is_raw=quote == "`",
+                        ),
+                        start=start,
+                        end=index,
+                        line=start_line,
+                        is_raw=quote == "`",
+                    )
+                )
+
+            blank(start, index)
+            continue
+
+        if content[index] == "\n":
+            line += 1
+
+        index += 1
+
+    return "".join(masked), strings
+
+
+def _find_matching(
+    text: str,
+    start: int,
+    opener: str,
+    closer: str,
+) -> int | None:
+    depth = 0
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if char == opener:
+            depth += 1
+
+        elif char == closer:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _split_top_level(text: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+    }
+    closers = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(text):
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            continue
+
+        if char in {'"', "'", "`"}:
+            quote = char
+
+        elif char in depths:
+            depths[char] += 1
+
+        elif char in closers:
+            depths[closers[char]] = max(
+                0,
+                depths[closers[char]] - 1,
+            )
+
+        elif char == "," and not any(depths.values()):
+            parts.append(text[start:index].strip())
+            start = index + 1
+
+    parts.append(text[start:].strip())
+    return parts
+
+
+def _split_top_level_key_value(
+    text: str,
+) -> tuple[str, str] | None:
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+    }
+    closers = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(text):
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            continue
+
+        if char in {'"', "'", "`"}:
+            quote = char
+
+        elif char in depths:
+            depths[char] += 1
+
+        elif char in closers:
+            depths[closers[char]] = max(
+                0,
+                depths[closers[char]] - 1,
+            )
+
+        elif char == ":" and not any(depths.values()):
+            return text[:index], text[index + 1 :]
+
+    return None
+
+
+def _regex_assignment_target(
+    content: str,
+    position: int,
+) -> str | None:
+    boundary = max(
+        content.rfind("\n", 0, position),
+        content.rfind(";", 0, position),
+        content.rfind("{", 0, position),
+    )
+
+    prefix = content[boundary + 1 : position]
+
+    match = re.search(
+        r"^\s*"
+        r"(?:(?:var|const)\s+)?"
+        r"(?P<first>[A-Za-z_][A-Za-z0-9_]*)"
+        r"(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*"
+        r"\s*(?::=|=)\s*$",
+        prefix,
+    )
+
+    return match.group("first") if match else None
+
+
+def _looks_like_function_declaration(
+    masked: str,
+    position: int,
+) -> bool:
+    line_start = masked.rfind("\n", 0, position) + 1
+    prefix = masked[line_start:position]
+
+    return bool(
+        re.search(
+            r"\bfunc(?:\s*\([^)]*\))?\s*$",
+            prefix,
+        )
+    )

--- a/nuguard/sbom/tests/test_go_parser.py
+++ b/nuguard/sbom/tests/test_go_parser.py
@@ -1,0 +1,242 @@
+"""Tests for structured Go source parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuguard.sbom.core import go_parser
+from nuguard.sbom.core.go_parser import parse_go
+
+
+def test_tree_sitter_parser_is_available_and_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert go_parser.HAS_TREE_SITTER is True
+    assert go_parser.get_go_parser() is not None
+
+    def fail_if_called(
+        *_args: object,
+        **_kwargs: object,
+    ) -> object:
+        raise AssertionError("regex fallback should not run")
+
+    monkeypatch.setattr(
+        go_parser,
+        "_parse_with_regex",
+        fail_if_called,
+    )
+
+    result = parse_go('package main\nimport "fmt"\n')
+
+    assert result.used_tree_sitter is True
+    assert result.parse_error is None
+    assert [item.path for item in result.imports] == ["fmt"]
+
+
+def test_extracts_single_and_grouped_imports_with_aliases() -> None:
+    result = parse_go(
+        """package main
+
+import "fmt"
+import (
+    openai "github.com/sashabaranov/go-openai"
+    _ "github.com/lib/pq"
+    . "github.com/example/helpers"
+)
+"""
+    )
+
+    imports = {(item.path, item.alias) for item in result.imports}
+
+    assert imports == {
+        ("fmt", None),
+        (
+            "github.com/sashabaranov/go-openai",
+            "openai",
+        ),
+        ("github.com/lib/pq", "_"),
+        ("github.com/example/helpers", "."),
+    }
+
+
+def test_extracts_struct_literal_and_resolves_simple_values() -> None:
+    result = parse_go(
+        """package main
+
+const model = "gpt-4o-mini"
+
+func build() {
+    request := openai.ChatCompletionRequest{
+        Model: model,
+        Temperature: 0.2,
+        Stream: true,
+    }
+    _ = request
+}
+"""
+    )
+
+    request = next(
+        item for item in result.instantiations if item.class_name == "openai.ChatCompletionRequest"
+    )
+
+    assert request.kind == "struct_literal"
+    assert request.assigned_to == "request"
+    assert request.args["Model"] == "gpt-4o-mini"
+    assert request.args["Temperature"] == 0.2
+    assert request.args["Stream"] is True
+
+
+def test_extracts_constructor_and_method_calls() -> None:
+    result = parse_go(
+        """package main
+
+func build(apiKey string, server *Server) {
+    client, err := openai.NewClient(
+        openai.WithAPIKey(apiKey),
+    )
+    server.AddTool(mcp.NewTool("search"))
+    _, _ = client, err
+}
+"""
+    )
+
+    calls = {item.full_name: item for item in result.function_calls}
+
+    constructors = {
+        item.class_name: item for item in result.instantiations if item.kind == "constructor_call"
+    }
+
+    assert calls["openai.NewClient"].assigned_to == "client"
+    assert calls["server.AddTool"].receiver == "server"
+    assert calls["server.AddTool"].function_name == "AddTool"
+
+    assert "openai.NewClient" in constructors
+    assert constructors["openai.NewClient"].assigned_to == "client"
+
+    assert "mcp.NewTool" in constructors
+
+
+def test_extracts_raw_and_interpreted_strings_with_context() -> None:
+    result = parse_go(
+        r"""package main
+
+import "fmt"
+
+const systemPrompt = `You are a careful assistant.`
+
+type Tagged struct {
+    Name string `json:"name"`
+}
+
+func run() {
+    prompt := "hello\nworld"
+    fmt.Println(prompt)
+}
+"""
+    )
+
+    values = {item.value: item for item in result.string_literals}
+
+    assert "fmt" not in values
+    assert 'json:"name"' not in values
+
+    assert values["You are a careful assistant."].is_raw is True
+
+    assert values["You are a careful assistant."].assigned_to == "systemPrompt"
+
+    assert values["hello\nworld"].is_raw is False
+    assert values["hello\nworld"].context == "run"
+    assert values["hello\nworld"].assigned_to == "prompt"
+
+
+def test_malformed_source_returns_partial_result_with_error() -> None:
+    result = parse_go(
+        """package main
+
+import "fmt"
+
+func main( {
+    prompt := "hello"
+"""
+    )
+
+    assert result.used_tree_sitter is True
+    assert result.parse_error is not None
+
+    assert any(item.path == "fmt" for item in result.imports)
+
+
+def test_regex_fallback_extracts_core_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        go_parser,
+        "get_go_parser",
+        lambda: None,
+    )
+
+    result = parse_go(
+        """package main
+
+import (
+    openai "github.com/sashabaranov/go-openai"
+)
+
+const model = "gpt-4o-mini"
+
+func (server *Server) Register() {
+    config := openai.ClientConfig{
+        Model: model,
+        Temperature: 0.2,
+        Debug: true,
+    }
+    client, err := openai.NewClient(config)
+    server.AddTool(mcp.NewTool(`search`))
+    _, _ = client, err
+}
+"""
+    )
+
+    assert result.used_tree_sitter is False
+    assert result.parse_error is None
+
+    assert [(item.path, item.alias) for item in result.imports] == [
+        (
+            "github.com/sashabaranov/go-openai",
+            "openai",
+        )
+    ]
+
+    structs = {item.class_name: item for item in result.instantiations}
+
+    calls = {item.full_name: item for item in result.function_calls}
+
+    assert structs["openai.ClientConfig"].args == {
+        "Model": "gpt-4o-mini",
+        "Temperature": 0.2,
+        "Debug": True,
+    }
+
+    assert structs["openai.ClientConfig"].assigned_to == "config"
+
+    assert structs["openai.NewClient"].assigned_to == "client"
+
+    assert "server.AddTool" in calls
+    assert "mcp.NewTool" in calls
+
+    # A method declaration is not a function call.
+    assert "server.Register" not in calls
+
+    assert any(item.value == "search" and item.is_raw for item in result.string_literals)
+
+
+def test_empty_source_returns_empty_result() -> None:
+    result = parse_go(
+        "",
+        file_path="empty.go",
+    )
+
+    assert result.file_path == "empty.go"
+    assert not result
+    assert result.parse_error is None

--- a/nuguard/sbom/tests/test_go_parser.py
+++ b/nuguard/sbom/tests/test_go_parser.py
@@ -231,6 +231,45 @@ func (server *Server) Register() {
     assert any(item.value == "search" and item.is_raw for item in result.string_literals)
 
 
+def test_regex_fallback_excludes_struct_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        go_parser,
+        "get_go_parser",
+        lambda: None,
+    )
+
+    result = parse_go(
+        r"""package main
+
+type Embedded struct{}
+
+type Tagged struct {
+    Name string `json:"name"`
+    Alias string "xml:\"alias\""
+    Embedded `yaml:",inline"`
+}
+
+func run() {
+    raw := `keep raw`
+    interpreted := "keep interpreted"
+    _, _ = raw, interpreted
+}
+"""
+    )
+
+    assert result.used_tree_sitter is False
+    assert result.parse_error is None
+
+    values = {item.value for item in result.string_literals}
+
+    assert values == {
+        "keep raw",
+        "keep interpreted",
+    }
+
+
 def test_empty_source_returns_empty_result() -> None:
     result = parse_go(
         "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "tree-sitter-typescript>=0.23",
     "python-dotenv>=1.0",
     "pathspec>=0.12",
+    "tree-sitter-go>=0.23",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1491,6 +1491,7 @@ dependencies = [
     { name = "rich" },
     { name = "structlog" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-go" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-typescript" },
     { name = "typer" },
@@ -1556,6 +1557,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'mcp'", specifier = ">=1.3.1" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tree-sitter", specifier = ">=0.23" },
+    { name = "tree-sitter-go", specifier = ">=0.23" },
     { name = "tree-sitter-javascript", specifier = ">=0.23" },
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
     { name = "typer", specifier = ">=0.12" },
@@ -2668,6 +2670,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/727308adbbc79bcb1c92fc0ea10556a735f9d0f0a5435a18f59d40f7fd77/tree_sitter_go-0.25.0.tar.gz", hash = "sha256:a7466e9b8d94dda94cae8d91629f26edb2d26166fd454d4831c3bf6dfa2e8d68", size = 93890, upload-time = "2025-08-29T06:20:25.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/aa/0984707acc2b9bb461fe4a41e7e0fc5b2b1e245c32820f0c83b3c602957c/tree_sitter_go-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b852993063a3429a443e7bd0aa376dd7dd329d595819fabf56ac4cf9d7257b54", size = 47117, upload-time = "2025-08-29T06:20:14.286Z" },
+    { url = "https://files.pythonhosted.org/packages/32/16/dd4cb124b35e99239ab3624225da07d4cb8da4d8564ed81d03fcb3a6ba9f/tree_sitter_go-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:503b81a2b4c31e302869a1de3a352ad0912ccab3df9ac9950197b0a9ceeabd8f", size = 48674, upload-time = "2025-08-29T06:20:17.557Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fb/b30d63a08044115d8b8bd196c6c2ab4325fb8db5757249a4ef0563966e2e/tree_sitter_go-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04b3b3cb4aff18e74e28d49b716c6f24cb71ddfdd66768987e26e4d0fa812f74", size = 66418, upload-time = "2025-08-29T06:20:18.345Z" },
+    { url = "https://files.pythonhosted.org/packages/26/21/d3d88a30ad007419b2c97b3baeeef7431407faf9f686195b6f1cad0aedf9/tree_sitter_go-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:148255aca2f54b90d48c48a9dbb4c7faad6cad310a980b2c5a5a9822057ed145", size = 72006, upload-time = "2025-08-29T06:20:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/0dd6442353ced8a88bbda9e546f4ea29e381b59b5a40b122e5abb586bb6c/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4d338116cdf8a6c6ff990d2441929b41323ef17c710407abe0993c13417d6aad", size = 70603, upload-time = "2025-08-29T06:20:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

- Add structured Go parsing infrastructure in
  `nuguard/sbom/core/go_parser.py`.
- Add `GoImport`, `GoInstantiation`, `GoFunctionCall`,
  `GoStringLiteral`, and `GoParseResult`.
- Expose `parse_go(content, file_path="")`.
- Prefer `tree_sitter_go` and fall back gracefully to best-effort
  regex extraction when the grammar is unavailable or cannot
  initialize.
- Add `tree-sitter-go` as a project dependency.
- Add focused coverage for both parser paths.

## Extracted information

The parser extracts:

- single and grouped imports, including aliases, blank imports, and
  dot imports;
- named struct literals and their keyed or positional values;
- conventional `New*()` constructor calls;
- function and method calls with receiver, arguments, assignment
  target, line range, and source snippet;
- raw and interpreted Go string literals;
- simple constant and variable values used in struct fields;
- partial results plus `parse_error` when tree-sitter reports
  malformed source.

## Scope

This PR is intentionally limited to the standalone parser
infrastructure requested in #174.

It does not change:

- the `.go` file-extension whitelist;
- `go.mod` or `go.sum` dependency scanning;
- framework adapters;
- extractor or pipeline wiring.

Those concerns are outside this PR and remain independent from the
work under #173.

## Tests

Added coverage for:

- real `tree_sitter_go` initialization and use;
- single and grouped imports with aliases;
- struct-literal extraction and simple value resolution;
- `New*()` constructor and method-call extraction;
- receiver and assignment-target extraction;
- raw and interpreted strings, while excluding import paths and
  struct tags;
- malformed Go source with partial results;
- a deliberately forced regex fallback;
- empty source and `file_path` propagation.

## Validation

- `python3 -m pytest nuguard/sbom/tests/test_go_parser.py -vv`
- `python3 -m pytest nuguard/sbom/tests -q`
- `python3 -m pytest -q`
- `python3 -m ruff check nuguard/`
- `python3 -m ruff format --check nuguard/sbom/core/go_parser.py nuguard/sbom/tests/test_go_parser.py`
- `python3 -m mypy nuguard/`
- `python3 -m pre_commit run --all-files`
- `git diff --check`

Closes #174