### PR TITLE
Fix gh pr view field name in cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-to-develop.yml
+++ b/.github/workflows/cherry-pick-to-develop.yml
@@ -41,12 +41,12 @@ jobs:
           fi
 
           pr_json=$(gh pr view "$pr_number" --repo "${{ github.repository }}" \
-            --json headRefName,baseRefName,merged)
+            --json headRefName,baseRefName,state)
           head_ref=$(echo "$pr_json" | jq -r .headRefName)
           base_ref=$(echo "$pr_json" | jq -r .baseRefName)
-          merged=$(echo "$pr_json" | jq -r .merged)
+          state=$(echo "$pr_json" | jq -r .state)
 
-          if [[ "$merged" == "true" && "$head_ref" == bug/* && "$base_ref" == "main" ]]; then
+          if [[ "$state" == "MERGED" && "$head_ref" == bug/* && "$base_ref" == "main" ]]; then
             echo "is_bug_merge=true" >> "$GITHUB_OUTPUT"
             echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## What

Fixes `find-pr`'s `gh pr view --json headRefName,baseRefName,merged` — `merged` isn't a valid field for `gh pr view --json`, only `state` (`OPEN`/`CLOSED`/`MERGED`).

## Why

This is what caused the real failure seen on the push event for #207's own merge commit into `main`:
```
Unknown JSON field: "merged"
Error: Process completed with exit code 1.
```
#207 merged before this fix was pushed (same timing gap as #205 → #207), so `main` still has the broken field name.

## How

Swapped `merged` for `state`, and the comparison from `merged == "true"` to `state == "MERGED"`.

## Test Steps

- [ ] Merge a throwaway `bug/*` PR into `main` (squash) — confirm `find-pr` no longer errors on the `gh pr view` call

## Checks

- [x] CI-only change.

## Other Notes

Related to #204, #205, #207.