### PR TITLE
Add bug/feature PR and issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,10 @@ Thanks for contributing. This project accepts issues and pull requests from the 
 - Read the [Code of Conduct](./CODE_OF_CONDUCT.md).
 - For security-sensitive reports, use [SECURITY.md](./SECURITY.md) instead of public issues.
 - Check existing issues and pull requests to avoid duplicate work.
+- When opening an issue, pick the **Bug Report** or **Feature Request** template
+  (`.github/ISSUE_TEMPLATE/`) — each auto-applies the matching `bug`/`enhancement`
+  label and ends with a hidden `<!-- issue-type: bug -->` / `<!-- issue-type: feature -->`
+  marker for automation; leave it in place.
 
 ## Development Setup
 
@@ -45,6 +49,10 @@ All four checks (`test`, `lint`, `fmt` check, and pre-commit) should pass locall
 - Update docs when user-facing behavior changes.
 - Do not include secrets, credentials, or private data.
 - Run `make test` and `make lint` locally before opening the PR.
+- When opening a PR, use the "Choose a template" link to pick either the **Bug Fix**
+  or **Feature** template (`.github/PULL_REQUEST_TEMPLATE/`). Each ends with a hidden
+  `<!-- pr-type: bug -->` / `<!-- pr-type: feature -->` marker — leave it in place; it's
+  read by automation to classify the PR, not meant to be edited.
 
 Include in the PR description:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report something that isn't working as expected
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Expected Behavior
+
+<!--- What should happen? -->
+
+## Current Behavior
+
+<!--- What happens instead of the expected behavior? -->
+
+## Steps to Reproduce
+
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code/commands to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+
+## Environment
+
+- NuGuard version / commit:
+- Python version:
+- OS:
+- Relevant config (`nuguard.yaml` snippet, CLI command, etc.):
+
+<!-- issue-type: bug -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/NuGuardAI/nuguard/security/policy
+    about: Please report security vulnerabilities privately per SECURITY.md — do not open a public issue.
+  - name: Question / Discussion
+    url: https://github.com/NuGuardAI/nuguard/discussions
+    about: For general questions or discussion that isn't a bug or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a new feature, enhancement, or change
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Expected Behavior
+
+<!--- Tell us how the new feature/change should work -->
+
+## Current Behavior
+
+<!--- What happens today, and how is it different from what you're proposing? -->
+
+## Possible Solution
+
+<!--- Not obligatory, but share ideas on how to implement this -->
+
+## Context
+
+<!--- What are you trying to accomplish? Why is this useful? -->
+<!--- Link any related issues, discussions, or prior art -->
+
+<!-- issue-type: feature -->

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,62 @@
+## What
+
+What changed at a high level?
+
+Example:
+- Fixed...
+- Corrected...
+- Patched...
+
+## Why
+
+Why was this a bug? What was the user-visible or system impact?
+
+**Example:**
+- Reported in issue #...
+- Caused incorrect output when...
+- Crashed / hung when...
+
+## Root Cause
+
+What was actually causing the bug?
+
+**Example:**
+- An off-by-one error in...
+- A race condition between...
+- Missing null check on...
+
+## How
+
+How did you fix it?
+
+Example:
+- Paired with <Teammate Name> where we did A, B, C
+- Tried another approach but it didn't work because X, Y, Z
+- Used these code APIs/SDKs: <Name>, <Name>, <Name>
+
+## Test Steps
+
+What are all the steps to verify the fix (and confirm no regression)?
+
+**Example:**
+- [ ] Reproduce the bug on `main` using these steps: ...
+- [ ] Confirm the bug no longer occurs on this branch
+- [ ] Added a regression test covering this case
+
+## Checks
+
+- [ ] `make test` passes (`uv run pytest tests/ -v`)
+- [ ] `make lint` passes (`ruff check` + `mypy`)
+- [ ] `make fmt` applied, no diff
+- [ ] Added/updated a regression test for this bug
+
+## Other Notes
+
+What, if anything, hasn't been addressed in these code changes but should be in future changes?
+
+**Example:**
+- ABC wasn't working as expected...
+- XYZ needs more research...
+- A fast-follow PR is already planned for addressing 1, 2, 3...
+
+<!-- pr-type: bug -->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,57 @@
+## What
+
+What changes did you make at a high level?
+
+Example:
+- Added...
+- Updated...
+- Refactored...
+- Moved...
+
+## Why
+
+Why are these changes helpful or necessary?
+
+**Example:**
+- New feature requested...
+- Refactoring in preparation for...
+- Addressing design feedback...
+- Fast-follow to previous PR...
+
+## How
+
+How did you go about making these changes?
+
+Example:
+- Paired with <Teammate Name> where we did A, B, C
+- Tried another approach but it didn't work because X, Y, Z
+- I followed this resource by <Author Name>: <Resource Link>
+- Used these code APIs/SDKs: <Name>, <Name>, <Name>
+
+## Test Steps
+
+What are all the steps to testing your code changes?
+
+**Example:**
+- [ ] Enable `feature_flag`
+- [ ] Go to this page: /a-test-page
+- [ ] Simulate "Browser Feature"
+- [ ] Etc...
+
+## Checks
+
+- [ ] `make test` passes (`uv run pytest tests/ -v`)
+- [ ] `make lint` passes (`ruff check` + `mypy`)
+- [ ] `make fmt` applied, no diff
+- [ ] Added/updated tests covering this feature
+
+## Other Notes
+
+What, if anything, hasn't been addressed in these code changes but should be in future changes?
+
+**Example:**
+- ABC wasn't working as expected...
+- XYZ needs more research...
+- A fast-follow PR is already planned for addressing 1, 2, 3...
+
+<!-- pr-type: feature -->


### PR DESCRIPTION
## What

- Split the PR template into two: `.github/PULL_REQUEST_TEMPLATE/bug_fix.md` and `feature.md`, selectable via GitHub's "Choose a template" link.
- Split the issue template into two: `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`, plus a `config.yml` to enable the chooser (with contact links to Security policy / Discussions instead of a blank issue for those cases).
- Updated `CONTRIBUTING.md` to point contributors at the new templates.

## Why

Closes #168, closes #169. Standardizes PR/issue structure and gives each type its own tailored fields (e.g. bug reports get Steps to Reproduce + Environment; features skip repro steps).

## How

- Each PR template ends with a hidden marker (`<!-- pr-type: bug -->` / `<!-- pr-type: feature -->`) that a future GitHub Action can parse from the PR body to classify it.
- Each issue template auto-applies the matching `bug`/`enhancement` label via front matter (the repo already has both labels) and also ends with a matching hidden `<!-- issue-type: ... -->` comment for consistency.
- Both PR templates add a **Checks** section with checkboxes for `make test` / `make lint` / `make fmt` (from CLAUDE.md), plus a type-specific test-coverage checkbox.

## Test Steps

- [ ] Open a new PR against this repo and confirm the "Choose a template" link shows both Bug Fix and Feature options.
- [ ] Open a new issue and confirm the picker shows Bug Report / Feature Request / Security / Question links, and that selecting Bug Report applies the `bug` label (Feature Request applies `enhancement`).

## Other Notes

Docs-only change — no code paths touched.