### PR TITLE
Add develop/main branch workflow automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Workflow files control what CI enforces and what has access to repo secrets.
+# Require the engineering team to review any change here before it can merge.
+/.github/workflows/ @NuGuardAI/ent:engineering

--- a/.github/rulesets/required-status-checks.json
+++ b/.github/rulesets/required-status-checks.json
@@ -1,0 +1,38 @@
+{
+  "name": "Require status checks",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main", "refs/heads/develop"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "check-base"
+          },
+          {
+            "context": "require-linked-issue"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/required-status-checks.json
+++ b/.github/rulesets/required-status-checks.json
@@ -14,7 +14,7 @@
       "parameters": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
-        "require_code_owner_review": false,
+        "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false
       }

--- a/.github/workflows/cherry-pick-to-develop.yml
+++ b/.github/workflows/cherry-pick-to-develop.yml
@@ -13,6 +13,13 @@ on:
   push:
     branches: [main]
 
+# find-pr reads commit/PR data with the default token; cherry-pick's actual
+# writes (push, PR create, issue comment) all go through the separate
+# CHERRY_PICK_BOT_TOKEN secret, never GITHUB_TOKEN, so read-only suffices here.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   find-pr:
     if: vars.ENFORCE_GIT_WORKFLOW == 'true'

