### PR TITLE
Add provider-neutral Go AI security Semgrep rules

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev --extra mcp
 
+      # Semgrep is an optional runtime scanner dependency, but Go rule-behaviour
+      # tests need the executable. Pin the version used for local validation so
+      # CI does not silently drift onto an incompatible Semgrep release.
+      - name: Install Semgrep for rule-behaviour tests
+        run: uv pip install "semgrep==1.172.0"
+
       - name: Run package unit tests
         run: uv run pytest nuguard/ -q
 

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -178,19 +178,42 @@ rules:
 
   - id: nuguard-go-llm-prompt-injection-sprintf
     mode: taint
+    # Issue #180 scope: untrusted string input must flow through fmt.Sprintf
+    # before reaching an LLM sink. USER-labeled sources alone are not enough;
+    # sinks require the FORMATTED label produced only by sprintf propagators.
+    # Trusted literals/constants/config fields are not USER sources, so
+    # trusted fmt.Sprintf -> LLM is not reported. Direct string-param -> LLM
+    # (no sprintf) keeps only USER and therefore does not match.
     pattern-sources:
-      - patterns:
-          - pattern: fmt.Sprintf($FMT, ..., $INPUT, ...)
-          - pattern-not: fmt.Sprintf($FMT)
+      - label: USER
+        patterns:
+          - pattern: |
+              func $FN(..., $INPUT string, ...) {
+                ...
+              }
+          - focus-metavariable: $INPUT
+    pattern-propagators:
+      - pattern: $TO = fmt.Sprintf(..., $FROM, ...)
+        from: $FROM
+        to: $TO
+        label: FORMATTED
+        requires: USER
+      - pattern: fmt.Sprintf(..., $FROM, ...)
+        from: $FROM
+        to: $FROM
+        label: FORMATTED
+        requires: USER
+        by-side-effect: false
     pattern-sinks:
-      - patterns:
+      - requires: FORMATTED
+        patterns:
           - pattern: $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
               regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
     message: >
-      Potential prompt injection: dynamic input is interpolated into an LLM
-      prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
+      Potential prompt injection: untrusted string input is interpolated into an
+      LLM prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
       sanitize untrusted input before including it in prompts, or use a
       parameterised template approach.
     languages: [go]
@@ -214,21 +237,18 @@ rules:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.AuthToken = os.Getenv(...)
-          - pattern-not: $CFG.AuthToken = os.LookupEnv(...)
       - patterns:
           - pattern: $CFG.APIKey = $KEY
           - metavariable-regex:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.APIKey = os.Getenv(...)
-          - pattern-not: $CFG.APIKey = os.LookupEnv(...)
       - patterns:
           - pattern: $CFG.ApiKey = $KEY
           - metavariable-regex:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.ApiKey = os.Getenv(...)
-          - pattern-not: $CFG.ApiKey = os.LookupEnv(...)
     message: >
       Hardcoded AI service API key or auth token detected. Store secrets in
       environment variables or a secrets manager. Never commit API keys to
@@ -306,6 +326,9 @@ rules:
       owasp: "LLM04: Model Denial of Service"
 
   - id: nuguard-go-llm-insecure-tls
+    # Match both value-form constructors (e.g. go-openai NewClientWithConfig(cfg))
+    # and pointer-deref forms (NewClientWithConfig(*cfg)) used by some providers.
+    # Passing a pointer config variable without dereference is covered by $CFG.
     pattern-either:
       - patterns:
           - pattern: |
@@ -323,7 +346,51 @@ rules:
                 ...
                 $CFG.HTTPClient = $HTTP
                 ...
