### PR TITLE
feat(sbom): add C# parser and adapter base

### DIFF
--- a/nuguard/sbom/adapters/csharp/__init__.py
+++ b/nuguard/sbom/adapters/csharp/__init__.py
@@ -1,0 +1,5 @@
+"""Shared infrastructure for C# framework adapters."""
+
+from ._csharp_base import CSharpFrameworkAdapter
+
+__all__ = ["CSharpFrameworkAdapter"]

--- a/nuguard/sbom/adapters/csharp/_csharp_base.py
+++ b/nuguard/sbom/adapters/csharp/_csharp_base.py
@@ -1,0 +1,184 @@
+"""Shared base class for C# framework adapters."""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from typing import Any
+
+from ...core.csharp_parser import CSharpParseResult, parse_csharp
+from ...types import ComponentType
+from ..base import ComponentDetection, FrameworkAdapter
+
+
+class CSharpFrameworkAdapter(
+    FrameworkAdapter,
+    ABC,
+):
+    """Base class for adapters that consume C# parse results.
+
+    Subclasses declare namespace prefixes in ``handles_namespaces`` or in the
+    inherited ``handles_imports`` alias and implement :meth:`extract`.
+    """
+
+    handles_namespaces: list[str] = []
+
+    def _namespace_prefixes(self) -> list[str]:
+        return self.handles_namespaces or self.handles_imports
+
+    @staticmethod
+    def _normalize_namespace(
+        namespace: str,
+    ) -> str:
+        return namespace.strip().removeprefix("global::").rstrip(".")
+
+    def can_handle(
+        self,
+        imports_present: set[str],
+    ) -> bool:
+        """Return whether an imported namespace matches this adapter."""
+        prefixes = [
+            self._normalize_namespace(prefix)
+            for prefix in self._namespace_prefixes()
+            if prefix.strip()
+        ]
+
+        for imported in imports_present:
+            namespace = self._normalize_namespace(imported)
+
+            for prefix in prefixes:
+                if namespace == prefix or namespace.startswith(prefix + "."):
+                    return True
+
+        return False
+
+    def _detect(
+        self,
+        result: CSharpParseResult,
+    ) -> bool:
+        """Return whether the parse result imports a handled namespace."""
+        return self.can_handle({directive.namespace for directive in result.using_directives})
+
+    @staticmethod
+    def _parse_result(
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> CSharpParseResult:
+        """Return a typed result, parsing content when necessary."""
+        if isinstance(
+            parse_result,
+            CSharpParseResult,
+        ):
+            return parse_result
+
+        return parse_csharp(
+            content,
+            file_path,
+        )
+
+    @abstractmethod
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        """Extract component detections from one C# source file."""
+        raise NotImplementedError
+
+    def _fw_node(
+        self,
+        file_path: str,
+        line: int = 0,
+    ) -> ComponentDetection:
+        """Emit a C# framework-presence node."""
+        return ComponentDetection(
+            component_type=ComponentType.FRAMEWORK,
+            canonical_name=f"framework:{self.name}",
+            display_name=f"framework:{self.name}",
+            adapter_name=self.name,
+            priority=self.priority,
+            confidence=0.95,
+            metadata={
+                "framework": self.name,
+                "language": "csharp",
+            },
+            file_path=file_path,
+            line=line,
+            snippet=f"using {self.name}",
+            evidence_kind="ast_import",
+        )
+
+    @staticmethod
+    def _clean(value: Any) -> str:
+        """Strip common C# string delimiters and placeholders."""
+        if value is None:
+            return ""
+
+        text = str(value).strip()
+
+        if text.startswith("$("):
+            return ""
+
+        text = re.sub(
+            r"^(?:\$@|@\$|\$+|@)",
+            "",
+            text,
+        )
+
+        if text.startswith('"""') and text.endswith('"""'):
+            text = text[3:-3]
+        else:
+            text = text.strip("'\" ")
+
+        if text.startswith("$(") or text in {
+            "<complex>",
+            "<lambda>",
+            "<dict>",
+            "<list>",
+        }:
+            return ""
+
+        return text
+
+    @staticmethod
+    def _assignment_name(
+        source: str,
+        line: int,
+    ) -> str | None:
+        """Return the assignment target on a one-based source line."""
+        lines = source.splitlines()
+
+        if line < 1 or line > len(lines):
+            return None
+
+        match = re.search(
+            r"(?:\b(?:const|var|"
+            r"[A-Za-z_]\w*"
+            r"(?:[.<>,?\[\] ]+[A-Za-z_]\w*)?)\s+)?"
+            r"(?P<name>@?[A-Za-z_]\w*)\s*=",
+            lines[line - 1],
+        )
+
+        return match.group("name").removeprefix("@") if match else None
+
+    @staticmethod
+    def _template_vars(
+        text: str,
+    ) -> list[str]:
+        """Extract unique expressions from interpolation braces."""
+        variables: list[str] = []
+        seen: set[str] = set()
+
+        for match in re.finditer(
+            r"(?<!\{)\{\s*([^{}]+?)\s*\}(?!\})",
+            text,
+        ):
+            expression = match.group(1).split(":", 1)[0].strip()
+
+            if expression and expression not in seen:
+                seen.add(expression)
+                variables.append(expression)
+
+        return variables

--- a/nuguard/sbom/core/csharp_parser.py
+++ b/nuguard/sbom/core/csharp_parser.py
@@ -1,0 +1,737 @@
+"""Dependency-free structural parsing for C# source files.
+
+The parser is intentionally best-effort. It extracts the source structures
+needed by C# framework adapters without attempting full compiler semantics.
+"""
+
+from __future__ import annotations
+
+import re
+from bisect import bisect_right
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CSharpUsingDirective:
+    """One C# ``using`` directive."""
+
+    namespace: str
+    alias: str | None = None
+    is_static: bool = False
+    is_global: bool = False
+    line: int = 0
+
+    @property
+    def module(self) -> str:
+        return self.namespace
+
+
+@dataclass(frozen=True)
+class CSharpTypeDeclaration:
+    """A class, record, struct, or interface declaration."""
+
+    name: str
+    kind: str
+    modifiers: tuple[str, ...] = ()
+    attributes: tuple[str, ...] = ()
+    base_types: tuple[str, ...] = ()
+    line: int = 0
+    line_end: int = 0
+    signature: str = ""
+
+
+@dataclass(frozen=True)
+class CSharpMethodDeclaration:
+    """A method or constructor declaration."""
+
+    name: str
+    return_type: str | None
+    parameters: tuple[str, ...] = ()
+    modifiers: tuple[str, ...] = ()
+    attributes: tuple[str, ...] = ()
+    containing_type: str | None = None
+    is_constructor: bool = False
+    line: int = 0
+    line_end: int = 0
+    signature: str = ""
+
+
+@dataclass(frozen=True)
+class CSharpStringLiteral:
+    """A regular, verbatim, interpolated, or raw string literal."""
+
+    value: str
+    line: int
+    line_end: int
+    assigned_to: str | None = None
+    enclosing_method: str | None = None
+    is_verbatim: bool = False
+    is_interpolated: bool = False
+    is_raw: bool = False
+    interpolation_expressions: tuple[str, ...] = ()
+
+    @property
+    def is_potential_prompt(self) -> bool:
+        lowered = self.value.lower()
+        return len(self.value) > 100 or any(
+            marker in lowered
+            for marker in (
+                "you are",
+                "system:",
+                "assistant:",
+                "user:",
+                "instructions:",
+            )
+        )
+
+
+@dataclass
+class CSharpParseResult:
+    """Structural information extracted from one C# source file."""
+
+    using_directives: list[CSharpUsingDirective] = field(default_factory=list)
+    type_declarations: list[CSharpTypeDeclaration] = field(default_factory=list)
+    method_declarations: list[CSharpMethodDeclaration] = field(default_factory=list)
+    string_literals: list[CSharpStringLiteral] = field(default_factory=list)
+    source: str = ""
+    file_path: str = ""
+    parse_error: str | None = None
+
+    @property
+    def imports(self) -> list[CSharpUsingDirective]:
+        return self.using_directives
+
+    @property
+    def classes(self) -> list[CSharpTypeDeclaration]:
+        return self.type_declarations
+
+    @property
+    def methods(self) -> list[CSharpMethodDeclaration]:
+        return self.method_declarations
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.using_directives
+            or self.type_declarations
+            or self.method_declarations
+            or self.string_literals
+        )
+
+
+@dataclass(frozen=True)
+class _LiteralToken:
+    start: int
+    end: int
+    value: str
+    is_verbatim: bool
+    is_interpolated: bool
+    is_raw: bool
+    expressions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Span:
+    name: str
+    start: int
+    body_start: int
+    end: int
+
+
+_IDENTIFIER = r"@?[A-Za-z_]\w*"
+
+_TOKEN_RE = re.compile(
+    r"(?P<line_comment>//[^\n]*)"
+    r"|(?P<block_comment>/\*.*?\*/)"
+    r'|(?P<raw>\$*""".*?""")'
+    r'|(?P<verbatim>(?:\$@|@\$|@)"(?:""|[^"])*")'
+    r'|(?P<regular>\$?"(?:\\.|[^"\\\r\n])*")'
+    r"|(?P<char>'(?:\\.|[^'\\\r\n])')",
+    re.DOTALL,
+)
+
+_USING_RE = re.compile(
+    rf"(?m)^[ \t]*(?P<global>global\s+)?using\s+"
+    rf"(?:(?P<static>static)\s+)?"
+    rf"(?:(?P<alias>{_IDENTIFIER})\s*=\s*)?"
+    rf"(?P<namespace>(?:global::)?{_IDENTIFIER}"
+    rf"(?:\.{_IDENTIFIER})*)\s*;"
+)
+
+_TYPE_RE = re.compile(
+    rf"(?m)^[ \t]*"
+    rf"(?P<attributes>(?:(?:\[[^\]\n]+\])[ \t\r\n]*)*)"
+    rf"(?P<modifiers>(?:(?:public|private|protected|internal|abstract|"
+    rf"sealed|static|partial|readonly|ref|unsafe|new|file)\s+)*)"
+    rf"(?P<kind>record(?:\s+(?:class|struct))?|class|struct|interface)\s+"
+    rf"(?P<name>{_IDENTIFIER})(?:\s*<[^>{{}};\n]+>)?"
+    rf"(?P<tail>\s*(?:\([^{{}};]*\))?\s*"
+    rf"(?::[^{{}};]+)?(?:\s+where\s+[^{{}};]+)*)"
+    rf"\s*(?P<terminator>{{|;)"
+)
+
+_METHOD_RE = re.compile(
+    rf"(?m)(?P<start>^[ \t]*|(?<=[{{}};]))"
+    rf"(?P<attributes>(?:(?:\[[^\]\n]+\])[ \t\r\n]*)*)"
+    rf"(?P<modifiers>(?:(?:public|private|protected|internal|static|"
+    rf"abstract|virtual|override|sealed|new|async|extern|unsafe|partial|"
+    rf"readonly|ref|required)\s+)*)"
+    rf"(?:(?P<return>[A-Za-z_][\w.<>,?\[\]\s:]*)\s+)?"
+    rf"(?P<name>{_IDENTIFIER})(?:\s*<[^>{{}};()\n]+>)?\s*"
+    rf"\((?P<params>[^()]*)\)\s*"
+    rf"(?:(?:where\s+[^{{}};=]+)\s*)?"
+    rf"(?P<terminator>{{|=>|;)"
+)
+
+_NON_METHOD_NAMES = {
+    "if",
+    "for",
+    "foreach",
+    "while",
+    "switch",
+    "catch",
+    "using",
+    "lock",
+    "return",
+    "throw",
+    "new",
+    "typeof",
+    "nameof",
+    "sizeof",
+    "default",
+}
+
+
+def parse_csharp(
+    content: str,
+    file_path: str = "",
+) -> CSharpParseResult:
+    """Parse C# source into a best-effort structural result."""
+    newlines = [match.start() for match in re.finditer(r"\n", content)]
+
+    masked, literal_tokens, lexical_error = _mask_non_code(
+        content,
+        newlines,
+    )
+
+    types, type_spans, type_headers = _extract_types(
+        content,
+        masked,
+        newlines,
+    )
+
+    methods, method_spans = _extract_methods(
+        content,
+        masked,
+        newlines,
+        type_spans,
+        type_headers,
+    )
+
+    errors = [
+        error
+        for error in (
+            lexical_error,
+            _brace_error(masked, newlines),
+        )
+        if error
+    ]
+
+    return CSharpParseResult(
+        using_directives=_extract_usings(
+            masked,
+            newlines,
+        ),
+        type_declarations=types,
+        method_declarations=methods,
+        string_literals=_build_literals(
+            content,
+            literal_tokens,
+            newlines,
+            method_spans,
+        ),
+        source=content,
+        file_path=file_path,
+        parse_error="; ".join(errors) if errors else None,
+    )
+
+
+def _line(
+    newlines: list[int],
+    position: int,
+) -> int:
+    return bisect_right(newlines, position) + 1
+
+
+def _mask_non_code(
+    source: str,
+    newlines: list[int],
+) -> tuple[str, list[_LiteralToken], str | None]:
+    masked = list(source)
+    tokens: list[_LiteralToken] = []
+
+    for match in _TOKEN_RE.finditer(source):
+        for index in range(
+            match.start(),
+            match.end(),
+        ):
+            if masked[index] not in {"\n", "\r"}:
+                masked[index] = " "
+
+        kind = match.lastgroup
+
+        if kind in {
+            "line_comment",
+            "block_comment",
+            "char",
+        }:
+            continue
+
+        raw = match.group(0)
+        is_raw = kind == "raw"
+        is_verbatim = kind == "verbatim"
+        is_interpolated = raw.startswith("$") or raw.startswith("@$")
+
+        if is_raw:
+            dollars = len(raw) - len(raw.lstrip("$"))
+            value = raw[dollars + 3 : -3]
+            braces = max(dollars, 1)
+        else:
+            quote = raw.find('"')
+            value = raw[quote + 1 : -1]
+
+            if is_verbatim:
+                value = value.replace('""', '"')
+            else:
+                value = _decode_escapes(value)
+
+            braces = 1
+
+        tokens.append(
+            _LiteralToken(
+                start=match.start(),
+                end=match.end(),
+                value=value,
+                is_verbatim=is_verbatim,
+                is_interpolated=is_interpolated,
+                is_raw=is_raw,
+                expressions=(_interpolations(value, braces) if is_interpolated else ()),
+            )
+        )
+
+    result = "".join(masked)
+    unterminated = result.find("/*")
+
+    error = (
+        f"Unterminated block comment near line {_line(newlines, unterminated)}"
+        if unterminated >= 0
+        else None
+    )
+
+    return result, tokens, error
+
+
+def _decode_escapes(value: str) -> str:
+    replacements = {
+        r"\0": "\0",
+        r"\n": "\n",
+        r"\r": "\r",
+        r"\t": "\t",
+        r"\"": '"',
+        r"\\": "\\",
+    }
+
+    return re.sub(
+        r"\\(?:0|n|r|t|\"|\\)",
+        lambda match: replacements.get(
+            match.group(0),
+            match.group(0),
+        ),
+        value,
+    )
+
+
+def _interpolations(
+    value: str,
+    brace_count: int,
+) -> tuple[str, ...]:
+    opening = "{" * brace_count
+    closing = "}" * brace_count
+
+    pattern = re.compile(
+        rf"(?<!\{{){re.escape(opening)}\s*"
+        rf"([^{{}}]+?)\s*"
+        rf"{re.escape(closing)}(?!\}})"
+    )
+
+    return tuple(dict.fromkeys(match.group(1).strip() for match in pattern.finditer(value)))
+
+
+def _brace_error(
+    masked: str,
+    newlines: list[int],
+) -> str | None:
+    stack: list[int] = []
+
+    for index, char in enumerate(masked):
+        if char == "{":
+            stack.append(index)
+        elif char == "}":
+            if not stack:
+                return f"Unexpected closing brace near line {_line(newlines, index)}"
+
+            stack.pop()
+
+    if stack:
+        return f"Unmatched opening brace near line {_line(newlines, stack[-1])}"
+
+    return None
+
+
+def _extract_usings(
+    masked: str,
+    newlines: list[int],
+) -> list[CSharpUsingDirective]:
+    return [
+        CSharpUsingDirective(
+            namespace=match.group("namespace").removeprefix("global::"),
+            alias=match.group("alias"),
+            is_static=bool(match.group("static")),
+            is_global=bool(match.group("global")),
+            line=_line(
+                newlines,
+                match.start(),
+            ),
+        )
+        for match in _USING_RE.finditer(masked)
+    ]
+
+
+def _extract_types(
+    source: str,
+    masked: str,
+    newlines: list[int],
+) -> tuple[
+    list[CSharpTypeDeclaration],
+    list[_Span],
+    list[tuple[int, int]],
+]:
+    declarations: list[CSharpTypeDeclaration] = []
+    spans: list[_Span] = []
+    headers: list[tuple[int, int]] = []
+
+    for match in _TYPE_RE.finditer(masked):
+        body_start = match.start("terminator")
+        end = match.end("terminator")
+
+        if match.group("terminator") == "{":
+            closing = _matching(
+                masked,
+                body_start,
+                "{",
+                "}",
+            )
+
+            end = len(source) if closing is None else closing + 1
+
+        name = match.group("name").removeprefix("@")
+
+        declaration = CSharpTypeDeclaration(
+            name=name,
+            kind=" ".join(match.group("kind").split()),
+            modifiers=tuple((match.group("modifiers") or "").split()),
+            attributes=_attributes(source[match.start("attributes") : match.end("attributes")]),
+            base_types=_base_types(match.group("tail") or ""),
+            line=_line(
+                newlines,
+                match.start("name"),
+            ),
+            line_end=_line(
+                newlines,
+                max(
+                    end - 1,
+                    match.start(),
+                ),
+            ),
+            signature=source[match.start() : body_start + 1].strip(),
+        )
+
+        declarations.append(declaration)
+
+        spans.append(
+            _Span(
+                name,
+                match.start(),
+                body_start,
+                end,
+            )
+        )
+
+        headers.append(
+            (
+                match.start(),
+                body_start + 1,
+            )
+        )
+
+    return declarations, spans, headers
+
+
+def _extract_methods(
+    source: str,
+    masked: str,
+    newlines: list[int],
+    type_spans: list[_Span],
+    type_headers: list[tuple[int, int]],
+) -> tuple[
+    list[CSharpMethodDeclaration],
+    list[_Span],
+]:
+    declarations: list[CSharpMethodDeclaration] = []
+    spans: list[_Span] = []
+
+    for match in _METHOD_RE.finditer(masked):
+        if any(start <= match.start("name") < end for start, end in type_headers):
+            continue
+
+        name = match.group("name").removeprefix("@")
+
+        if name in _NON_METHOD_NAMES:
+            continue
+
+        containing = _containing(
+            type_spans,
+            match.start("name"),
+        )
+
+        return_type = (match.group("return") or "").strip() or None
+
+        is_constructor = bool(containing and containing.name == name and return_type is None)
+
+        if return_type is None and not is_constructor:
+            continue
+
+        body_start = match.start("terminator")
+        end = match.end("terminator")
+
+        if match.group("terminator") == "{":
+            closing = _matching(
+                masked,
+                body_start,
+                "{",
+                "}",
+            )
+
+            end = len(source) if closing is None else closing + 1
+
+        elif match.group("terminator") == "=>":
+            semicolon = masked.find(
+                ";",
+                body_start,
+            )
+
+            end = len(source) if semicolon < 0 else semicolon + 1
+
+        declaration = CSharpMethodDeclaration(
+            name=name,
+            return_type=return_type,
+            parameters=tuple(
+                part.strip() for part in _split(match.group("params")) if part.strip()
+            ),
+            modifiers=tuple((match.group("modifiers") or "").split()),
+            attributes=_attributes(source[match.start("attributes") : match.end("attributes")]),
+            containing_type=(containing.name if containing else None),
+            is_constructor=is_constructor,
+            line=_line(
+                newlines,
+                match.start("name"),
+            ),
+            line_end=_line(
+                newlines,
+                max(
+                    end - 1,
+                    match.start(),
+                ),
+            ),
+            signature=source[match.start() : match.end()].strip(),
+        )
+
+        declarations.append(declaration)
+
+        spans.append(
+            _Span(
+                name,
+                match.start(),
+                body_start,
+                end,
+            )
+        )
+
+    return declarations, spans
+
+
+def _matching(
+    source: str,
+    start: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    depth = 0
+
+    for index in range(
+        start,
+        len(source),
+    ):
+        if source[index] == opening:
+            depth += 1
+        elif source[index] == closing:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _containing(
+    spans: list[_Span],
+    position: int,
+) -> _Span | None:
+    matches = [span for span in spans if span.body_start < position < span.end]
+
+    return (
+        min(
+            matches,
+            key=lambda span: span.end - span.start,
+        )
+        if matches
+        else None
+    )
+
+
+def _attributes(raw: str) -> tuple[str, ...]:
+    return tuple(
+        match.group(1).strip()
+        for match in re.finditer(
+            r"\[([^\]]+)\]",
+            raw,
+        )
+    )
+
+
+def _base_types(
+    tail: str,
+) -> tuple[str, ...]:
+    if ":" not in tail:
+        return ()
+
+    value = re.split(
+        r"\bwhere\b",
+        tail.split(":", 1)[1],
+        maxsplit=1,
+    )[0]
+
+    return tuple(part.strip() for part in _split(value) if part.strip())
+
+
+def _split(value: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(value):
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+        elif char in {'"', "'"}:
+            quote = char
+        elif char in "([{<":
+            depth += 1
+        elif char in ")]}>":
+            depth = max(
+                depth - 1,
+                0,
+            )
+        elif char == "," and depth == 0:
+            parts.append(value[start:index])
+            start = index + 1
+
+    parts.append(value[start:])
+
+    return parts
+
+
+def _build_literals(
+    source: str,
+    tokens: list[_LiteralToken],
+    newlines: list[int],
+    method_spans: list[_Span],
+) -> list[CSharpStringLiteral]:
+    literals: list[CSharpStringLiteral] = []
+
+    for token in tokens:
+        method = _containing(
+            method_spans,
+            token.start,
+        )
+
+        literals.append(
+            CSharpStringLiteral(
+                value=token.value,
+                line=_line(
+                    newlines,
+                    token.start,
+                ),
+                line_end=_line(
+                    newlines,
+                    token.end - 1,
+                ),
+                assigned_to=_assignment_target(
+                    source,
+                    token.start,
+                ),
+                enclosing_method=(method.name if method else None),
+                is_verbatim=token.is_verbatim,
+                is_interpolated=token.is_interpolated,
+                is_raw=token.is_raw,
+                interpolation_expressions=token.expressions,
+            )
+        )
+
+    return literals
+
+
+def _assignment_target(
+    source: str,
+    position: int,
+) -> str | None:
+    prefix = source[
+        source.rfind(
+            "\n",
+            0,
+            position,
+        )
+        + 1 : position
+    ]
+
+    match = re.search(
+        rf"(?P<name>{_IDENTIFIER})\s*=\s*$",
+        prefix,
+    )
+
+    return match.group("name").removeprefix("@") if match else None
+
+
+__all__ = [
+    "CSharpMethodDeclaration",
+    "CSharpParseResult",
+    "CSharpStringLiteral",
+    "CSharpTypeDeclaration",
+    "CSharpUsingDirective",
+    "parse_csharp",
+]

--- a/nuguard/sbom/core/csharp_parser.py
+++ b/nuguard/sbom/core/csharp_parser.py
@@ -1038,13 +1038,16 @@ def _containing(
 
 
 def _attributes(raw: str) -> tuple[str, ...]:
-    return tuple(
-        match.group(1).strip()
-        for match in re.finditer(
-            r"\[([^\]]+)\]",
-            raw,
-        )
-    )
+    """Extract individual attributes from one or more attribute sections."""
+    attributes: list[str] = []
+
+    for match in re.finditer(
+        r"\[([^\]]+)\]",
+        raw,
+    ):
+        attributes.extend(item.strip() for item in _split(match.group(1)) if item.strip())
+
+    return tuple(attributes)
 
 
 def _base_types(

--- a/nuguard/sbom/core/csharp_parser.py
+++ b/nuguard/sbom/core/csharp_parser.py
@@ -139,16 +139,6 @@ class _Span:
 
 _IDENTIFIER = r"@?[A-Za-z_]\w*"
 
-_TOKEN_RE = re.compile(
-    r"(?P<line_comment>//[^\n]*)"
-    r"|(?P<block_comment>/\*.*?\*/)"
-    r'|(?P<raw>\$*""".*?""")'
-    r'|(?P<verbatim>(?:\$@|@\$|@)"(?:""|[^"])*")'
-    r'|(?P<regular>\$?"(?:\\.|[^"\\\r\n])*")'
-    r"|(?P<char>'(?:\\.|[^'\\\r\n])')",
-    re.DOTALL,
-)
-
 _USING_RE = re.compile(
     rf"(?m)^[ \t]*(?P<global>global\s+)?using\s+"
     rf"(?:(?P<static>static)\s+)?"
@@ -169,17 +159,23 @@ _TYPE_RE = re.compile(
     rf"\s*(?P<terminator>{{|;)"
 )
 
-_METHOD_RE = re.compile(
-    rf"(?m)(?P<start>^[ \t]*|(?<=[{{}};]))"
+_TYPE_TOKEN = (
+    rf"(?:global::)?{_IDENTIFIER}"
+    rf"(?:\.{_IDENTIFIER})*"
+    rf"(?:\s*<[^;{{}}()\n]+>)?"
+    rf"(?:\s*\[\s*\])*\??"
+)
+
+_METHOD_HEAD_RE = re.compile(
+    rf"(?m)(?P<start>^[ \t]*|(?<=[{{}};])[ \t]*)"
     rf"(?P<attributes>(?:(?:\[[^\]\n]+\])[ \t\r\n]*)*)"
     rf"(?P<modifiers>(?:(?:public|private|protected|internal|static|"
     rf"abstract|virtual|override|sealed|new|async|extern|unsafe|partial|"
     rf"readonly|ref|required)\s+)*)"
-    rf"(?:(?P<return>[A-Za-z_][\w.<>,?\[\]\s:]*)\s+)?"
-    rf"(?P<name>{_IDENTIFIER})(?:\s*<[^>{{}};()\n]+>)?\s*"
-    rf"\((?P<params>[^()]*)\)\s*"
-    rf"(?:(?:where\s+[^{{}};=]+)\s*)?"
-    rf"(?P<terminator>{{|=>|;)"
+    rf"(?:(?P<return>{_TYPE_TOKEN})\s+)?"
+    rf"(?P<name>{_IDENTIFIER})"
+    rf"(?:\s*<[^>{{}};()\n]+>)?\s*"
+    rf"(?P<open>\()"
 )
 
 _NON_METHOD_NAMES = {
@@ -245,6 +241,7 @@ def parse_csharp(
         method_declarations=methods,
         string_literals=_build_literals(
             content,
+            masked,
             literal_tokens,
             newlines,
             method_spans,
@@ -266,68 +263,403 @@ def _mask_non_code(
     source: str,
     newlines: list[int],
 ) -> tuple[str, list[_LiteralToken], str | None]:
+    """Mask comments, strings, and characters while preserving offsets."""
     masked = list(source)
     tokens: list[_LiteralToken] = []
+    errors: list[str] = []
+    index = 0
+    end: int | None
+    closing: int | None
 
-    for match in _TOKEN_RE.finditer(source):
-        for index in range(
-            match.start(),
-            match.end(),
-        ):
-            if masked[index] not in {"\n", "\r"}:
-                masked[index] = " "
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index)
 
-        kind = match.lastgroup
+            if end < 0:
+                end = len(source)
 
-        if kind in {
-            "line_comment",
-            "block_comment",
-            "char",
-        }:
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+            index = end
             continue
 
-        raw = match.group(0)
-        is_raw = kind == "raw"
-        is_verbatim = kind == "verbatim"
-        is_interpolated = raw.startswith("$") or raw.startswith("@$")
+        if source.startswith("/*", index):
+            closing = source.find(
+                "*/",
+                index + 2,
+            )
 
-        if is_raw:
-            dollars = len(raw) - len(raw.lstrip("$"))
-            value = raw[dollars + 3 : -3]
-            braces = max(dollars, 1)
-        else:
-            quote = raw.find('"')
-            value = raw[quote + 1 : -1]
+            if closing < 0:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                errors.append(f"Unterminated block comment near line {_line(newlines, index)}")
+                break
+
+            end = closing + 2
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+            index = end
+            continue
+
+        raw_opener = _raw_string_opener(
+            source,
+            index,
+        )
+
+        if raw_opener is not None:
+            (
+                dollar_count,
+                quote_count,
+                content_start,
+            ) = raw_opener
+
+            closing = _raw_string_close(
+                source,
+                content_start,
+                quote_count,
+            )
+
+            if closing is None:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                errors.append(f"Unterminated raw string near line {_line(newlines, index)}")
+                break
+
+            end = closing + quote_count
+            value = source[content_start:closing]
+            is_interpolated = dollar_count > 0
+
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+
+            tokens.append(
+                _LiteralToken(
+                    start=index,
+                    end=end,
+                    value=value,
+                    is_verbatim=False,
+                    is_interpolated=(is_interpolated),
+                    is_raw=True,
+                    expressions=(
+                        _interpolations(
+                            value,
+                            max(
+                                dollar_count,
+                                1,
+                            ),
+                        )
+                        if is_interpolated
+                        else ()
+                    ),
+                )
+            )
+
+            index = end
+            continue
+
+        quoted_prefix = _quoted_string_prefix(
+            source,
+            index,
+        )
+
+        if quoted_prefix is not None:
+            (
+                prefix,
+                is_verbatim,
+                is_interpolated,
+            ) = quoted_prefix
+            body_start = index + len(prefix)
+            end = _quoted_string_end(
+                source,
+                body_start,
+                is_verbatim,
+            )
+
+            if end is None:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                string_kind = "verbatim" if is_verbatim else "regular"
+                errors.append(
+                    f"Unterminated {string_kind} string near line {_line(newlines, index)}"
+                )
+                break
+
+            value = source[body_start : end - 1]
 
             if is_verbatim:
-                value = value.replace('""', '"')
+                value = value.replace(
+                    '""',
+                    '"',
+                )
             else:
                 value = _decode_escapes(value)
 
-            braces = 1
-
-        tokens.append(
-            _LiteralToken(
-                start=match.start(),
-                end=match.end(),
-                value=value,
-                is_verbatim=is_verbatim,
-                is_interpolated=is_interpolated,
-                is_raw=is_raw,
-                expressions=(_interpolations(value, braces) if is_interpolated else ()),
+            _mask_range(
+                masked,
+                index,
+                end,
             )
-        )
 
-    result = "".join(masked)
-    unterminated = result.find("/*")
+            tokens.append(
+                _LiteralToken(
+                    start=index,
+                    end=end,
+                    value=value,
+                    is_verbatim=is_verbatim,
+                    is_interpolated=(is_interpolated),
+                    is_raw=False,
+                    expressions=(
+                        _interpolations(
+                            value,
+                            1,
+                        )
+                        if is_interpolated
+                        else ()
+                    ),
+                )
+            )
 
-    error = (
-        f"Unterminated block comment near line {_line(newlines, unterminated)}"
-        if unterminated >= 0
-        else None
+            index = end
+            continue
+
+        if source[index] == "'":
+            end = _character_literal_end(
+                source,
+                index,
+            )
+
+            if end is None:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                errors.append(f"Unterminated character literal near line {_line(newlines, index)}")
+                break
+
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+            index = end
+            continue
+
+        index += 1
+
+    return (
+        "".join(masked),
+        tokens,
+        "; ".join(errors) if errors else None,
     )
 
-    return result, tokens, error
+
+def _mask_range(
+    masked: list[str],
+    start: int,
+    end: int,
+) -> None:
+    """Mask a source range without changing line positions."""
+    for index in range(start, end):
+        if masked[index] not in {
+            "\n",
+            "\r",
+        }:
+            masked[index] = " "
+
+
+def _raw_string_opener(
+    source: str,
+    start: int,
+) -> tuple[int, int, int] | None:
+    """Return dollar count, quote count, and content start."""
+    cursor = start
+
+    while cursor < len(source) and source[cursor] == "$":
+        cursor += 1
+
+    quote_start = cursor
+
+    while cursor < len(source) and source[cursor] == '"':
+        cursor += 1
+
+    quote_count = cursor - quote_start
+
+    if quote_count < 3:
+        return None
+
+    return (
+        quote_start - start,
+        quote_count,
+        cursor,
+    )
+
+
+def _raw_string_close(
+    source: str,
+    start: int,
+    quote_count: int,
+) -> int | None:
+    """Find a raw-string closing delimiter of the same length."""
+    cursor = start
+
+    while cursor < len(source):
+        if source[cursor] != '"':
+            cursor += 1
+            continue
+
+        run_start = cursor
+
+        while cursor < len(source) and source[cursor] == '"':
+            cursor += 1
+
+        if cursor - run_start == quote_count:
+            return run_start
+
+    return None
+
+
+def _quoted_string_prefix(
+    source: str,
+    start: int,
+) -> tuple[str, bool, bool] | None:
+    """Return prefix, verbatim flag, and interpolation flag."""
+    prefixes = (
+        (
+            '$@"',
+            True,
+            True,
+        ),
+        (
+            '@$"',
+            True,
+            True,
+        ),
+        (
+            '@"',
+            True,
+            False,
+        ),
+        (
+            '$"',
+            False,
+            True,
+        ),
+        (
+            '"',
+            False,
+            False,
+        ),
+    )
+
+    for (
+        prefix,
+        is_verbatim,
+        is_interpolated,
+    ) in prefixes:
+        if source.startswith(
+            prefix,
+            start,
+        ):
+            return (
+                prefix,
+                is_verbatim,
+                is_interpolated,
+            )
+
+    return None
+
+
+def _quoted_string_end(
+    source: str,
+    start: int,
+    is_verbatim: bool,
+) -> int | None:
+    """Return the offset immediately after a closing quote."""
+    cursor = start
+
+    while cursor < len(source):
+        char = source[cursor]
+
+        if is_verbatim:
+            if char == '"':
+                if cursor + 1 < len(source) and source[cursor + 1] == '"':
+                    cursor += 2
+                    continue
+
+                return cursor + 1
+
+            cursor += 1
+            continue
+
+        if char == "\\":
+            if cursor + 1 >= len(source) or source[cursor + 1] in {"\n", "\r"}:
+                return None
+
+            cursor += 2
+            continue
+
+        if char == '"':
+            return cursor + 1
+
+        if char in {
+            "\n",
+            "\r",
+        }:
+            return None
+
+        cursor += 1
+
+    return None
+
+
+def _character_literal_end(
+    source: str,
+    start: int,
+) -> int | None:
+    """Return the offset immediately after a character literal."""
+    cursor = start + 1
+
+    while cursor < len(source):
+        char = source[cursor]
+
+        if char == "\\":
+            if cursor + 1 >= len(source):
+                return None
+
+            cursor += 2
+            continue
+
+        if char == "'":
+            return cursor + 1
+
+        if char in {
+            "\n",
+            "\r",
+        }:
+            return None
+
+        cursor += 1
+
+    return None
 
 
 def _decode_escapes(value: str) -> str:
@@ -489,8 +821,29 @@ def _extract_methods(
     declarations: list[CSharpMethodDeclaration] = []
     spans: list[_Span] = []
 
-    for match in _METHOD_RE.finditer(masked):
-        if any(start <= match.start("name") < end for start, end in type_headers):
+    for match in _METHOD_HEAD_RE.finditer(masked):
+        name_position = match.start("name")
+
+        if any(start <= name_position < end for start, end in type_headers):
+            continue
+
+        # Once a method has been found, do not reinterpret calls or
+        # statements inside its body as additional declarations.
+        if (
+            _containing(
+                spans,
+                name_position,
+            )
+            is not None
+        ):
+            continue
+
+        containing = _containing(
+            type_spans,
+            name_position,
+        )
+
+        if containing is None:
             continue
 
         name = match.group("name").removeprefix("@")
@@ -498,22 +851,48 @@ def _extract_methods(
         if name in _NON_METHOD_NAMES:
             continue
 
-        containing = _containing(
-            type_spans,
-            match.start("name"),
-        )
-
         return_type = (match.group("return") or "").strip() or None
 
-        is_constructor = bool(containing and containing.name == name and return_type is None)
+        if return_type is not None and return_type.casefold() in {
+            "return",
+            "throw",
+            "yield",
+            "await",
+        }:
+            continue
+
+        is_constructor = bool(containing.name == name and return_type is None)
 
         if return_type is None and not is_constructor:
             continue
 
-        body_start = match.start("terminator")
-        end = match.end("terminator")
+        open_paren = match.start("open")
+        close_paren = _matching(
+            masked,
+            open_paren,
+            "(",
+            ")",
+        )
 
-        if match.group("terminator") == "{":
+        if close_paren is None:
+            continue
+
+        terminator_info = _method_terminator(
+            masked,
+            close_paren + 1,
+        )
+
+        if terminator_info is None:
+            continue
+
+        (
+            body_start,
+            terminator,
+        ) = terminator_info
+        terminator_end = body_start + len(terminator)
+        end = terminator_end
+
+        if terminator == "{":
             closing = _matching(
                 masked,
                 body_start,
@@ -523,27 +902,27 @@ def _extract_methods(
 
             end = len(source) if closing is None else closing + 1
 
-        elif match.group("terminator") == "=>":
+        elif terminator == "=>":
             semicolon = masked.find(
                 ";",
-                body_start,
+                terminator_end,
             )
 
             end = len(source) if semicolon < 0 else semicolon + 1
 
+        parameters_text = source[open_paren + 1 : close_paren]
+
         declaration = CSharpMethodDeclaration(
             name=name,
             return_type=return_type,
-            parameters=tuple(
-                part.strip() for part in _split(match.group("params")) if part.strip()
-            ),
+            parameters=tuple(part.strip() for part in _split(parameters_text) if part.strip()),
             modifiers=tuple((match.group("modifiers") or "").split()),
             attributes=_attributes(source[match.start("attributes") : match.end("attributes")]),
-            containing_type=(containing.name if containing else None),
+            containing_type=(containing.name),
             is_constructor=is_constructor,
             line=_line(
                 newlines,
-                match.start("name"),
+                name_position,
             ),
             line_end=_line(
                 newlines,
@@ -552,7 +931,7 @@ def _extract_methods(
                     match.start(),
                 ),
             ),
-            signature=source[match.start() : match.end()].strip(),
+            signature=source[match.start() : terminator_end].strip(),
         )
 
         declarations.append(declaration)
@@ -567,6 +946,56 @@ def _extract_methods(
         )
 
     return declarations, spans
+
+
+def _method_terminator(
+    source: str,
+    start: int,
+) -> tuple[int, str] | None:
+    """Find a declaration terminator after a balanced parameter list."""
+    depths = {
+        "(": 0,
+        "[": 0,
+        "<": 0,
+    }
+    closing = {
+        ")": "(",
+        "]": "[",
+        ">": "<",
+    }
+    cursor = start
+
+    while cursor < len(source):
+        if not any(depths.values()) and source.startswith(
+            "=>",
+            cursor,
+        ):
+            return cursor, "=>"
+
+        char = source[cursor]
+
+        if not any(depths.values()):
+            if char == "{":
+                return cursor, "{"
+
+            if char == ";":
+                return cursor, ";"
+
+            if char == "}":
+                return None
+
+        if char in depths:
+            depths[char] += 1
+        elif char in closing:
+            opener = closing[char]
+            depths[opener] = max(
+                depths[opener] - 1,
+                0,
+            )
+
+        cursor += 1
+
+    return None
 
 
 def _matching(
@@ -668,6 +1097,7 @@ def _split(value: str) -> list[str]:
 
 def _build_literals(
     source: str,
+    masked: str,
     tokens: list[_LiteralToken],
     newlines: list[int],
     method_spans: list[_Span],
@@ -691,15 +1121,18 @@ def _build_literals(
                     newlines,
                     token.end - 1,
                 ),
-                assigned_to=_assignment_target(
-                    source,
-                    token.start,
+                assigned_to=(
+                    _assignment_target(
+                        source,
+                        masked,
+                        token.start,
+                    )
                 ),
                 enclosing_method=(method.name if method else None),
-                is_verbatim=token.is_verbatim,
-                is_interpolated=token.is_interpolated,
+                is_verbatim=(token.is_verbatim),
+                is_interpolated=(token.is_interpolated),
                 is_raw=token.is_raw,
-                interpolation_expressions=token.expressions,
+                interpolation_expressions=(token.expressions),
             )
         )
 
@@ -708,23 +1141,47 @@ def _build_literals(
 
 def _assignment_target(
     source: str,
+    masked: str,
     position: int,
 ) -> str | None:
-    prefix = source[
-        source.rfind(
-            "\n",
-            0,
-            position,
+    """Return the assignment target before a string literal."""
+    statement_start = (
+        max(
+            masked.rfind(
+                ";",
+                0,
+                position,
+            ),
+            masked.rfind(
+                "{",
+                0,
+                position,
+            ),
+            masked.rfind(
+                "}",
+                0,
+                position,
+            ),
         )
-        + 1 : position
-    ]
+        + 1
+    )
+
+    prefix = masked[statement_start:position]
 
     match = re.search(
-        rf"(?P<name>{_IDENTIFIER})\s*=\s*$",
+        rf"(?P<name>{_IDENTIFIER})"
+        rf"\s*=\s*$",
         prefix,
     )
 
-    return match.group("name").removeprefix("@") if match else None
+    if match is None:
+        return None
+
+    # Access source so this helper continues to validate compatible offsets.
+    if len(source) != len(masked):
+        return None
+
+    return match.group("name").removeprefix("@")
 
 
 __all__ = [

--- a/nuguard/sbom/tests/test_csharp_base.py
+++ b/nuguard/sbom/tests/test_csharp_base.py
@@ -1,0 +1,149 @@
+"""Tests for the shared C# framework-adapter base class."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from nuguard.sbom.adapters.base import ComponentDetection
+from nuguard.sbom.adapters.csharp import CSharpFrameworkAdapter
+from nuguard.sbom.core.csharp_parser import (
+    CSharpParseResult,
+    parse_csharp,
+)
+
+
+class _ExampleAdapter(CSharpFrameworkAdapter):
+    name = "example_csharp"
+    priority = 25
+
+    handles_namespaces = [
+        "Azure.AI.OpenAI",
+        "Microsoft.SemanticKernel",
+    ]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result):
+            return []
+
+        line = result.using_directives[0].line if result.using_directives else 0
+
+        return [
+            self._fw_node(
+                file_path,
+                line,
+            )
+        ]
+
+
+def test_base_class_is_abstract() -> None:
+    assert inspect.isabstract(CSharpFrameworkAdapter)
+
+
+def test_can_handle_exact_descendant_and_global_namespace() -> None:
+    adapter = _ExampleAdapter()
+
+    assert adapter.can_handle({"Azure.AI.OpenAI"})
+    assert adapter.can_handle({"Azure.AI.OpenAI.Chat"})
+    assert adapter.can_handle({"global::Microsoft.SemanticKernel.Connectors.OpenAI"})
+
+
+def test_can_handle_rejects_siblings_and_substrings() -> None:
+    adapter = _ExampleAdapter()
+
+    assert not adapter.can_handle({"Azure.AI"})
+    assert not adapter.can_handle({"Contoso.Azure.AI.OpenAI"})
+    assert not adapter.can_handle({"Microsoft.SemanticKernelish"})
+
+
+def test_detect_and_extract_use_structural_parse_result() -> None:
+    adapter = _ExampleAdapter()
+
+    source = "using Azure.AI.OpenAI;\npublic class App {}\n"
+
+    result = parse_csharp(
+        source,
+        "App.cs",
+    )
+
+    assert adapter._detect(result)
+
+    detections = adapter.extract(
+        source,
+        "App.cs",
+        result,
+    )
+
+    assert len(detections) == 1
+    assert detections[0].file_path == "App.cs"
+    assert detections[0].line == 1
+
+
+def test_parse_result_reuses_typed_result_or_parses_content() -> None:
+    existing = CSharpParseResult(file_path="Existing.cs")
+
+    assert (
+        _ExampleAdapter._parse_result(
+            "ignored",
+            "Other.cs",
+            existing,
+        )
+        is existing
+    )
+
+    parsed = _ExampleAdapter._parse_result(
+        "using Microsoft.SemanticKernel;",
+        "Kernel.cs",
+        None,
+    )
+
+    assert parsed.file_path == "Kernel.cs"
+    assert parsed.using_directives[0].namespace == "Microsoft.SemanticKernel"
+
+
+def test_framework_node_uses_csharp_metadata() -> None:
+    node = _ExampleAdapter()._fw_node(
+        "Program.cs",
+        7,
+    )
+
+    assert node.canonical_name == "framework:example_csharp"
+    assert node.adapter_name == "example_csharp"
+    assert node.priority == 25
+    assert node.metadata == {
+        "framework": "example_csharp",
+        "language": "csharp",
+    }
+    assert node.evidence_kind == "ast_import"
+
+
+def test_common_helpers_clean_assignments_and_template_variables() -> None:
+    assert _ExampleAdapter._clean('$"gpt-4o"') == "gpt-4o"
+
+    assert _ExampleAdapter._clean("$(ModelName)") == ""
+
+    assert (
+        _ExampleAdapter._assignment_name(
+            'var client = new AzureOpenAIClient("endpoint");',
+            1,
+        )
+        == "client"
+    )
+
+    assert _ExampleAdapter._template_vars(
+        "Hello {user.Name}; total {amount:N2}; escaped {{literal}}"
+    ) == [
+        "user.Name",
+        "amount",
+    ]

--- a/nuguard/sbom/tests/test_csharp_parser.py
+++ b/nuguard/sbom/tests/test_csharp_parser.py
@@ -355,3 +355,24 @@ def test_unterminated_strings_are_masked_and_reported() -> None:
         assert expected_error in result.parse_error.lower()
         assert [item.name for item in result.type_declarations] == ["Real"]
         assert [item.name for item in result.method_declarations] == ["Run"]
+
+
+def test_combined_attribute_sections_are_split() -> None:
+    result = parse_csharp(
+        """public class SearchPlugin
+{
+    [KernelFunction, Description("query, text")]
+    public string Search(string query) => query;
+}
+"""
+    )
+
+    assert len(result.method_declarations) == 1
+
+    method = result.method_declarations[0]
+
+    assert method.name == "Search"
+    assert method.attributes == (
+        "KernelFunction",
+        'Description("query, text")',
+    )

--- a/nuguard/sbom/tests/test_csharp_parser.py
+++ b/nuguard/sbom/tests/test_csharp_parser.py
@@ -216,3 +216,142 @@ def test_empty_source_is_false_and_preserves_context() -> None:
     assert not result
     assert result.file_path == "Empty.cs"
     assert result.parse_error is None
+
+
+def test_method_parser_handles_nested_parameters_and_initializer() -> None:
+    result = parse_csharp(
+        """public class Service : BaseService
+{
+    public Service(
+        string name = nameof(DefaultName),
+        Func<(int X, int Y), Task> handler = null)
+        : base(CreateOptions())
+    {
+    }
+
+    public void Run(
+        (int X, int Y) point,
+        Action<Func<int, string>> callback)
+    {
+    }
+}
+"""
+    )
+
+    assert [method.name for method in result.method_declarations] == [
+        "Service",
+        "Run",
+    ]
+
+    constructor, method = result.method_declarations
+
+    assert constructor.is_constructor
+    assert constructor.parameters == (
+        "string name = nameof(DefaultName)",
+        "Func<(int X, int Y), Task> handler = null",
+    )
+    assert ": base(CreateOptions())" in constructor.signature
+
+    assert method.parameters == (
+        "(int X, int Y) point",
+        "Action<Func<int, string>> callback",
+    )
+
+
+def test_method_calls_inside_bodies_are_not_declarations() -> None:
+    result = parse_csharp(
+        """public class PromptBuilder
+{
+    public string Run()
+    {
+        return BuildPrompt();
+    }
+
+    private string BuildPrompt() => "prompt";
+}
+"""
+    )
+
+    assert [method.name for method in result.method_declarations] == [
+        "Run",
+        "BuildPrompt",
+    ]
+
+
+def test_raw_string_uses_matching_quote_delimiter_length() -> None:
+    result = parse_csharp(
+        "public class RawPrompt\n"
+        "{\n"
+        "    public void Run()\n"
+        "    {\n"
+        '        var prompt = """"text with """ inside"""";\n'
+        "    }\n"
+        "}\n"
+    )
+
+    assert result.parse_error is None
+    assert len(result.string_literals) == 1
+
+    literal = result.string_literals[0]
+
+    assert literal.is_raw
+    assert literal.value == 'text with """ inside'
+    assert literal.assigned_to == "prompt"
+    assert literal.enclosing_method == "Run"
+
+
+def test_multiline_string_assignment_preserves_target() -> None:
+    result = parse_csharp(
+        """public class PromptBuilder
+{
+    public string Build()
+    {
+        var prompt =
+            "You are a careful assistant.";
+        return prompt;
+    }
+}
+"""
+    )
+
+    assert len(result.string_literals) == 1
+    assert result.string_literals[0].assigned_to == "prompt"
+
+
+def test_unterminated_strings_are_masked_and_reported() -> None:
+    cases = (
+        (
+            '"',
+            "unterminated regular string",
+        ),
+        (
+            '@"',
+            "unterminated verbatim string",
+        ),
+        (
+            '""""',
+            "unterminated raw string",
+        ),
+    )
+
+    for opener, expected_error in cases:
+        source = (
+            "public class Real\n"
+            "{\n"
+            "    public void Run()\n"
+            "    {\n"
+            f"        var broken = {opener}unterminated\n"
+            "        public class Fake\n"
+            "        {\n"
+            "            public void Bad() {}\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+
+        result = parse_csharp(source)
+
+        assert result.parse_error is not None
+        assert expected_error in result.parse_error.lower()
+        assert [item.name for item in result.type_declarations] == ["Real"]
+        assert [item.name for item in result.method_declarations] == ["Run"]

--- a/nuguard/sbom/tests/test_csharp_parser.py
+++ b/nuguard/sbom/tests/test_csharp_parser.py
@@ -1,0 +1,218 @@
+"""Tests for the lightweight C# structural parser."""
+
+from __future__ import annotations
+
+from nuguard.sbom.core.csharp_parser import parse_csharp
+
+
+def test_using_directives_capture_global_static_and_alias() -> None:
+    result = parse_csharp(
+        """global using Azure.AI.OpenAI;
+using static System.Math;
+using SK = Microsoft.SemanticKernel;
+""",
+        "Imports.cs",
+    )
+
+    assert result.file_path == "Imports.cs"
+
+    assert [item.namespace for item in result.using_directives] == [
+        "Azure.AI.OpenAI",
+        "System.Math",
+        "Microsoft.SemanticKernel",
+    ]
+
+    assert result.using_directives[0].is_global
+    assert result.using_directives[1].is_static
+    assert result.using_directives[2].alias == "SK"
+    assert result.imports == result.using_directives
+
+
+def test_type_declarations_capture_kinds_modifiers_and_bases() -> None:
+    result = parse_csharp(
+        """public sealed class ChatService<T> : IChatService, IDisposable
+    where T : class
+{
+}
+public interface IChatClient {}
+public readonly record struct ChatResult(string Value);
+"""
+    )
+
+    assert [item.name for item in result.type_declarations] == [
+        "ChatService",
+        "IChatClient",
+        "ChatResult",
+    ]
+
+    chat_service = result.type_declarations[0]
+
+    assert chat_service.kind == "class"
+    assert chat_service.modifiers == (
+        "public",
+        "sealed",
+    )
+    assert chat_service.base_types == (
+        "IChatService",
+        "IDisposable",
+    )
+    assert result.type_declarations[2].kind == "record struct"
+    assert result.classes == result.type_declarations
+
+
+def test_methods_and_constructor_capture_signatures() -> None:
+    result = parse_csharp(
+        """public class ChatService
+{
+    public ChatService(string name, int retries = 3) {}
+
+    public async Task<string> CompleteAsync(
+        string input,
+        CancellationToken cancellationToken = default)
+    {
+        return input;
+    }
+}
+"""
+    )
+
+    constructor, method = result.method_declarations
+
+    assert constructor.is_constructor
+    assert constructor.return_type is None
+    assert constructor.containing_type == "ChatService"
+    assert constructor.parameters == (
+        "string name",
+        "int retries = 3",
+    )
+
+    assert method.name == "CompleteAsync"
+    assert method.return_type == "Task<string>"
+    assert method.modifiers == (
+        "public",
+        "async",
+    )
+    assert method.parameters[1] == "CancellationToken cancellationToken = default"
+    assert result.methods == result.method_declarations
+
+
+def test_interface_and_expression_bodied_methods_are_parsed() -> None:
+    result = parse_csharp(
+        """public interface IChatClient
+{
+    Task<string> CompleteAsync(string prompt);
+}
+[ApiController]
+[Route("api/format")]
+public class Formatter
+{
+    [HttpPost("trim")]
+    public string Format(string value) => value.Trim();
+}
+"""
+    )
+
+    assert [
+        (
+            item.name,
+            item.return_type,
+        )
+        for item in result.method_declarations
+    ] == [
+        (
+            "CompleteAsync",
+            "Task<string>",
+        ),
+        (
+            "Format",
+            "string",
+        ),
+    ]
+
+    assert result.type_declarations[1].attributes == (
+        "ApiController",
+        'Route("api/format")',
+    )
+
+    assert result.method_declarations[1].attributes == ('HttpPost("trim")',)
+
+
+def test_strings_capture_forms_assignment_and_method_context() -> None:
+    source = (
+        "public class PromptBuilder\n"
+        "{\n"
+        "    public string Build(string user)\n"
+        "    {\n"
+        '        var regular = "System: be helpful\\nUser:";\n'
+        '        var verbatim = @"C:\\prompts\\system.txt";\n'
+        '        var interpolated = $"Hello {user}";\n'
+        '        var raw = """\n'
+        "You are a careful assistant.\n"
+        '""";\n'
+        '        var rawInterpolated = $$"""Hello {{user}}""";\n'
+        "        return interpolated;\n"
+        "    }\n"
+        "}\n"
+    )
+
+    result = parse_csharp(source)
+
+    literals = {item.assigned_to: item for item in result.string_literals}
+
+    assert literals["regular"].value == "System: be helpful\nUser:"
+    assert literals["regular"].enclosing_method == "Build"
+    assert literals["verbatim"].is_verbatim
+    assert literals["interpolated"].interpolation_expressions == ("user",)
+    assert literals["raw"].is_raw
+    assert literals["raw"].is_potential_prompt
+    assert literals["rawInterpolated"].interpolation_expressions == ("user",)
+
+
+def test_comments_chars_and_string_contents_are_not_declarations() -> None:
+    result = parse_csharp(
+        """// using Fake.Namespace;
+/* public class FakeBlock { void Bad() {} } */
+public class Real
+{
+    private char quote = '\\'';
+    private string sample = "class FakeString { void Nope() {} }";
+    public void Good() {}
+}
+"""
+    )
+
+    assert [item.name for item in result.type_declarations] == ["Real"]
+
+    assert [item.name for item in result.method_declarations] == ["Good"]
+
+    assert result.using_directives == []
+
+
+def test_malformed_source_preserves_partial_results() -> None:
+    result = parse_csharp(
+        """using Azure.AI.OpenAI;
+public class Broken
+{
+    public void Run()
+    {
+        var prompt = "You are still visible";
+"""
+    )
+
+    assert result.parse_error is not None
+    assert "Unmatched opening brace" in result.parse_error
+    assert result.using_directives[0].namespace == "Azure.AI.OpenAI"
+    assert result.type_declarations[0].name == "Broken"
+    assert result.method_declarations[0].name == "Run"
+    assert result.string_literals[0].assigned_to == "prompt"
+
+
+def test_empty_source_is_false_and_preserves_context() -> None:
+    result = parse_csharp(
+        "",
+        "Empty.cs",
+    )
+
+    assert not result
+    assert result.file_path == "Empty.cs"
+    assert result.parse_error is None


### PR DESCRIPTION
Closes #211 
## PR Type

- [ ] Bug fix
- [x] Feature

## What

- Added a lightweight structural parser for C# source files.
- Added structured parse results for:
  - `using` directives
  - class, record, struct, and interface declarations
  - method and constructor signatures
  - method parameter text
  - regular, verbatim, interpolated, and raw string literals
- Added source locations, containing-type context, containing-method context, assignment targets, and malformed-source reporting.
- Added a shared `CSharpFrameworkAdapter` base class.
- Added focused parser and adapter-base tests.

## Why

NuGuard needs a shared C# parsing layer before framework-specific adapters can detect Azure OpenAI, Semantic Kernel, ML.NET, ASP.NET Core, and other .NET AI usage.

This implements the parser and adapter-base infrastructure requested in #211 and supports the broader C# work tracked in #170.

## How

- Added `nuguard/sbom/core/csharp_parser.py`.
- Uses only the Python standard library and adds no runtime dependency.
- Masks comments, character literals, and string contents before matching declarations.
- Extracts normal, global, static, and aliased `using` directives.
- Extracts classes, records, structs, interfaces, modifiers, attributes, and base types.
- Extracts constructors, ordinary methods, interface methods, and expression-bodied methods.
- Extracts regular, verbatim, interpolated, and raw strings.
- Associates strings with assignment targets and enclosing methods when available.
- Preserves successfully extracted structures when malformed input is encountered and exposes the problem through `parse_error`.
- Added `CSharpFrameworkAdapter` with:
  - exact and descendant namespace matching
  - `global::` normalization
  - typed C# parse-result handling
  - framework-node creation
  - assignment, value-cleaning, and template-variable helpers

## Test Steps

- [x] `uv run ruff format --check nuguard/sbom/core/csharp_parser.py nuguard/sbom/adapters/csharp/__init__.py nuguard/sbom/adapters/csharp/_csharp_base.py nuguard/sbom/tests/test_csharp_parser.py nuguard/sbom/tests/test_csharp_base.py`
- [x] `uv run ruff check nuguard/`
- [x] `uv run mypy nuguard/`
- [x] `uv run pytest nuguard/sbom/tests/test_csharp_parser.py nuguard/sbom/tests/test_csharp_base.py -v`
- [x] `uv run pytest nuguard/ -q`
- [x] `uv run pytest tests/ --ignore=tests/apps/contact-center-ai-samples -v`
- [x] `make precommit-run`
- [x] `git diff --check`

## Checks

- [x] The feature branch was created from `develop`
- [x] This PR targets `develop`
- [x] Changed Python files are Ruff-formatted
- [x] Ruff lint passes
- [x] Mypy passes
- [x] Package and integration tests pass
- [x] Focused tests cover successful parsing, namespace matching, string forms, and malformed source
- [x] No new runtime dependency was added
- [x] No extractor-pipeline or adapter-registry wiring was added

## Other Notes

The following remain intentionally out of scope:

- Azure OpenAI, OpenAI .NET, and Anthropic .NET adapters
- Semantic Kernel and ML.NET adapters
- ASP.NET Core controller and Minimal API adapters
- adapter registry changes
- `.cs` and `.csx` source-extension configuration
- extraction-pipeline wiring
- C# Semgrep rules
- end-to-end C# fixture applications

Those concerns are tracked by the subsequent C# support issues.

Closes #211
Part of #170