--- a/.github/workflows/cherry-pick-to-develop.yml
+++ b/.github/workflows/cherry-pick-to-develop.yml
@@ -1,0 +1,107 @@
+name: Cherry-pick bug fix to develop
+
+# push (not pull_request) so github.ref resolves cleanly to refs/heads/main,
+# matching the cherry-pick-bot environment's branch policy. pull_request-family
+# events resolve to refs/pull/<n>/merge instead, which never matches a literal
+# branch name in an environment's deployment branch policy — using push avoids
+# that ambiguity instead of working around it.
+#
+# Also safe for the same reason as cherry-pick-to-develop always was: this only
+# fires after a commit has already landed on main, so the workflow definition
+# that runs is already the reviewed version on main.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  find-pr:
+    if: vars.ENFORCE_GIT_WORKFLOW == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      is_bug_merge: ${{ steps.pr.outputs.is_bug_merge }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    steps:
+      - name: Identify the PR this push came from
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_number=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[0].number // empty')
+
+          if [[ -z "$pr_number" ]]; then
+            echo "is_bug_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_json=$(gh pr view "$pr_number" --repo "${{ github.repository }}" \
+            --json headRefName,baseRefName,merged)
+          head_ref=$(echo "$pr_json" | jq -r .headRefName)
+          base_ref=$(echo "$pr_json" | jq -r .baseRefName)
+          merged=$(echo "$pr_json" | jq -r .merged)
+
+          if [[ "$merged" == "true" && "$head_ref" == bug/* && "$base_ref" == "main" ]]; then
+            echo "is_bug_merge=true" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bug_merge=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  cherry-pick:
+    needs: find-pr
+    if: needs.find-pr.outputs.is_bug_merge == 'true'
+    runs-on: ubuntu-latest
+    environment: cherry-pick-bot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CHERRY_PICK_BOT_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "nuguard-bot"
+          git config user.email "nuguard-bot@users.noreply.github.com"
+
+      - name: Cherry-pick merge commit onto a new branch
+        id: cherry
+        env:
+          PR_NUMBER: ${{ needs.find-pr.outputs.pr_number }}
+        run: |
+          set -e
+          BRANCH="cherry-pick/${PR_NUMBER}-into-develop"
+          git fetch origin develop
+          git checkout -b "$BRANCH" origin/develop
+          if git cherry-pick -m 1 "${{ github.sha }}"; then
+            git push origin "$BRANCH"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            git cherry-pick --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open cherry-pick PR
+        if: steps.cherry.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.CHERRY_PICK_BOT_TOKEN }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.pr_number }}
+        run: |
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base develop \
+            --head "${{ steps.cherry.outputs.branch }}" \
+            --title "Cherry-pick #${PR_NUMBER} into develop" \
+            --body "Automated cherry-pick of #${PR_NUMBER} (merged into \`main\`) onto \`develop\`. Please review and merge — not auto-merged." \
+            --label "cherry-pick"
+
+      - name: Notify on conflict
+        if: steps.cherry.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CHERRY_PICK_BOT_TOKEN }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.pr_number }}
+        run: |
+          gh issue comment "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --body "⚠️ Automated cherry-pick to \`develop\` failed due to a merge conflict. A maintainer needs to cherry-pick this manually."

--- a/.github/workflows/enforce-base-branch.yml
+++ b/.github/workflows/enforce-base-branch.yml
@@ -1,0 +1,54 @@
+name: Enforce PR base branch
+
+# Runs as pull_request_target (not pull_request) so the checks always execute
+# using the workflow definition already merged on the base branch, not
+# whatever a contributor's own branch contains. Safe here because this job
+# never checks out or executes the PR's code — it only reads PR metadata.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-base:
+    if: vars.ENFORCE_GIT_WORKFLOW == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Determine expected base branch
+        id: validate
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          expected=""
+          case "$HEAD_REF" in
+            feat/*) expected="develop" ;;
+            bug/*) expected="main" ;;
+            cherry-pick/*) expected="develop" ;;
+          esac
+
+          if [[ -n "$expected" && "$BASE_REF" != "$expected" ]]; then
+            echo "expected=$expected" >> "$GITHUB_OUTPUT"
+            echo "invalid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "invalid=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment with the correct base branch
+        if: steps.validate.outputs.invalid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED: ${{ steps.validate.outputs.expected }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "🚫 \`${{ github.head_ref }}\` must target \`$EXPECTED\`, not \`${{ github.base_ref }}\`. Please change the base branch — click **Edit** at the top of this PR and set base to \`$EXPECTED\` — then push again."
+
+      - name: Fail if base branch is wrong
+        if: steps.validate.outputs.invalid == 'true'
+        env:
+          EXPECTED: ${{ steps.validate.outputs.expected }}
+        run: |
+          echo "::error::${{ github.head_ref }} must target $EXPECTED, not ${{ github.base_ref }}"
+          exit 1

--- a/.github/workflows/enforce-base-branch.yml
+++ b/.github/workflows/enforce-base-branch.yml
@@ -4,6 +4,12 @@ name: Enforce PR base branch
 # using the workflow definition already merged on the base branch, not
 # whatever a contributor's own branch contains. Safe here because this job
 # never checks out or executes the PR's code — it only reads PR metadata.
+#
+# No comment-on-failure step: the org's Actions permission ceiling is
+# read-only, so GITHUB_TOKEN can't post PR comments regardless of what
+# permissions: this job declares (a job can only narrow the token's ceiling,
+# never expand past the repo/org default). The ::error:: annotation below
+# still surfaces on the PR's Checks tab without needing any write permission.
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
@@ -12,11 +18,8 @@ jobs:
   check-base:
     if: vars.ENFORCE_GIT_WORKFLOW == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-      - name: Determine expected base branch
-        id: validate
+      - name: Validate base branch matches branch type
         env:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
@@ -29,26 +32,6 @@ jobs:
           esac
 
           if [[ -n "$expected" && "$BASE_REF" != "$expected" ]]; then
-            echo "expected=$expected" >> "$GITHUB_OUTPUT"
-            echo "invalid=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "invalid=false" >> "$GITHUB_OUTPUT"
+            echo "::error::${HEAD_REF} must target ${expected}, not ${BASE_REF}. Change the base branch (Edit, top of this PR) to ${expected} and push again."
+            exit 1
           fi
-
-      - name: Comment with the correct base branch
-        if: steps.validate.outputs.invalid == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXPECTED: ${{ steps.validate.outputs.expected }}
-        run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --body "🚫 \`${{ github.head_ref }}\` must target \`$EXPECTED\`, not \`${{ github.base_ref }}\`. Please change the base branch — click **Edit** at the top of this PR and set base to \`$EXPECTED\` — then push again."
-
-      - name: Fail if base branch is wrong
-        if: steps.validate.outputs.invalid == 'true'
-        env:
-          EXPECTED: ${{ steps.validate.outputs.expected }}
-        run: |
-          echo "::error::${{ github.head_ref }} must target $EXPECTED, not ${{ github.base_ref }}"
-          exit 1

--- a/.github/workflows/enforce-base-branch.yml
+++ b/.github/workflows/enforce-base-branch.yml
@@ -14,6 +14,10 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# This job only reads github.head_ref/base_ref from event context — no API
+# calls, no checkout — so it needs no permissions at all.
+permissions: {}
+
 jobs:
   check-base:
     if: vars.ENFORCE_GIT_WORKFLOW == 'true'

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -3,6 +3,11 @@ name: Require linked issue
 # pull_request_target for the same reason as enforce-base-branch.yml: this job
 # only reads PR metadata via the GraphQL API, it never checks out or runs the
 # PR's code, so using the base branch's workflow definition is safe.
+#
+# No comment-on-failure step: the org's Actions permission ceiling is
+# read-only, so GITHUB_TOKEN can't post PR comments regardless of what
+# permissions: this job declares. The ::error:: annotation below still
+# surfaces on the PR's Checks tab without needing any write permission.
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
@@ -11,8 +16,6 @@ jobs:
   require-linked-issue:
     if: vars.ENFORCE_GIT_WORKFLOW == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Check for a linked issue
         id: check
@@ -36,19 +39,8 @@ jobs:
               number: context.issue.number,
             });
             const count = result.repository.pullRequest.closingIssuesReferences.totalCount;
-            core.setOutput("invalid", count === 0 ? "true" : "false");
-
-      - name: Comment asking for a linked issue
-        if: steps.check.outputs.invalid == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --body "🚫 This PR isn't linked to an issue. Add \`Closes #123\` (or \`Fixes\`/\`Resolves\`) to the description, or link one via the **Development** panel on the right, then push again."
-
-      - name: Fail if no linked issue
-        if: steps.check.outputs.invalid == 'true'
-        run: |
-          echo "::error::This PR must be linked to an issue."
-          exit 1
+            if (count === 0) {
+              core.setFailed(
+                "This PR must be linked to an issue. Add 'Closes #123' to the description, or link one via the Development panel."
+              );
+            }

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -12,6 +12,10 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# Queries PR data via GraphQL — needs read access to pull requests, nothing else.
+permissions:
+  pull-requests: read
+
 jobs:
   require-linked-issue:
     if: vars.ENFORCE_GIT_WORKFLOW == 'true'

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,54 @@
+name: Require linked issue
+
+# pull_request_target for the same reason as enforce-base-branch.yml: this job
+# only reads PR metadata via the GraphQL API, it never checks out or runs the
+# PR's code, so using the base branch's workflow definition is safe.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  require-linked-issue:
+    if: vars.ENFORCE_GIT_WORKFLOW == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check for a linked issue
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 1) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            `;
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: context.issue.number,
+            });
+            const count = result.repository.pullRequest.closingIssuesReferences.totalCount;
+            core.setOutput("invalid", count === 0 ? "true" : "false");
+
+      - name: Comment asking for a linked issue
+        if: steps.check.outputs.invalid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "🚫 This PR isn't linked to an issue. Add \`Closes #123\` (or \`Fixes\`/\`Resolves\`) to the description, or link one via the **Development** panel on the right, then push again."
+
+      - name: Fail if no linked issue
+        if: steps.check.outputs.invalid == 'true'
+        run: |
+          echo "::error::This PR must be linked to an issue."
+          exit 1


### PR DESCRIPTION
## What

Implements the branch-workflow automation designed in #204:
- `enforce-base-branch.yml` — rejects `feat/*` PRs not targeting `develop` and `bug/*` PRs not targeting `main`
- `require-linked-issue.yml` — rejects PRs with no linked issue
- `cherry-pick-to-develop.yml` — auto cherry-picks merged `bug/*` PRs from `main` into a PR against `develop`
- `.github/rulesets/required-status-checks.json` — importable ruleset requiring PRs (no direct pushes) + the two checks above on `main`/`develop`
- `.github/CODEOWNERS` — requires `@NuGuardAI/ent:engineering` review on any change under `.github/workflows/`

## Why

Closes the automation gaps identified in #204: base-branch mistargeting, unlinked PRs, and manual cherry-picking were all previously unenforced.

## How

- `enforce-base-branch.yml`/`require-linked-issue.yml` use `pull_request_target` (not `pull_request`) so the check always runs the base branch's reviewed copy of the workflow, not a contributor's own edited version — safe because neither job checks out or executes PR code.
- Both were simplified to drop PR-comment steps: this org's Actions token permission ceiling is read-only, so `GITHUB_TOKEN` can't post comments regardless of a job's declared `permissions:`. The `::error::`/`core.setFailed` annotation still surfaces on the PR's Checks tab without needing write access.
- `cherry-pick-to-develop.yml` triggers on `push` to `main` (not `pull_request: closed`) so `github.ref` resolves cleanly to `refs/heads/main`, matching the `cherry-pick-bot` environment's branch policy — `pull_request`-family events resolve to an ambiguous merge ref instead. A `find-pr` job (using the default read-only token) looks up the merged PR from the pushed commit; only the actual cherry-pick job is gated by the `cherry-pick-bot` environment + its Required reviewers, and uses the separate `CHERRY_PICK_BOT_TOKEN` secret for all write actions.
- Everything gates behind one repo variable, `vars.ENFORCE_GIT_WORKFLOW` — disabled by default, nothing runs until it's explicitly set to `"true"`.

## Test Steps

- [ ] Set `ENFORCE_GIT_WORKFLOW` repo variable to `"true"`
- [ ] Import `.github/rulesets/required-status-checks.json` and set its enforcement to **Active** (imports can land disabled)
- [ ] Open a throwaway `feat/*` PR targeting `main` — confirm `check-base` fails with a clear annotation
- [ ] Open a throwaway `bug/*` PR targeting `main`, merge it (squash) — confirm the cherry-pick job reaches the `cherry-pick-bot` environment gate and, once approved, opens a PR into `develop`
- [ ] Open a PR with no linked issue — confirm `require-linked-issue` fails

## Checks

- [x] Docs/CI-only change — no `nuguard/` code touched, `make test`/`make lint`/`make fmt` not applicable.

## Other Notes

Two things outside this PR's scope, still need attention in repo settings:
- `origin/develop` and `origin/Develop` both currently exist as separate branches (identical commit right now) — pick one and delete the other before they diverge, since all references here are to lowercase `develop`.
- The imported ruleset needs its enforcement flipped from the default to **Active**.

Closes #204 (partially — cherry-pick automation still needs a live end-to-end test post-merge).