+                $CLIENT := $NEW(..., $CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $TRANSPORT := &http.Transport{
+                  TLSClientConfig: &tls.Config{
+                    InsecureSkipVerify: true,
+                  },
+                }
+                ...
+                $HTTP := &http.Client{
+                  Transport: $TRANSPORT,
+                }
+                ...
+                $CFG.HTTPClient = $HTTP
+                ...
                 $CLIENT := $NEW(..., *$CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $CFG.HTTPClient = &http.Client{
+                  Transport: &http.Transport{
+                    TLSClientConfig: &tls.Config{
+                      InsecureSkipVerify: true,
+                    },
+                  },
+                }
+                ...
+                $CLIENT := $NEW(..., $CFG, ...)
                 ...
                 $CLIENT.$METHOD($CTX, $REQ)
                 ...

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -198,6 +198,11 @@ rules:
         to: $TO
         label: FORMATTED
         requires: USER
+      - pattern: $TO := fmt.Sprintf(..., $FROM, ...)
+        from: $FROM
+        to: $TO
+        label: FORMATTED
+        requires: USER
       - pattern: fmt.Sprintf(..., $FROM, ...)
         from: $FROM
         to: $FROM
@@ -290,7 +295,19 @@ rules:
           - pattern-not: |
               $CTX := context.Background()
               ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
               $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
               ...
               $CLIENT.$METHOD($CTX, $REQ)
       - patterns:
@@ -310,7 +327,83 @@ rules:
           - pattern-not: |
               $CTX := context.TODO()
               ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
               $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
               ...
               $CLIENT.$METHOD($CTX, $REQ)
     message: >
@@ -418,15 +511,6 @@ rules:
           - metavariable-regex:
               metavariable: $METHOD
               regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
-    pattern-not:
-      - pattern: |
-          $CFG.HTTPClient = &http.Client{
-            Transport: &http.Transport{
-              TLSClientConfig: &tls.Config{
-                InsecureSkipVerify: false,
-              },
-            },
-          }
     message: >
       HTTP client TLS configuration disables certificate verification
       (InsecureSkipVerify: true) on an HTTP client assigned to a config that is

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -1,7 +1,7 @@
 rules:
   # -------------------------------------------------------------------------
   # NuGuard AI Security Semgrep Rules
-  # Detects common AI/LLM application security anti-patterns in Python code.
+  # Detects common AI/LLM application security anti-patterns in Python and Go.
   # -------------------------------------------------------------------------
 
   - id: nuguard-llm-prompt-injection-fstring
@@ -57,12 +57,13 @@ rules:
       nuguard_rule: NGA-003
 
   - id: nuguard-openai-key-in-code
-    pattern: |
-      openai.api_key = $LITERAL
-    pattern-not: |
-      openai.api_key = os.environ[...]
-    pattern-not: |
-      openai.api_key = os.getenv(...)
+    patterns:
+      - pattern: |
+          openai.api_key = $LITERAL
+      - pattern-not: |
+          openai.api_key = os.environ[...]
+      - pattern-not: |
+          openai.api_key = os.getenv(...)
     message: >
       OpenAI API key set to a literal value rather than an environment variable.
       Use `os.environ["OPENAI_API_KEY"]` or a secrets manager.
@@ -170,3 +171,204 @@ rules:
       technology: [ml, pytorch, scikit-learn]
       owasp: "A08: Software and Data Integrity Failures"
       nuguard_rule: NGA-008
+
+  # -------------------------------------------------------------------------
+  # Go AI/LLM security rules (issue #180)
+  # -------------------------------------------------------------------------
+
+  - id: nuguard-go-llm-prompt-injection-sprintf
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: fmt.Sprintf($FMT, ..., $INPUT, ...)
+          - pattern-not: fmt.Sprintf($FMT)
+    pattern-sinks:
+      - patterns:
+          - pattern: $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+    message: >
+      Potential prompt injection: dynamic input is interpolated into an LLM
+      prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
+      sanitize untrusted input before including it in prompts, or use a
+      parameterised template approach.
+    languages: [go]
+    severity: WARNING
+    metadata:
+      category: security
+      technology: [go, llm]
+      owasp: "LLM01: Prompt Injection"
+      nuguard_rule: NGA-002
+
+  - id: nuguard-go-hardcoded-api-key
+    pattern-either:
+      - patterns:
+          - pattern: openai.DefaultConfig($KEY)
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+      - patterns:
+          - pattern: $CFG.AuthToken = $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+          - pattern-not: $CFG.AuthToken = os.Getenv(...)
+          - pattern-not: $CFG.AuthToken = os.LookupEnv(...)
+      - patterns:
+          - pattern: $CFG.APIKey = $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+          - pattern-not: $CFG.APIKey = os.Getenv(...)
+          - pattern-not: $CFG.APIKey = os.LookupEnv(...)
+      - patterns:
+          - pattern: $CFG.ApiKey = $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+          - pattern-not: $CFG.ApiKey = os.Getenv(...)
+          - pattern-not: $CFG.ApiKey = os.LookupEnv(...)
+    message: >
+      Hardcoded AI service API key or auth token detected. Store secrets in
+      environment variables or a secrets manager. Never commit API keys to
+      source control.
+    languages: [go]
+    severity: ERROR
+    metadata:
+      category: security
+      technology: [go, llm]
+      owasp: "A02: Cryptographic Failures"
+      nuguard_rule: NGA-003
+
+  - id: nuguard-go-llm-missing-context-timeout
+    pattern-either:
+      - patterns:
+          - pattern: $CLIENT.$METHOD(context.Background(), $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: $CLIENT.$METHOD(context.TODO(), $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+    message: >
+      AI/LLM request uses an unbounded root context (context.Background or
+      context.TODO) with no timeout or deadline. Unbounded LLM calls can hang
+      indefinitely and enable denial-of-service. Wrap the context with
+      context.WithTimeout or context.WithDeadline before calling the LLM API.
+    languages: [go]
+    severity: WARNING
+    metadata:
+      category: security
+      technology: [go, llm]
+      owasp: "LLM04: Model Denial of Service"
+
+  - id: nuguard-go-llm-insecure-tls
+    pattern-either:
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $TRANSPORT := &http.Transport{
+                  TLSClientConfig: &tls.Config{
+                    InsecureSkipVerify: true,
+                  },
+                }
+                ...
+                $HTTP := &http.Client{
+                  Transport: $TRANSPORT,
+                }
+                ...
+                $CFG.HTTPClient = $HTTP
+                ...
+                $CLIENT := $NEW(..., *$CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $CFG.HTTPClient = &http.Client{
+                  Transport: &http.Transport{
+                    TLSClientConfig: &tls.Config{
+                      InsecureSkipVerify: true,
+                    },
+                  },
+                }
+                ...
+                $CLIENT := $NEW(..., *$CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+    pattern-not:
+      - pattern: |
+          $CFG.HTTPClient = &http.Client{
+            Transport: &http.Transport{
+              TLSClientConfig: &tls.Config{
+                InsecureSkipVerify: false,
+              },
+            },
+          }
+    message: >
+      HTTP client TLS configuration disables certificate verification
+      (InsecureSkipVerify: true) on an HTTP client assigned to a config that is
+      then used to construct the AI/LLM client for an API call. This enables
+      man-in-the-middle attacks against LLM API traffic. Use the default TLS
+      settings or pin trusted certificates.
+    languages: [go]
+    severity: ERROR
+    metadata:
+      category: security
+      technology: [go, llm, tls]
+      owasp: "A02: Cryptographic Failures"

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
@@ -12,24 +12,34 @@ func (s secretStore) Get(name string) string { return "from-store" }
 
 func HardcodedKeyFromEnv() {
 	cfg := openai.DefaultConfig(os.Getenv("AI_API_TOKEN"))
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = openai.NewClientWithConfig(cfg)
 }
 
 func HardcodedKeyFromLookupEnv() {
-	cfg := openai.DefaultConfig("")
-	cfg.AuthToken = os.LookupEnv("AI_API_TOKEN")
-	_ = openai.NewClientWithConfig(*cfg)
+	token, ok := os.LookupEnv("AI_API_TOKEN")
+	if !ok {
+		return
+	}
+	cfg := providerConfig{}
+	cfg.AuthToken = token
+	_ = cfg
 }
 
 func HardcodedKeyFromSecretStore() {
 	store := secretStore{}
-	cfg := openai.DefaultConfig("")
+	cfg := providerConfig{}
 	cfg.APIKey = store.Get("openai-key")
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = cfg
+}
+
+func HardcodedKeyApiKeyFromEnv() {
+	cfg := providerConfig{}
+	cfg.ApiKey = os.Getenv("AI_API_TOKEN")
+	_ = cfg
 }
 
 func HarmlessStringAssignment() {
 	cfg := openai.DefaultConfig("")
 	cfg.BaseURL = "https://api.example.com/v1"
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = openai.NewClientWithConfig(cfg)
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
@@ -1,0 +1,35 @@
+package semgrepfixtures
+
+import (
+	"os"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type secretStore struct{}
+
+func (s secretStore) Get(name string) string { return "from-store" }
+
+func HardcodedKeyFromEnv() {
+	cfg := openai.DefaultConfig(os.Getenv("AI_API_TOKEN"))
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedKeyFromLookupEnv() {
+	cfg := openai.DefaultConfig("")
+	cfg.AuthToken = os.LookupEnv("AI_API_TOKEN")
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedKeyFromSecretStore() {
+	store := secretStore{}
+	cfg := openai.DefaultConfig("")
+	cfg.APIKey = store.Get("openai-key")
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HarmlessStringAssignment() {
+	cfg := openai.DefaultConfig("")
+	cfg.BaseURL = "https://api.example.com/v1"
+	_ = openai.NewClientWithConfig(*cfg)
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
@@ -1,0 +1,22 @@
+package semgrepfixtures
+
+import (
+	"github.com/sashabaranov/go-openai"
+)
+
+func HardcodedOpenAIDefaultConfig() {
+	cfg := openai.DefaultConfig("sk-SYNTHETIC_TEST_KEY_001")
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedAuthTokenAssignment() {
+	cfg := openai.DefaultConfig("")
+	cfg.AuthToken = "sk-SYNTHETIC_TEST_KEY_002"
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedAPIKeyField() {
+	cfg := openai.DefaultConfig("")
+	cfg.APIKey = "AIzaSYNTHETIC_TEST_KEY_003"
+	_ = openai.NewClientWithConfig(*cfg)
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
@@ -4,19 +4,33 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+// providerConfig is a minimal local type that preserves provider-neutral
+// credential field names without pretending go-openai.ClientConfig exposes them.
+type providerConfig struct {
+	AuthToken string
+	APIKey    string
+	ApiKey    string
+}
+
 func HardcodedOpenAIDefaultConfig() {
 	cfg := openai.DefaultConfig("sk-SYNTHETIC_TEST_KEY_001")
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = openai.NewClientWithConfig(cfg)
 }
 
 func HardcodedAuthTokenAssignment() {
-	cfg := openai.DefaultConfig("")
+	cfg := providerConfig{}
 	cfg.AuthToken = "sk-SYNTHETIC_TEST_KEY_002"
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = cfg
 }
 
 func HardcodedAPIKeyField() {
-	cfg := openai.DefaultConfig("")
+	cfg := providerConfig{}
 	cfg.APIKey = "AIzaSYNTHETIC_TEST_KEY_003"
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = cfg
+}
+
+func HardcodedApiKeyField() {
+	cfg := providerConfig{}
+	cfg.ApiKey = "sk-SYNTHETIC_TEST_KEY_004"
+	_ = cfg
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
@@ -57,5 +57,5 @@ func UnrelatedHTTPClientField(cfg genericHTTPConfig) {
 	}
 	httpClient := &http.Client{Transport: transport}
 	cfg.HTTPClient = httpClient
-	_ = cfg.HTTPClient.Get("https://example.com")
+	_, _ = cfg.HTTPClient.Get("https://example.com")
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
@@ -1,0 +1,61 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type internalConfig struct {
+	HTTPClient *http.Client
+}
+
+func UnrelatedClientsSameFunction(ctx context.Context, llmClient *openai.Client, request openai.ChatCompletionRequest) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	unrelatedHTTP := &http.Client{Transport: transport}
+	internalConfig := internalConfig{}
+	internalConfig.HTTPClient = unrelatedHTTP
+
+	llmClient.CreateChatCompletion(ctx, request)
+}
+
+func SecureTLSExplicitFalse() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: false,
+		},
+	}
+	_ = &http.Client{Transport: transport}
+}
+
+func DefaultSecureTransport() {
+	_ = &http.Client{}
+}
+
+func UnrelatedTLSNoLLMContext() {
+	cfg := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	_ = cfg
+}
+
+type genericHTTPConfig struct {
+	HTTPClient *http.Client
+}
+
+func UnrelatedHTTPClientField(cfg genericHTTPConfig) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	cfg.HTTPClient = httpClient
+	_ = cfg.HTTPClient.Get("https://example.com")
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
@@ -1,0 +1,45 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func InsecureTLSWithLLMClient() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	cfg := openai.DefaultConfig("test-token")
+	cfg.HTTPClient = httpClient
+	client := openai.NewClientWithConfig(*cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func InsecureTLSNestedClientLiteral() {
+	cfg := openai.DefaultConfig("test-token")
+	cfg.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	client := openai.NewClientWithConfig(*cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
@@ -8,6 +8,22 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+// providerHTTPConfig is a minimal local config type used to exercise the
+// pointer-dereference constructor form (*cfg) in a compile-valid way without
+// pretending go-openai's ClientConfig is itself a pointer API.
+type providerHTTPConfig struct {
+	HTTPClient *http.Client
+}
+
+type providerLLMClient struct{}
+
+func newProviderLLMClient(cfg providerHTTPConfig) *providerLLMClient {
+	return &providerLLMClient{}
+}
+
+func (c *providerLLMClient) CreateChatCompletion(ctx context.Context, req openai.ChatCompletionRequest) {
+}
+
 func InsecureTLSWithLLMClient() {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -17,7 +33,7 @@ func InsecureTLSWithLLMClient() {
 	httpClient := &http.Client{Transport: transport}
 	cfg := openai.DefaultConfig("test-token")
 	cfg.HTTPClient = httpClient
-	client := openai.NewClientWithConfig(*cfg)
+	client := openai.NewClientWithConfig(cfg)
 	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
@@ -35,7 +51,25 @@ func InsecureTLSNestedClientLiteral() {
 			},
 		},
 	}
-	client := openai.NewClientWithConfig(*cfg)
+	client := openai.NewClientWithConfig(cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func InsecureTLSPointerDerefConfig() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	cfg := &providerHTTPConfig{}
+	cfg.HTTPClient = httpClient
+	client := newProviderLLMClient(*cfg)
 	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
@@ -1,0 +1,49 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func BoundedContextWithTimeout() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextWithDeadline() {
+	deadline := time.Now().Add(30 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func NonLLMBackgroundContext(db *sql.DB) {
+	ctx := context.Background()
+	_ = db.QueryContext(ctx, "SELECT 1")
+}
+
+func LLMWithParameterContext(ctx context.Context) {
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
@@ -33,6 +33,184 @@ func BoundedContextWithDeadline() {
 	})
 }
 
+func BoundedContextBackgroundAssignWithTimeout() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	ctx = context.Background()
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextBackgroundAssignWithDeadline() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.Background()
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextTODOAssignWithTimeout() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	ctx = context.TODO()
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextTODOAssignWithDeadline() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.TODO()
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclBackgroundAssignTimeout() {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclTODOAssignTimeout() {
+	ctx := context.TODO()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclBackgroundAssignDeadline() {
+	deadline := time.Now().Add(30 * time.Second)
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclTODOAssignDeadline() {
+	deadline := time.Now().Add(30 * time.Second)
+	ctx := context.TODO()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignBackgroundShortDeclTimeout() {
+	var ctx context.Context
+	ctx = context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignTODOShortDeclTimeout() {
+	var ctx context.Context
+	ctx = context.TODO()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignBackgroundShortDeclDeadline() {
+	var ctx context.Context
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.Background()
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignTODOShortDeclDeadline() {
+	var ctx context.Context
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.TODO()
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
 func NonLLMBackgroundContext(db *sql.DB) {
 	ctx := context.Background()
 	_, _ = db.QueryContext(ctx, "SELECT 1")

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
@@ -35,7 +35,7 @@ func BoundedContextWithDeadline() {
 
 func NonLLMBackgroundContext(db *sql.DB) {
 	ctx := context.Background()
-	_ = db.QueryContext(ctx, "SELECT 1")
+	_, _ = db.QueryContext(ctx, "SELECT 1")
 }
 
 func LLMWithParameterContext(ctx context.Context) {

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_positive.go
@@ -1,0 +1,28 @@
+package semgrepfixtures
+
+import (
+	"context"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func MissingTimeoutAssignmentThenCall() {
+	ctx := context.Background()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func MissingTimeoutInlineBackground() {
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+type appConfig struct {
+	Model string
+}
+
+// Case 4: user/dynamic input -> fmt.Sprintf, but no LLM sink.
 func OrdinarySprintfNoLLM(orderID string) {
 	message := fmt.Sprintf("order %s", orderID)
 	log.Println(message)
@@ -23,6 +28,48 @@ func StaticLLMPrompt() {
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+// Case 2: trusted literal/constant -> fmt.Sprintf -> LLM.
+func TrustedFormattedPromptReachesLLM() {
+	model := "internal-model"
+	prompt := fmt.Sprintf("Use model %s", model)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+// Case 3: trusted application-configuration value -> fmt.Sprintf -> LLM.
+func TrustedAppConfigFormattedPromptReachesLLM(cfg appConfig) {
+	prompt := fmt.Sprintf("Use model %s", cfg.Model)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+// Case 5: string parameter -> LLM directly, with no fmt.Sprintf.
+func DirectStringParamToLLM(userInput string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: userInput},
 		},
 	})
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
@@ -1,0 +1,28 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func OrdinarySprintfNoLLM(orderID string) {
+	message := fmt.Sprintf("order %s", orderID)
+	log.Println(message)
+}
+
+func StaticLLMPrompt() {
+	prompt := "fixed prompt"
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_positive.go
@@ -1,0 +1,29 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func PromptInjectionAssignmentThenCall(userInput string) {
+	prompt := fmt.Sprintf("Answer this user: %s", userInput)
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+func PromptInjectionInlineCall(userInput string) {
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: fmt.Sprintf("Summarize: %s", userInput)},
+		},
+	})
+}

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -1,0 +1,204 @@
+"""Semgrep Go AI-security rule tests for bundled ai-security.yaml.
+
+Runs the four Go rules against annotated fixture files. Skips when semgrep is
+not installed on PATH (same behaviour as SemgrepScannerPlugin).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+_RULES = Path(__file__).parent.parent / "plugins" / "semgrep_rules" / "ai-security.yaml"
+_FIXTURES = Path(__file__).parent / "fixtures" / "semgrep_go"
+
+_GO_RULE_IDS = frozenset(
+    {
+        "nuguard-go-llm-prompt-injection-sprintf",
+        "nuguard-go-hardcoded-api-key",
+        "nuguard-go-llm-missing-context-timeout",
+        "nuguard-go-llm-insecure-tls",
+    }
+)
+
+
+def _semgrep_binary() -> str | None:
+    return shutil.which("semgrep")
+
+
+def _run_semgrep_on_fixtures() -> dict[str, list[dict[str, object]]]:
+    """Run bundled rules on all Go fixture files; return findings keyed by filename."""
+    binary = _semgrep_binary()
+    if binary is None:
+        pytest.skip("semgrep not installed — Go rule tests skipped")
+
+    files = sorted(_FIXTURES.glob("*.go"))
+    if not files:
+        pytest.fail(f"no Go fixtures found in {_FIXTURES}")
+
+    cmd = [
+        binary,
+        "--quiet",
+        "--json",
+        "--config",
+        str(_RULES),
+        *[str(f) for f in files],
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode not in (0, 1):
+        pytest.fail(f"semgrep exited {result.returncode}: {result.stderr.strip()}")
+
+    data = json.loads(result.stdout)
+    by_file: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in data.get("results") or []:
+        path = str(row.get("path", ""))
+        filename = Path(path).name
+        check_id = str(row.get("check_id", ""))
+        rule_id = check_id.rsplit(".", 1)[-1]
+        start = row.get("start") or {}
+        by_file[filename].append(
+            {
+                "rule_id": rule_id,
+                "line": start.get("line"),
+            }
+        )
+    return by_file
+
+
+@pytest.fixture(scope="module")
+def semgrep_findings() -> dict[str, list[dict[str, object]]]:
+    return _run_semgrep_on_fixtures()
+
+
+def _rule_lines(
+    findings: dict[str, list[dict[str, object]]],
+    filename: str,
+    rule_id: str,
+) -> list[int]:
+    rows = findings.get(filename, [])
+    lines: list[int] = []
+    for row in rows:
+        if row["rule_id"] != rule_id:
+            continue
+        line = row.get("line")
+        if isinstance(line, int):
+            lines.append(line)
+    return sorted(lines)
+
+
+def _assert_no_rule(
+    findings: dict[str, list[dict[str, object]]],
+    filename: str,
+    rule_id: str,
+) -> None:
+    hits = _rule_lines(findings, filename, rule_id)
+    assert hits == [], f"unexpected {rule_id} on {filename}: lines {hits}"
+
+
+class TestGoPromptInjectionSprintf:
+    def test_positive_assignment_and_inline(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "prompt_injection_positive.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+        assert lines == [13, 23]
+
+    def test_negative_ordinary_sprintf(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+    def test_negative_static_prompt(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+
+class TestGoHardcodedApiKey:
+    def test_positive_literals(self, semgrep_findings: dict[str, list[dict[str, object]]]) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "hardcoded_key_positive.go",
+            "nuguard-go-hardcoded-api-key",
+        )
+        assert lines == [8, 14, 20]
+
+    def test_negative_env_and_store(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "hardcoded_key_negative.go",
+            "nuguard-go-hardcoded-api-key",
+        )
+
+
+class TestGoMissingContextTimeout:
+    def test_positive_background_context(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "missing_timeout_positive.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+        assert lines == [10, 22]
+
+    def test_negative_bounded_and_non_llm(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "missing_timeout_negative.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+
+
+class TestGoInsecureTls:
+    def test_positive_llm_client_transport(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "insecure_tls_positive.go",
+            "nuguard-go-llm-insecure-tls",
+        )
+        assert lines == [11, 29]
+
+    def test_negative_secure_and_unrelated(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "insecure_tls_negative.go",
+            "nuguard-go-llm-insecure-tls",
+        )
+
+
+class TestGoRuleInventory:
+    def test_only_expected_go_rules_fire_on_fixtures(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        fired: set[str] = set()
+        for rows in semgrep_findings.values():
+            for row in rows:
+                rule_id = str(row["rule_id"])
+                if rule_id in _GO_RULE_IDS:
+                    fired.add(rule_id)
+        assert fired == _GO_RULE_IDS

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -1,12 +1,14 @@
 """Semgrep Go AI-security rule tests for bundled ai-security.yaml.
 
 Runs the four Go rules against annotated fixture files. Skips when semgrep is
-not installed on PATH (same behaviour as SemgrepScannerPlugin).
+not installed on PATH (same behaviour as SemgrepScannerPlugin). In CI, missing
+semgrep is a hard failure so rule-behaviour regressions cannot silently skip.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from collections import defaultdict
@@ -35,6 +37,11 @@ def _run_semgrep_on_fixtures() -> dict[str, list[dict[str, object]]]:
     """Run bundled rules on all Go fixture files; return findings keyed by filename."""
     binary = _semgrep_binary()
     if binary is None:
+        if os.environ.get("CI"):
+            pytest.fail(
+                "semgrep is required in CI for Go rule-behaviour tests; "
+                "install semgrep before running pytest"
+            )
         pytest.skip("semgrep not installed — Go rule tests skipped")
 
     files = sorted(_FIXTURES.glob("*.go"))
@@ -101,9 +108,10 @@ def _assert_no_rule(
 
 
 class TestGoPromptInjectionSprintf:
-    def test_positive_assignment_and_inline(
+    def test_case1_untrusted_through_sprintf_to_llm(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
     ) -> None:
+        """user/external/dynamic input -> fmt.Sprintf -> LLM = MATCH."""
         lines = _rule_lines(
             semgrep_findings,
             "prompt_injection_positive.go",
@@ -111,18 +119,40 @@ class TestGoPromptInjectionSprintf:
         )
         assert lines == [13, 23]
 
-    def test_negative_ordinary_sprintf(
+    def test_case2_trusted_literal_sprintf_to_llm(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
     ) -> None:
+        """trusted literal/constant -> fmt.Sprintf -> LLM = NO MATCH."""
         _assert_no_rule(
             semgrep_findings,
             "prompt_injection_negative.go",
             "nuguard-go-llm-prompt-injection-sprintf",
         )
 
-    def test_negative_static_prompt(
+    def test_case3_trusted_app_config_sprintf_to_llm(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
     ) -> None:
+        """trusted application-configuration value -> fmt.Sprintf -> LLM = NO MATCH."""
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+    def test_case4_sprintf_without_llm_sink(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        """user/dynamic input -> fmt.Sprintf but no LLM sink = NO MATCH."""
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+    def test_case5_direct_string_param_to_llm_without_sprintf(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        """string parameter -> LLM directly, with no fmt.Sprintf = NO MATCH."""
         _assert_no_rule(
             semgrep_findings,
             "prompt_injection_negative.go",
@@ -137,7 +167,7 @@ class TestGoHardcodedApiKey:
             "hardcoded_key_positive.go",
             "nuguard-go-hardcoded-api-key",
         )
-        assert lines == [8, 14, 20]
+        assert lines == [16, 22, 28, 34]
 
     def test_negative_env_and_store(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
@@ -179,7 +209,7 @@ class TestGoInsecureTls:
             "insecure_tls_positive.go",
             "nuguard-go-llm-insecure-tls",
         )
-        assert lines == [11, 29]
+        assert lines == [27, 45, 63]
 
     def test_negative_secure_and_unrelated(
         self, semgrep_findings: dict[str, list[dict[str, object]]]

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -228,7 +228,5 @@ class TestGoRuleInventory:
         fired: set[str] = set()
         for rows in semgrep_findings.values():
             for row in rows:
-                rule_id = str(row["rule_id"])
-                if rule_id in _GO_RULE_IDS:
-                    fired.add(rule_id)
+                fired.add(str(row["rule_id"]))
         assert fired == _GO_RULE_IDS


### PR DESCRIPTION
## Summary

Fixes #180.

Adds four Go rules to NuGuard's bundled AI-security Semgrep ruleset:

- Dynamic `fmt.Sprintf` data flowing into common LLM request methods
- Hardcoded AI-service API keys and authentication tokens
- LLM requests using unbounded `context.Background()` or `context.TODO()`
- Insecure TLS configuration structurally connected to an LLM client's HTTP configuration and request path

`SemgrepScannerPlugin` is unchanged because Semgrep already supports Go.

## Provider-neutral matching

The rules use common LLM operation shapes and method names rather than requiring a specific provider package.

The insecure-TLS rule links:

1. the insecure `http.Transport`
2. the configured `http.Client`
3. the client configuration
4. construction of the client from that configuration
5. an LLM request performed by that same client

This avoids reporting unrelated insecure HTTP clients that merely appear in the same function as a separate LLM call.

## False-positive controls

Tests verify that the rules do not report:

- ordinary `fmt.Sprintf` use
- static prompts
- credentials loaded from environment variables or secret stores
- bounded contexts using `WithTimeout` or `WithDeadline`
- non-LLM uses of root contexts
- `InsecureSkipVerify: false`
- unrelated TLS configurations
- an unrelated insecure HTTP client located in the same function as an independent LLM call

Fixtures use synthetic credentials only.

## Existing YAML correction

The existing `nuguard-openai-key-in-code` rule contained duplicate `pattern-not` YAML keys. It now uses a `patterns` list that preserves both intended exclusions and allows current Semgrep versions to validate the complete bundled ruleset.

## Validation

- Focused Go Semgrep tests — passed
- Bundled ruleset validation — 14 rules, 0 configuration errors
- Full test suite — passed
- Lint and type checks — passed
- Pre-commit checks — passed
- `git diff --check` — passed

The Go Semgrep tests skip when the optional Semgrep executable is unavailable, matching the scanner's optional-runtime behavior. They were executed locally against the installed Semgrep version and all positive and negative cases passed.