### PR TITLE
Document branch naming convention in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,6 +42,14 @@ make precommit-run
 
 All four checks (`test`, `lint`, `fmt` check, and pre-commit) should pass locally before you open a PR — the [PR Tests](workflows/pr-tests.yml) workflow re-runs lint and type checks on every pull request.
 
+## Branch Naming
+
+Branch names are enforced server-side by a repository ruleset — a push that doesn't match is rejected outright, not just flagged in review.
+
+- Format: `feat/<short-description>` or `bug/<short-description>` — lowercase, hyphenated (e.g. `feat/add-pr-templates`, `bug/fix-null-check`).
+- `main` and `develop` are exempt from the rule.
+- Only applies going forward: existing branches that predate the rule aren't affected, and it only blocks *creating* a new non-conforming branch, not pushing further commits to one you already have.
+
 ## Pull Request Guidelines
 
 - Keep PRs focused and small enough to review.


### PR DESCRIPTION
## What

Adds a **Branch Naming** section to `CONTRIBUTING.md`.

## Why

A repository ruleset now enforces `feat/<desc>` / `bug/<desc>` branch names server-side (rejects non-conforming pushes), but there was no documentation telling contributors the format, that `main`/`develop` are exempt, or that it's forward-looking only (existing branches unaffected).

## How

Added a short section between "Running Tests, Lint, and Format" and "Pull Request Guidelines" covering the format, exemptions, and scope.

## Test Steps

- [ ] Read the new section, confirm it matches the actual ruleset config on the repo (`.github` settings → Rules → "Enforce Branch naming convention").

## Checks

- [x] Docs-only change.

## Other Notes

None.