### PR TITLE
feat(sbom): add C# framework adapters

### DIFF
--- a/nuguard/sbom/adapters/csharp/__init__.py
+++ b/nuguard/sbom/adapters/csharp/__init__.py
@@ -1,5 +1,17 @@
-"""Shared infrastructure for C# framework adapters."""
+"""C# framework adapters."""
 
 from ._csharp_base import CSharpFrameworkAdapter
+from .aspnet_core import CSharpAspNetCoreAdapter
+from .llm_clients import CSharpLLMClientsAdapter
+from .mlnet import CSharpMLNetAdapter
+from .semantic_kernel import (
+    CSharpSemanticKernelAdapter,
+)
 
-__all__ = ["CSharpFrameworkAdapter"]
+__all__ = [
+    "CSharpAspNetCoreAdapter",
+    "CSharpFrameworkAdapter",
+    "CSharpLLMClientsAdapter",
+    "CSharpMLNetAdapter",
+    "CSharpSemanticKernelAdapter",
+]

--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -125,7 +125,7 @@ def find_calls(
         prefix = masked[max(0, match.start() - 12) : match.start()]
         is_constructor = bool(re.search(r"\bnew\s*$", prefix))
         assigned_to = _assignment_target(
-            source,
+            masked,
             match.start(),
         )
         end = close_paren + 1
@@ -268,11 +268,55 @@ def split_top_level(value: str) -> list[str]:
 def string_constants(
     result: CSharpParseResult,
 ) -> dict[str, str]:
-    """Build a variable-to-string map from parsed literal results."""
+    """Return unambiguous C# ``const`` string declarations.
+
+    Mutable variables are deliberately excluded because a file-wide
+    name-to-value dictionary cannot safely model reassignment or scope.
+    Duplicate constant names with different values are also omitted.
+    """
+    source = result.source
+
+    if not source:
+        return {}
+
+    masked = mask_non_code(source)
+    values: dict[str, set[str]] = {}
+
+    for token in _TOKEN_RE.finditer(source):
+        if token.lastgroup not in {
+            "raw",
+            "verbatim",
+            "regular",
+        }:
+            continue
+
+        start = token.start()
+        boundary = max(
+            masked.rfind(";", 0, start),
+            masked.rfind("{", 0, start),
+            masked.rfind("}", 0, start),
+        )
+        prefix = masked[boundary + 1 : start]
+        declaration = re.search(
+            rf"\bconst\s+(?:string|var)\s+"
+            rf"(?P<name>{_IDENTIFIER})"
+            rf"\s*=\s*$",
+            prefix,
+        )
+
+        if declaration is None:
+            continue
+
+        value = _decode_string(token.group(0))
+
+        if value is None:
+            continue
+
+        name = declaration.group("name").removeprefix("@")
+        values.setdefault(name, set()).add(value)
+
     return {
-        literal.assigned_to: literal.value
-        for literal in result.string_literals
-        if literal.assigned_to and literal.value
+        name: next(iter(candidates)) for name, candidates in values.items() if len(candidates) == 1
     }
 
 
@@ -446,7 +490,8 @@ def _assignment_target(
 ) -> str | None:
     boundary = max(
         source.rfind(";", 0, position),
-        source.rfind("\n", 0, position),
+        source.rfind("{", 0, position),
+        source.rfind("}", 0, position),
     )
     prefix = source[boundary + 1 : position]
     match = re.search(

--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -1,0 +1,554 @@
+"""Small source helpers shared by C# framework adapters."""
+
+from __future__ import annotations
+
+import re
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import Iterable
+
+from ...core.csharp_parser import CSharpMethodDeclaration, CSharpParseResult
+
+_IDENTIFIER = r"@?[A-Za-z_]\w*"
+_TOKEN_RE = re.compile(
+    r"(?P<line_comment>//[^\n]*)"
+    r"|(?P<block_comment>/\*.*?\*/)"
+    r'|(?P<raw>\$*""".*?""")'
+    r'|(?P<verbatim>(?:\$@|@\$|@)"(?:""|[^"])*")'
+    r'|(?P<regular>\$?"(?:\\.|[^"\\\r\n])*")'
+    r"|(?P<char>'(?:\\.|[^'\\\r\n])')",
+    re.DOTALL,
+)
+_GENERIC = r"(?:\s*<[^<>{}();\n]+>)?"
+_CALL_RE = re.compile(
+    rf"(?P<callee>(?:global::)?{_IDENTIFIER}{_GENERIC}"
+    rf"(?:\s*\.\s*{_IDENTIFIER}{_GENERIC})*)\s*\("
+)
+_CONTROL_NAMES = {
+    "if",
+    "for",
+    "foreach",
+    "while",
+    "switch",
+    "catch",
+    "using",
+    "lock",
+    "return",
+    "throw",
+    "typeof",
+    "nameof",
+    "sizeof",
+    "default",
+    "checked",
+    "unchecked",
+}
+
+
+@dataclass(frozen=True)
+class CSharpCall:
+    """One best-effort C# call or constructor expression."""
+
+    callee: str
+    name: str
+    receiver: str | None
+    generic_arguments: tuple[str, ...]
+    arguments_text: str
+    named_arguments: dict[str, str]
+    positional_arguments: tuple[str, ...]
+    assigned_to: str | None
+    is_constructor: bool
+    line: int
+    start: int
+    end: int
+    snippet: str
+
+
+def mask_non_code(source: str) -> str:
+    """Mask comments, strings, and character literals without shifting offsets."""
+    masked = list(source)
+
+    for match in _TOKEN_RE.finditer(source):
+        for index in range(match.start(), match.end()):
+            if masked[index] not in {"\n", "\r"}:
+                masked[index] = " "
+
+    return "".join(masked)
+
+
+def line_number(source: str, position: int) -> int:
+    offsets = [match.start() for match in re.finditer(r"\n", source)]
+    return bisect_right(offsets, position) + 1
+
+
+def find_calls(
+    source: str,
+    names: set[str] | None = None,
+) -> list[CSharpCall]:
+    """Return call expressions whose simple name is in *names*, if supplied."""
+    masked = mask_non_code(source)
+    calls: list[CSharpCall] = []
+
+    for match in _CALL_RE.finditer(masked):
+        callee = re.sub(
+            r"\s+",
+            "",
+            match.group("callee"),
+        )
+        simple_parts = _split_callee(callee)
+
+        if not simple_parts:
+            continue
+
+        name, generic_arguments = _split_generic(simple_parts[-1])
+        name = name.removeprefix("@")
+
+        if name in _CONTROL_NAMES:
+            continue
+
+        if names is not None and name not in names:
+            continue
+
+        open_paren = match.end() - 1
+        close_paren = _matching(
+            masked,
+            open_paren,
+            "(",
+            ")",
+        )
+
+        if close_paren is None:
+            continue
+
+        args_text = source[open_paren + 1 : close_paren]
+        named, positional = parse_arguments(args_text)
+        receiver = ".".join(simple_parts[:-1]) or None
+        prefix = masked[max(0, match.start() - 12) : match.start()]
+        is_constructor = bool(re.search(r"\bnew\s*$", prefix))
+        assigned_to = _assignment_target(
+            source,
+            match.start(),
+        )
+        end = close_paren + 1
+        snippet = " ".join(source[match.start() : end].strip().split())[:240]
+
+        calls.append(
+            CSharpCall(
+                callee=callee,
+                name=name,
+                receiver=receiver,
+                generic_arguments=generic_arguments,
+                arguments_text=args_text,
+                named_arguments=named,
+                positional_arguments=tuple(positional),
+                assigned_to=assigned_to,
+                is_constructor=is_constructor,
+                line=line_number(
+                    source,
+                    match.start(),
+                ),
+                start=match.start(),
+                end=end,
+                snippet=snippet,
+            )
+        )
+
+    return calls
+
+
+def parse_arguments(
+    value: str,
+) -> tuple[dict[str, str], list[str]]:
+    """Split C# call arguments into named and positional expressions."""
+    named: dict[str, str] = {}
+    positional: list[str] = []
+
+    for part in split_top_level(value):
+        item = part.strip()
+
+        if not item:
+            continue
+
+        name, expression = _named_argument(item)
+
+        if name is None:
+            positional.append(item)
+        else:
+            named[name] = expression
+
+    return named, positional
+
+
+def split_top_level(value: str) -> list[str]:
+    """Split comma-delimited C# text while respecting nesting and strings."""
+    parts: list[str] = []
+    start = 0
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+        "<": 0,
+    }
+    closing = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+        ">": "<",
+    }
+    index = 0
+    quote: str | None = None
+    verbatim = False
+    raw = False
+
+    while index < len(value):
+        if raw:
+            if value.startswith('"""', index):
+                raw = False
+                index += 3
+                continue
+
+            index += 1
+            continue
+
+        char = value[index]
+
+        if quote:
+            if verbatim:
+                if char == '"' and index + 1 < len(value) and value[index + 1] == '"':
+                    index += 2
+                    continue
+
+                if char == '"':
+                    quote = None
+                    verbatim = False
+            else:
+                if char == "\\":
+                    index += 2
+                    continue
+
+                if char == quote:
+                    quote = None
+
+            index += 1
+            continue
+
+        if value.startswith('"""', index):
+            raw = True
+            index += 3
+            continue
+
+        if char == '"':
+            quote = char
+            verbatim = index > 0 and value[index - 1] == "@"
+            index += 1
+            continue
+
+        if char == "'":
+            quote = char
+            index += 1
+            continue
+
+        if char in depths:
+            depths[char] += 1
+        elif char in closing:
+            opener = closing[char]
+            depths[opener] = max(
+                depths[opener] - 1,
+                0,
+            )
+        elif char == "," and not any(depths.values()):
+            parts.append(value[start:index])
+            start = index + 1
+
+        index += 1
+
+    parts.append(value[start:])
+    return parts
+
+
+def string_constants(
+    result: CSharpParseResult,
+) -> dict[str, str]:
+    """Build a variable-to-string map from parsed literal results."""
+    return {
+        literal.assigned_to: literal.value
+        for literal in result.string_literals
+        if literal.assigned_to and literal.value
+    }
+
+
+def resolve_expression(
+    expression: str | None,
+    constants: dict[str, str],
+) -> str:
+    """Resolve a simple C# string, constant, enum member, or nameof value."""
+    if not expression:
+        return ""
+
+    value = expression.strip()
+
+    while value.startswith("(") and value.endswith(")") and _balanced_outer(value):
+        value = value[1:-1].strip()
+
+    named = re.fullmatch(
+        r"nameof\s*\(\s*([^)]+)\s*\)",
+        value,
+    )
+
+    if named:
+        return named.group(1).split(".")[-1].strip()
+
+    uri = re.fullmatch(
+        r"new\s+Uri\s*\((.*)\)",
+        value,
+        re.DOTALL,
+    )
+
+    if uri:
+        return resolve_expression(
+            uri.group(1),
+            constants,
+        )
+
+    decoded = _decode_string(value)
+
+    if decoded is not None:
+        return decoded
+
+    identifier = value.removeprefix("global::").removeprefix("@").strip()
+
+    if identifier in constants:
+        return constants[identifier]
+
+    if re.fullmatch(
+        r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+",
+        identifier,
+    ):
+        return identifier
+
+    return ""
+
+
+def method_source(
+    source: str,
+    method: CSharpMethodDeclaration,
+) -> str:
+    """Return the source range covered by a parsed method declaration."""
+    lines = source.splitlines()
+    start = max(method.line - 1, 0)
+    end = min(
+        max(method.line_end, method.line),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
+def statement_tail(
+    source: str,
+    end: int,
+) -> str:
+    """Return the remainder of the current statement after a call."""
+    stop = source.find(";", end)
+
+    if stop < 0:
+        stop = min(
+            len(source),
+            end + 300,
+        )
+
+    return source[end:stop]
+
+
+def first_argument(
+    call: CSharpCall,
+    names: Iterable[str],
+    constants: dict[str, str],
+    position: int | None = 0,
+) -> str:
+    """Resolve the first named argument or optional positional argument."""
+    for name in names:
+        if name in call.named_arguments:
+            resolved = resolve_expression(
+                call.named_arguments[name],
+                constants,
+            )
+
+            if resolved:
+                return resolved
+
+    if position is not None and len(call.positional_arguments) > position:
+        return resolve_expression(
+            call.positional_arguments[position],
+            constants,
+        )
+
+    return ""
+
+
+def _split_callee(callee: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+
+    for index, char in enumerate(callee):
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth = max(depth - 1, 0)
+        elif char == "." and depth == 0:
+            parts.append(callee[start:index])
+            start = index + 1
+
+    parts.append(callee[start:])
+    return [part for part in parts if part]
+
+
+def _split_generic(
+    value: str,
+) -> tuple[str, tuple[str, ...]]:
+    match = re.fullmatch(
+        r"(?P<name>@?[A-Za-z_]\w*)"
+        r"\s*<(?P<args>.+)>",
+        value,
+    )
+
+    if not match:
+        return value, ()
+
+    return (
+        match.group("name"),
+        tuple(item.strip() for item in split_top_level(match.group("args")) if item.strip()),
+    )
+
+
+def _matching(
+    source: str,
+    start: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    depth = 0
+
+    for index in range(start, len(source)):
+        if source[index] == opening:
+            depth += 1
+        elif source[index] == closing:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _assignment_target(
+    source: str,
+    position: int,
+) -> str | None:
+    boundary = max(
+        source.rfind(";", 0, position),
+        source.rfind("\n", 0, position),
+    )
+    prefix = source[boundary + 1 : position]
+    match = re.search(
+        rf"(?P<name>{_IDENTIFIER})"
+        r"\s*=\s*(?:new\s+)?$",
+        prefix,
+    )
+
+    return match.group("name").removeprefix("@") if match else None
+
+
+def _named_argument(
+    value: str,
+) -> tuple[str | None, str]:
+    depth = 0
+
+    for index, char in enumerate(value):
+        if char in "([{<":
+            depth += 1
+        elif char in ")]}>":
+            depth = max(depth - 1, 0)
+        elif char == ":" and depth == 0:
+            name = value[:index].strip()
+
+            if re.fullmatch(_IDENTIFIER, name):
+                return (
+                    name.removeprefix("@"),
+                    value[index + 1 :].strip(),
+                )
+
+    return None, value
+
+
+def _decode_string(value: str) -> str | None:
+    raw_match = re.fullmatch(
+        r'\$*(?:@)?"""(.*)"""',
+        value,
+        re.DOTALL,
+    )
+
+    if raw_match:
+        return raw_match.group(1)
+
+    prefix_match = re.fullmatch(
+        r"(?P<prefix>\$@|@\$|\$|@)?"
+        r'"(?P<body>.*)"',
+        value,
+        re.DOTALL,
+    )
+
+    if not prefix_match:
+        return None
+
+    prefix = prefix_match.group("prefix") or ""
+    body = prefix_match.group("body")
+
+    if "@" in prefix:
+        return body.replace('""', '"')
+
+    replacements = {
+        r"\n": "\n",
+        r"\r": "\r",
+        r"\t": "\t",
+        r"\"": '"',
+        r"\\": "\\",
+    }
+
+    return re.sub(
+        r"\\(?:n|r|t|\"|\\)",
+        lambda match: replacements.get(
+            match.group(0),
+            match.group(0),
+        ),
+        body,
+    )
+
+
+def _balanced_outer(value: str) -> bool:
+    depth = 0
+
+    for index, char in enumerate(value):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+
+            if depth == 0 and index != len(value) - 1:
+                return False
+
+    return depth == 0
+
+
+__all__ = [
+    "CSharpCall",
+    "find_calls",
+    "first_argument",
+    "line_number",
+    "mask_non_code",
+    "method_source",
+    "parse_arguments",
+    "resolve_expression",
+    "split_top_level",
+    "statement_tail",
+    "string_constants",
+]

--- a/nuguard/sbom/adapters/csharp/aspnet_core.py
+++ b/nuguard/sbom/adapters/csharp/aspnet_core.py
@@ -1,0 +1,914 @@
+"""C# adapter for AI-facing ASP.NET Core routes."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import (
+    find_calls,
+    method_source,
+    parse_arguments,
+    resolve_expression,
+    statement_tail,
+    string_constants,
+)
+
+_HTTP_ATTRIBUTES = {
+    "HttpGet": "GET",
+    "HttpPost": "POST",
+    "HttpPut": "PUT",
+    "HttpDelete": "DELETE",
+    "HttpPatch": "PATCH",
+}
+_MAP_METHODS = {
+    "MapGet": "GET",
+    "MapPost": "POST",
+    "MapPut": "PUT",
+    "MapDelete": "DELETE",
+    "MapPatch": "PATCH",
+}
+_PROMPT_FIELDS = {
+    "message",
+    "messages",
+    "prompt",
+    "query",
+    "question",
+    "input",
+    "text",
+    "userinput",
+    "user_input",
+}
+_RESPONSE_FIELDS = {
+    "answer",
+    "content",
+    "message",
+    "output",
+    "response",
+    "result",
+    "text",
+}
+_PRIMITIVE_TYPES = {
+    "bool",
+    "byte",
+    "char",
+    "DateTime",
+    "DateTimeOffset",
+    "decimal",
+    "double",
+    "float",
+    "Guid",
+    "int",
+    "long",
+    "short",
+    "string",
+    "uint",
+    "ulong",
+    "ushort",
+}
+_INFRASTRUCTURE_TYPES = {
+    "CancellationToken",
+    "ClaimsPrincipal",
+    "HttpContext",
+    "HttpRequest",
+    "HttpResponse",
+    "IFormFile",
+    "IHeaderDictionary",
+    "IServiceProvider",
+}
+_AI_ROUTE_RE = re.compile(
+    r"(?:^|[/_-])"
+    r"(?:ai|ask|assistant|chat|complete|"
+    r"completion|generate|inference|model|"
+    r"predict|prompt)"
+    r"(?:$|[/_-])",
+    re.IGNORECASE,
+)
+_AI_CODE_RE = re.compile(
+    r"\b(?:AnthropicClient|AzureOpenAIClient|"
+    r"ChatClient|CompleteChat(?:Async)?|"
+    r"GetChatClient|Kernel\.(?:CreateBuilder|Invoke)|"
+    r"InvokePrompt(?:Async)?|"
+    r"Messages\.(?:Create|CreateAsync)|"
+    r"MLContext|PredictionEngine|"
+    r"OpenAIClient|ResponsesClient)\b"
+)
+_AI_NAMESPACE_PREFIXES = (
+    "Anthropic",
+    "Azure.AI.OpenAI",
+    "Microsoft.ML",
+    "Microsoft.SemanticKernel",
+    "OpenAI",
+)
+_PROPERTY_RE = re.compile(
+    r"(?m)^\s*public\s+"
+    r"(?P<type>[A-Za-z_][\w.<>,?\[\]]*)\s+"
+    r"(?P<name>[A-Za-z_]\w*)\s*"
+    r"\{\s*(?:get|init|set)\s*;"
+)
+
+
+class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
+    """Detect AI-facing controllers and Minimal API endpoints."""
+
+    name = "csharp_aspnet_core"
+    priority = 50
+    handles_namespaces = ["Microsoft.AspNetCore"]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result) and "WebApplication.CreateBuilder" not in content:
+            return []
+
+        constants = string_constants(result)
+        root = "framework:aspnet_core"
+        import_line = next(
+            (
+                item.line
+                for item in result.using_directives
+                if item.namespace.startswith("Microsoft.AspNetCore")
+            ),
+            0,
+        )
+        detections: list[ComponentDetection] = [
+            ComponentDetection(
+                component_type=(ComponentType.FRAMEWORK),
+                canonical_name=root,
+                display_name="ASP.NET Core",
+                adapter_name=self.name,
+                priority=self.priority,
+                confidence=0.97,
+                metadata={
+                    "framework": "aspnet_core",
+                    "language": "csharp",
+                },
+                file_path=file_path,
+                line=import_line,
+                snippet=("using Microsoft.AspNetCore"),
+                evidence_kind="ast_import",
+            )
+        ]
+
+        ai_imported = any(
+            any(
+                (item.namespace == prefix or item.namespace.startswith(prefix + "."))
+                for prefix in _AI_NAMESPACE_PREFIXES
+            )
+            for item in result.using_directives
+        )
+
+        detections.extend(
+            self._controller_endpoints(
+                content,
+                file_path,
+                result,
+                constants,
+                ai_imported,
+                root,
+            )
+        )
+        detections.extend(
+            self._minimal_endpoints(
+                content,
+                file_path,
+                result,
+                constants,
+                ai_imported,
+                root,
+            )
+        )
+
+        return _dedupe(detections)
+
+    def _controller_endpoints(
+        self,
+        content: str,
+        file_path: str,
+        result: Any,
+        constants: dict[str, str],
+        ai_imported: bool,
+        root: str,
+    ) -> list[ComponentDetection]:
+        detections: list[ComponentDetection] = []
+        controllers = {
+            item.name: (
+                item,
+                _declaration_attributes(
+                    item.attributes,
+                    item.signature,
+                ),
+            )
+            for item in result.type_declarations
+            if (
+                any(_base_type(base) == "ControllerBase" for base in item.base_types)
+                or _has_attribute(
+                    _declaration_attributes(
+                        item.attributes,
+                        item.signature,
+                    ),
+                    "ApiController",
+                )
+            )
+        }
+
+        for method in result.method_declarations:
+            controller_entry = controllers.get(method.containing_type or "")
+
+            if controller_entry is None:
+                continue
+
+            (
+                controller,
+                controller_attributes,
+            ) = controller_entry
+            method_attributes = _declaration_attributes(
+                method.attributes,
+                method.signature,
+            )
+            http_attribute = _http_attribute(
+                method_attributes,
+                constants,
+            )
+
+            if http_attribute is None:
+                continue
+
+            http_method, action_route = http_attribute
+            base_route = _route_attribute(
+                controller_attributes,
+                constants,
+            )
+            route = _combine_routes(
+                base_route,
+                action_route,
+                controller.name,
+                method.name,
+            )
+            body = method_source(
+                content,
+                method,
+            )
+
+            if not _is_ai_endpoint(
+                route,
+                method.name,
+                body,
+                ai_imported,
+            ):
+                continue
+
+            auth_required = (
+                _has_attribute(
+                    controller_attributes,
+                    "Authorize",
+                )
+                or _has_attribute(
+                    method_attributes,
+                    "Authorize",
+                )
+            ) and not _has_attribute(
+                method_attributes,
+                "AllowAnonymous",
+            )
+
+            params = [
+                parsed
+                for value in method.parameters
+                if (parsed := _parse_parameter(value)) is not None
+            ]
+            (
+                request_type,
+                request_name,
+            ) = _request_parameter(params)
+            request_schema = _schema_for_type(
+                content,
+                result,
+                request_type,
+            )
+            chat_key = _chat_key(
+                request_schema,
+                body,
+                request_name,
+            )
+            response_type = _unwrap_return_type(method.return_type or "")
+            response_schema = _schema_for_type(
+                content,
+                result,
+                response_type,
+            )
+            response_key = _response_key(response_schema)
+
+            detections.append(
+                _endpoint_node(
+                    adapter=self,
+                    root=root,
+                    file_path=file_path,
+                    line=method.line,
+                    http_method=http_method,
+                    route=route,
+                    display_name=method.name,
+                    snippet=method.signature,
+                    evidence_kind=("ast_attribute"),
+                    auth_required=(auth_required),
+                    request_schema=(request_schema),
+                    response_schema=(response_schema),
+                    chat_key=chat_key,
+                    response_key=response_key,
+                )
+            )
+
+        return detections
+
+    def _minimal_endpoints(
+        self,
+        content: str,
+        file_path: str,
+        result: Any,
+        constants: dict[str, str],
+        ai_imported: bool,
+        root: str,
+    ) -> list[ComponentDetection]:
+        detections: list[ComponentDetection] = []
+
+        for call in find_calls(
+            content,
+            set(_MAP_METHODS),
+        ):
+            if not call.positional_arguments:
+                continue
+
+            route = resolve_expression(
+                call.positional_arguments[0],
+                constants,
+            )
+
+            if not route:
+                continue
+
+            handler = call.positional_arguments[-1] if len(call.positional_arguments) > 1 else ""
+
+            if not _is_ai_endpoint(
+                route,
+                call.name,
+                handler,
+                ai_imported,
+            ):
+                continue
+
+            params = [
+                parsed
+                for value in _lambda_parameters(handler)
+                if (parsed := _parse_parameter(value)) is not None
+            ]
+            (
+                request_type,
+                request_name,
+            ) = _request_parameter(params)
+            request_schema = _schema_for_type(
+                content,
+                result,
+                request_type,
+            )
+            chat_key = _chat_key(
+                request_schema,
+                handler,
+                request_name,
+            )
+            auth_required = "RequireAuthorization" in statement_tail(
+                content,
+                call.end,
+            )
+            normalized_route = _normalize_route(route)
+            method = _MAP_METHODS[call.name]
+
+            detections.append(
+                _endpoint_node(
+                    adapter=self,
+                    root=root,
+                    file_path=file_path,
+                    line=call.line,
+                    http_method=method,
+                    route=normalized_route,
+                    display_name=(f"{method} {normalized_route}"),
+                    snippet=call.snippet,
+                    evidence_kind="ast_call",
+                    auth_required=(auth_required),
+                    request_schema=(request_schema),
+                    response_schema={},
+                    chat_key=chat_key,
+                    response_key=None,
+                )
+            )
+
+        return detections
+
+
+def _endpoint_node(
+    adapter: CSharpAspNetCoreAdapter,
+    root: str,
+    file_path: str,
+    line: int,
+    http_method: str,
+    route: str,
+    display_name: str,
+    snippet: str,
+    evidence_kind: str,
+    auth_required: bool,
+    request_schema: dict[str, str],
+    response_schema: dict[str, str],
+    chat_key: str | None,
+    response_key: str | None,
+) -> ComponentDetection:
+    canonical = canonicalize_text(f"aspnet:endpoint:{http_method}:{route}")
+    metadata: dict[str, Any] = {
+        "framework": "aspnet_core",
+        "method": http_method,
+        "endpoint": route,
+        "auth_required": auth_required,
+        "language": "csharp",
+    }
+
+    if request_schema:
+        metadata["request_body_schema"] = request_schema
+
+    if response_schema:
+        metadata["response_body_schema"] = response_schema
+
+    if chat_key:
+        metadata["chat_payload_key"] = chat_key
+        metadata["chat_payload_list"] = False
+
+    if response_key:
+        metadata["response_text_key"] = response_key
+
+    return ComponentDetection(
+        component_type=(ComponentType.API_ENDPOINT),
+        canonical_name=canonical,
+        display_name=display_name,
+        adapter_name=adapter.name,
+        priority=adapter.priority,
+        confidence=0.92,
+        metadata=metadata,
+        file_path=file_path,
+        line=line,
+        snippet=snippet,
+        evidence_kind=evidence_kind,
+        relationships=[
+            RelationshipHint(
+                source_canonical=root,
+                source_type=(ComponentType.FRAMEWORK),
+                target_canonical=canonical,
+                target_type=(ComponentType.API_ENDPOINT),
+                relationship_type="CALLS",
+            )
+        ],
+    )
+
+
+def _declaration_attributes(
+    parsed: tuple[str, ...],
+    signature: str,
+) -> tuple[str, ...]:
+    """Recover attributes containing brackets inside route strings."""
+    recovered: list[str] = []
+    index = 0
+
+    while index < len(signature):
+        start = signature.find(
+            "[",
+            index,
+        )
+
+        if start < 0:
+            break
+
+        depth = 1
+        quote: str | None = None
+        escaped = False
+        cursor = start + 1
+
+        while cursor < len(signature):
+            char = signature[cursor]
+
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif char == "\\" and quote == '"':
+                    escaped = True
+                elif char == quote:
+                    quote = None
+            elif char in {'"', "'"}:
+                quote = char
+            elif char == "[":
+                depth += 1
+            elif char == "]":
+                depth -= 1
+
+                if depth == 0:
+                    recovered.append(signature[start + 1 : cursor].strip())
+                    cursor += 1
+                    break
+
+            cursor += 1
+
+        if depth != 0:
+            break
+
+        index = cursor
+
+    return tuple(recovered) if recovered else parsed
+
+
+def _http_attribute(
+    attributes: tuple[str, ...],
+    constants: dict[str, str],
+) -> tuple[str, str] | None:
+    for attribute in attributes:
+        name, positional = _attribute_parts(
+            attribute,
+            constants,
+        )
+
+        if name in _HTTP_ATTRIBUTES:
+            return (
+                _HTTP_ATTRIBUTES[name],
+                positional[0] if positional else "",
+            )
+
+    return None
+
+
+def _route_attribute(
+    attributes: tuple[str, ...],
+    constants: dict[str, str],
+) -> str:
+    for attribute in attributes:
+        name, positional = _attribute_parts(
+            attribute,
+            constants,
+        )
+
+        if name == "Route" and positional:
+            return positional[0]
+
+    return ""
+
+
+def _attribute_parts(
+    attribute: str,
+    constants: dict[str, str],
+) -> tuple[str, list[str]]:
+    value = attribute.strip()
+
+    if "(" not in value:
+        return (
+            value.split(".")[-1].removesuffix("Attribute"),
+            [],
+        )
+
+    name, raw = value.split(
+        "(",
+        1,
+    )
+    raw = raw.rsplit(
+        ")",
+        1,
+    )[0]
+    _, positional = parse_arguments(raw)
+
+    return (
+        name.split(".")[-1].removesuffix("Attribute"),
+        [
+            resolved
+            for item in positional
+            if (
+                resolved := resolve_expression(
+                    item,
+                    constants,
+                )
+            )
+        ],
+    )
+
+
+def _has_attribute(
+    attributes: tuple[str, ...],
+    expected: str,
+) -> bool:
+    return any(
+        (
+            attribute.split(
+                "(",
+                1,
+            )[0]
+            .split(".")[-1]
+            .removesuffix("Attribute")
+            == expected
+        )
+        for attribute in attributes
+    )
+
+
+def _combine_routes(
+    base: str,
+    action: str,
+    controller_name: str,
+    action_name: str,
+) -> str:
+    controller = controller_name.removesuffix("Controller")
+    combined = "/".join(part.strip("/") for part in (base, action) if part.strip("/"))
+    combined = re.sub(
+        r"\[controller\]",
+        controller,
+        combined,
+        flags=re.IGNORECASE,
+    )
+    combined = re.sub(
+        r"\[action\]",
+        action_name,
+        combined,
+        flags=re.IGNORECASE,
+    )
+    return _normalize_route(combined)
+
+
+def _normalize_route(route: str) -> str:
+    clean = re.sub(
+        r"/{2,}",
+        "/",
+        "/" + route.strip(),
+    )
+    return clean if clean else "/"
+
+
+def _is_ai_endpoint(
+    route: str,
+    name: str,
+    body: str,
+    ai_imported: bool,
+) -> bool:
+    route_and_name = f"{route}/{name}"
+
+    if _AI_ROUTE_RE.search(route_and_name):
+        return True
+
+    if _AI_CODE_RE.search(body):
+        return True
+
+    return ai_imported and bool(
+        re.search(
+            r"\b(?:client|kernel|"
+            r"model|prompt)\b",
+            body,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _lambda_parameters(
+    handler: str,
+) -> list[str]:
+    match = re.search(
+        r"(?:async\s*)?"
+        r"\((?P<params>[^()]*)\)"
+        r"\s*=>",
+        handler,
+        re.DOTALL,
+    )
+
+    if match:
+        _, positional = parse_arguments(match.group("params"))
+        return positional
+
+    single = re.search(
+        r"(?:async\s+)?"
+        r"(?P<param>[A-Za-z_]\w*)"
+        r"\s*=>",
+        handler,
+    )
+
+    return [single.group("param")] if single else []
+
+
+def _parse_parameter(
+    value: str,
+) -> tuple[str, str, bool] | None:
+    clean = (
+        re.sub(
+            r"\[[^\]]+\]\s*",
+            "",
+            value,
+        )
+        .split(
+            "=",
+            1,
+        )[0]
+        .strip()
+    )
+    clean = re.sub(
+        r"\b(?:in|out|params|ref|"
+        r"scoped|this)\s+",
+        "",
+        clean,
+    )
+    match = re.search(
+        r"(?P<type>"
+        r"[A-Za-z_][\w.<>,?\[\]]*)"
+        r"\s+"
+        r"(?P<name>@?[A-Za-z_]\w*)$",
+        clean,
+    )
+
+    if not match:
+        return None
+
+    return (
+        match.group("type"),
+        match.group("name").removeprefix("@"),
+        "FromBody" in value,
+    )
+
+
+def _request_parameter(
+    parameters: list[tuple[str, str, bool]],
+) -> tuple[str, str | None]:
+    ordered = sorted(
+        parameters,
+        key=lambda item: not item[2],
+    )
+
+    for type_name, name, _ in ordered:
+        base = _base_type(type_name)
+
+        if base in _PRIMITIVE_TYPES or base in _INFRASTRUCTURE_TYPES:
+            continue
+
+        if base.startswith("I") and len(base) > 1 and base[1].isupper():
+            continue
+
+        return base, name
+
+    return "", None
+
+
+def _schema_for_type(
+    content: str,
+    result: Any,
+    type_name: str,
+) -> dict[str, str]:
+    if not type_name:
+        return {}
+
+    declaration = next(
+        (item for item in result.type_declarations if item.name == _base_type(type_name)),
+        None,
+    )
+
+    if declaration is None:
+        return {}
+
+    schema: dict[str, str] = {}
+    record_match = re.search(
+        r"\((?P<params>[^()]*)\)",
+        declaration.signature,
+        re.DOTALL,
+    )
+
+    if record_match:
+        _, values = parse_arguments(record_match.group("params"))
+
+        for value in values:
+            parameter = _parse_parameter(value)
+
+            if parameter is not None:
+                (
+                    field_type,
+                    field_name,
+                    _,
+                ) = parameter
+                schema[field_name] = field_type
+
+    lines = content.splitlines()
+    start = max(
+        declaration.line - 1,
+        0,
+    )
+    end = min(
+        max(
+            declaration.line_end,
+            declaration.line,
+        ),
+        len(lines),
+    )
+
+    for match in _PROPERTY_RE.finditer("\n".join(lines[start:end])):
+        schema.setdefault(
+            match.group("name"),
+            match.group("type"),
+        )
+
+    return schema
+
+
+def _chat_key(
+    schema: dict[str, str],
+    body: str,
+    request_name: str | None,
+) -> str | None:
+    for field in schema:
+        if field.lower() in _PROMPT_FIELDS:
+            return field
+
+    if request_name:
+        match = re.search(
+            rf"\b{re.escape(request_name)}"
+            r"\.(?P<field>[A-Za-z_]\w*)",
+            body,
+        )
+
+        if match and match.group("field").lower() in _PROMPT_FIELDS:
+            return match.group("field")
+
+    return None
+
+
+def _response_key(
+    schema: dict[str, str],
+) -> str | None:
+    return next(
+        (field for field in schema if field.lower() in _RESPONSE_FIELDS),
+        None,
+    )
+
+
+def _unwrap_return_type(value: str) -> str:
+    clean = value.strip().rstrip("?")
+    wrappers = (
+        "Task",
+        "ValueTask",
+        "ActionResult",
+        "Results",
+    )
+    changed = True
+
+    while changed:
+        changed = False
+
+        for wrapper in wrappers:
+            match = re.fullmatch(
+                rf"{wrapper}\s*"
+                r"<\s*(.+)\s*>",
+                clean,
+            )
+
+            if match:
+                clean = match.group(1).split(",", 1)[0].strip()
+                changed = True
+                break
+
+    return _base_type(clean)
+
+
+def _base_type(value: str) -> str:
+    clean = value.strip().rstrip("?")
+    clean = clean.removeprefix("global::")
+    clean = clean.split("<", 1)[0]
+    return clean.split(".")[-1]
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpAspNetCoreAdapter"]

--- a/nuguard/sbom/adapters/csharp/aspnet_core.py
+++ b/nuguard/sbom/adapters/csharp/aspnet_core.py
@@ -11,9 +11,11 @@ from ..base import ComponentDetection, RelationshipHint
 from ._csharp_base import CSharpFrameworkAdapter
 from ._source import (
     find_calls,
+    mask_non_code,
     method_source,
     parse_arguments,
     resolve_expression,
+    split_top_level,
     statement_tail,
     string_constants,
 )
@@ -131,7 +133,19 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
             parse_result,
         )
 
-        if not self._detect(result) and "WebApplication.CreateBuilder" not in content:
+        builder_call = next(
+            (
+                call
+                for call in find_calls(
+                    content,
+                    {"CreateBuilder"},
+                )
+                if (call.receiver or "").split(".")[-1] == "WebApplication"
+            ),
+            None,
+        )
+
+        if not self._detect(result) and builder_call is None:
             return []
 
         constants = string_constants(result)
@@ -280,9 +294,15 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                     method_attributes,
                     "Authorize",
                 )
-            ) and not _has_attribute(
-                method_attributes,
-                "AllowAnonymous",
+            ) and not (
+                _has_attribute(
+                    controller_attributes,
+                    "AllowAnonymous",
+                )
+                or _has_attribute(
+                    method_attributes,
+                    "AllowAnonymous",
+                )
             )
 
             params = [
@@ -388,10 +408,20 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 handler,
                 request_name,
             )
-            auth_required = "RequireAuthorization" in statement_tail(
-                content,
-                call.end,
+            tail = mask_non_code(
+                statement_tail(
+                    content,
+                    call.end,
+                )
             )
+            auth_required = "RequireAuthorization" in tail and "AllowAnonymous" not in tail
+            response_type = _minimal_response_type(handler)
+            response_schema = _schema_for_type(
+                content,
+                result,
+                response_type,
+            )
+            response_key = _response_key(response_schema)
             normalized_route = _normalize_route(route)
             method = _MAP_METHODS[call.name]
 
@@ -408,9 +438,9 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                     evidence_kind="ast_call",
                     auth_required=(auth_required),
                     request_schema=(request_schema),
-                    response_schema={},
+                    response_schema=(response_schema),
                     chat_key=chat_key,
-                    response_key=None,
+                    response_key=response_key,
                 )
             )
 
@@ -519,7 +549,11 @@ def _declaration_attributes(
                 depth -= 1
 
                 if depth == 0:
-                    recovered.append(signature[start + 1 : cursor].strip())
+                    recovered.extend(
+                        item.strip()
+                        for item in split_top_level(signature[start + 1 : cursor])
+                        if item.strip()
+                    )
                     cursor += 1
                     break
 
@@ -666,17 +700,58 @@ def _is_ai_endpoint(
     if _AI_ROUTE_RE.search(route_and_name):
         return True
 
-    if _AI_CODE_RE.search(body):
+    code = mask_non_code(body)
+
+    if _AI_CODE_RE.search(code):
         return True
 
     return ai_imported and bool(
         re.search(
             r"\b(?:client|kernel|"
             r"model|prompt)\b",
-            body,
+            code,
             re.IGNORECASE,
         )
     )
+
+
+def _minimal_response_type(
+    handler: str,
+) -> str:
+    """Infer a DTO instantiated by a Minimal API handler."""
+    code = mask_non_code(handler)
+    type_pattern = (
+        r"(?P<type>(?:global::)?"
+        r"[A-Za-z_]\w*"
+        r"(?:\.[A-Za-z_]\w*)*)"
+    )
+    patterns = (
+        (
+            r"\breturn\s+"
+            r"(?:await\s+)?"
+            r"(?:Results\.\w+\s*"
+            r"\(\s*)?"
+            r"new\s+" + type_pattern + r"\s*\("
+        ),
+        (
+            r"=>\s*"
+            r"(?:Results\.\w+\s*"
+            r"\(\s*)?"
+            r"new\s+" + type_pattern + r"\s*\("
+        ),
+    )
+
+    for pattern in patterns:
+        match = re.search(
+            pattern,
+            code,
+            re.DOTALL,
+        )
+
+        if match is not None:
+            return _base_type(match.group("type"))
+
+    return ""
 
 
 def _lambda_parameters(

--- a/nuguard/sbom/adapters/csharp/llm_clients.py
+++ b/nuguard/sbom/adapters/csharp/llm_clients.py
@@ -1,0 +1,410 @@
+"""C# adapters for the Azure OpenAI, OpenAI, and Anthropic SDKs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ..models_kb import get_model_details, infer_provider
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import (
+    find_calls,
+    first_argument,
+    line_number,
+    resolve_expression,
+    string_constants,
+)
+
+_PROVIDER_NAMESPACES: dict[str, tuple[str, ...]] = {
+    "azure": ("Azure.AI.OpenAI",),
+    "openai": ("OpenAI",),
+    "anthropic": ("Anthropic",),
+}
+_CLIENT_CLASSES: dict[str, str] = {
+    "AzureOpenAIClient": "azure",
+    "OpenAIClient": "openai",
+    "ChatClient": "openai",
+    "ResponsesClient": "openai",
+    "EmbeddingClient": "openai",
+    "AssistantClient": "openai",
+    "AnthropicClient": "anthropic",
+}
+_MODEL_CLIENT_CLASSES = {
+    "ChatClient",
+    "ResponsesClient",
+    "EmbeddingClient",
+}
+_MODEL_FACTORY_CALLS = {
+    "GetChatClient",
+    "GetResponsesClient",
+    "GetEmbeddingClient",
+    "GetAssistantClient",
+}
+_MODEL_API_CALLS = {
+    "CompleteChat",
+    "CompleteChatAsync",
+    "Create",
+    "CreateAsync",
+    "GenerateResponse",
+    "GenerateResponseAsync",
+}
+_MODEL_ASSIGNMENT_RE = re.compile(
+    r"\bModel\s*=\s*(?P<value>"
+    r'\$?@?"(?:""|\\.|[^"])*"'
+    r"|[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)",
+    re.MULTILINE,
+)
+
+
+class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
+    """Detect direct C# usage of supported LLM client libraries."""
+
+    name = "csharp_llm_clients"
+    priority = 90
+    handles_namespaces = [
+        "Azure.AI.OpenAI",
+        "OpenAI",
+        "Anthropic",
+    ]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+        providers = _providers_from_result(result)
+
+        strong_markers = (
+            "AzureOpenAIClient",
+            "AnthropicClient",
+            "OpenAI.Chat.ChatClient",
+            "OpenAI.Responses.ResponsesClient",
+            "OpenAI.Embeddings.EmbeddingClient",
+        )
+
+        if not providers and not any(marker in content for marker in strong_markers):
+            return []
+
+        constants = string_constants(result)
+        detections: list[ComponentDetection] = []
+        provider_lines: dict[str, int] = {}
+
+        for directive in result.using_directives:
+            provider = _provider_for_namespace(directive.namespace)
+
+            if provider is not None:
+                provider_lines.setdefault(
+                    provider,
+                    directive.line,
+                )
+
+        calls = find_calls(
+            content,
+            set(_CLIENT_CLASSES) | _MODEL_FACTORY_CALLS | _MODEL_API_CALLS,
+        )
+
+        client_providers: dict[str, str] = {}
+
+        for call in calls:
+            provider = _provider_for_call(
+                call.name,
+                call.receiver,
+                providers,
+                client_providers,
+            )
+
+            if provider is not None and call.assigned_to:
+                client_providers[call.assigned_to] = provider
+
+        for call in calls:
+            provider = _provider_for_call(
+                call.name,
+                call.receiver,
+                providers,
+                client_providers,
+            )
+
+            if provider is None:
+                continue
+
+            provider_lines.setdefault(
+                provider,
+                call.line,
+            )
+            model_name = ""
+
+            if call.name in _MODEL_CLIENT_CLASSES and call.is_constructor:
+                model_name = first_argument(
+                    call,
+                    (
+                        "model",
+                        "modelId",
+                        "model_id",
+                        "deploymentName",
+                    ),
+                    constants,
+                    0,
+                )
+            elif call.name in _MODEL_FACTORY_CALLS:
+                model_name = first_argument(
+                    call,
+                    (
+                        "model",
+                        "modelId",
+                        "deploymentName",
+                        "deployment",
+                    ),
+                    constants,
+                    0,
+                )
+            elif call.name in _MODEL_API_CALLS:
+                model_name = first_argument(
+                    call,
+                    (
+                        "model",
+                        "modelId",
+                        "model_id",
+                    ),
+                    constants,
+                    None,
+                )
+
+            if model_name:
+                detections.append(
+                    _model_node(
+                        adapter=self,
+                        provider=provider,
+                        model_name=model_name,
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        client_class=call.name,
+                    )
+                )
+
+        if "anthropic" in providers or "AnthropicClient" in content:
+            for match in _MODEL_ASSIGNMENT_RE.finditer(content):
+                model_name = resolve_expression(
+                    match.group("value"),
+                    constants,
+                )
+
+                if not model_name:
+                    continue
+
+                line = line_number(
+                    content,
+                    match.start(),
+                )
+                provider_lines.setdefault(
+                    "anthropic",
+                    line,
+                )
+                detections.append(
+                    _model_node(
+                        adapter=self,
+                        provider="anthropic",
+                        model_name=model_name,
+                        file_path=file_path,
+                        line=line,
+                        snippet=" ".join(match.group(0).split()),
+                        client_class="AnthropicClient",
+                    )
+                )
+
+        for provider in sorted(providers | set(provider_lines)):
+            detections.insert(
+                0,
+                _framework_node(
+                    adapter=self,
+                    provider=provider,
+                    file_path=file_path,
+                    line=provider_lines.get(
+                        provider,
+                        0,
+                    ),
+                ),
+            )
+
+        return _dedupe(detections)
+
+
+def _providers_from_result(
+    result: Any,
+) -> set[str]:
+    providers: set[str] = set()
+
+    for directive in result.using_directives:
+        provider = _provider_for_namespace(directive.namespace)
+
+        if provider is not None:
+            providers.add(provider)
+
+    return providers
+
+
+def _provider_for_namespace(
+    namespace: str,
+) -> str | None:
+    clean = namespace.removeprefix("global::")
+
+    for provider, prefixes in _PROVIDER_NAMESPACES.items():
+        if any(clean == prefix or clean.startswith(prefix + ".") for prefix in prefixes):
+            return provider
+
+    return None
+
+
+def _provider_for_call(
+    name: str,
+    receiver: str | None,
+    imported: set[str],
+    client_providers: dict[str, str],
+) -> str | None:
+    if name == "OpenAIClient" and imported == {"azure"}:
+        return "azure"
+
+    if name in _CLIENT_CLASSES:
+        return _CLIENT_CLASSES[name]
+
+    receiver_text = receiver or ""
+    receiver_root = receiver_text.split(
+        ".",
+        1,
+    )[0]
+
+    if receiver_root in client_providers:
+        return client_providers[receiver_root]
+
+    if "AzureOpenAI" in receiver_text:
+        return "azure"
+
+    if "Anthropic" in receiver_text or "Messages" in receiver_text:
+        return "anthropic"
+
+    if "OpenAI" in receiver_text or "Chat" in receiver_text or "Responses" in receiver_text:
+        return "openai"
+
+    if len(imported) == 1:
+        return next(iter(imported))
+
+    return None
+
+
+def _framework_node(
+    adapter: CSharpLLMClientsAdapter,
+    provider: str,
+    file_path: str,
+    line: int,
+) -> ComponentDetection:
+    framework = "azure_openai" if provider == "azure" else provider
+    display = {
+        "azure": "Azure OpenAI .NET SDK",
+        "openai": "OpenAI .NET SDK",
+        "anthropic": "Anthropic C# SDK",
+    }[provider]
+
+    return ComponentDetection(
+        component_type=ComponentType.FRAMEWORK,
+        canonical_name=(f"framework:{framework}"),
+        display_name=display,
+        adapter_name=adapter.name,
+        priority=adapter.priority,
+        confidence=0.95,
+        metadata={
+            "framework": framework,
+            "provider": provider,
+            "language": "csharp",
+            "client_kind": "llm_sdk",
+        },
+        file_path=file_path,
+        line=line,
+        snippet=f"using {display}",
+        evidence_kind="ast_import",
+    )
+
+
+def _model_node(
+    adapter: CSharpLLMClientsAdapter,
+    provider: str,
+    model_name: str,
+    file_path: str,
+    line: int,
+    snippet: str,
+    client_class: str,
+) -> ComponentDetection:
+    inferred = infer_provider(model_name)
+    effective_provider = provider if provider != "azure" else "azure"
+
+    if effective_provider == "openai" and inferred not in {"unknown", "openai"}:
+        effective_provider = inferred
+
+    details = get_model_details(
+        model_name,
+        effective_provider,
+        {},
+    )
+    canonical = canonicalize_text(model_name.lower())
+    framework = "azure_openai" if provider == "azure" else provider
+
+    return ComponentDetection(
+        component_type=ComponentType.MODEL,
+        canonical_name=canonical,
+        display_name=model_name,
+        adapter_name=adapter.name,
+        priority=adapter.priority,
+        confidence=0.93,
+        metadata={
+            "framework": framework,
+            "provider": effective_provider,
+            "client_class": client_class,
+            "language": "csharp",
+            **{key: value for key, value in details.items() if value is not None},
+        },
+        file_path=file_path,
+        line=line,
+        snippet=snippet,
+        evidence_kind="ast_call",
+        relationships=[
+            RelationshipHint(
+                source_canonical=(f"framework:{framework}"),
+                source_type=ComponentType.FRAMEWORK,
+                target_canonical=canonical,
+                target_type=ComponentType.MODEL,
+                relationship_type="USES",
+            )
+        ],
+    )
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpLLMClientsAdapter"]

--- a/nuguard/sbom/adapters/csharp/llm_clients.py
+++ b/nuguard/sbom/adapters/csharp/llm_clients.py
@@ -14,6 +14,7 @@ from ._source import (
     find_calls,
     first_argument,
     line_number,
+    mask_non_code,
     resolve_expression,
     string_constants,
 )
@@ -51,10 +52,10 @@ _MODEL_API_CALLS = {
     "GenerateResponse",
     "GenerateResponseAsync",
 }
-_MODEL_ASSIGNMENT_RE = re.compile(
-    r"\bModel\s*=\s*(?P<value>"
-    r'\$?@?"(?:""|\\.|[^"])*"'
-    r"|[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)",
+_MODEL_ENUM_ASSIGNMENT_RE = re.compile(
+    r"\bModel\s*=\s*"
+    r"(?P<value>[A-Za-z_]\w*"
+    r"(?:\.[A-Za-z_]\w*)*)",
     re.MULTILINE,
 )
 
@@ -81,17 +82,19 @@ class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
             file_path,
             parse_result,
         )
+        code = mask_non_code(content)
         providers = _providers_from_result(result)
 
         strong_markers = (
             "AzureOpenAIClient",
+            "Azure.AI.OpenAI.OpenAIClient",
             "AnthropicClient",
             "OpenAI.Chat.ChatClient",
             "OpenAI.Responses.ResponsesClient",
             "OpenAI.Embeddings.EmbeddingClient",
         )
 
-        if not providers and not any(marker in content for marker in strong_markers):
+        if not providers and not any(marker in code for marker in strong_markers):
             return []
 
         constants = string_constants(result)
@@ -191,8 +194,33 @@ class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
                     )
                 )
 
-        if "anthropic" in providers or "AnthropicClient" in content:
-            for match in _MODEL_ASSIGNMENT_RE.finditer(content):
+        if "anthropic" in providers or "AnthropicClient" in code:
+            for literal in result.string_literals:
+                if (literal.assigned_to or "").casefold() != "model":
+                    continue
+
+                model_name = literal.value.strip()
+
+                if not model_name:
+                    continue
+
+                provider_lines.setdefault(
+                    "anthropic",
+                    literal.line,
+                )
+                detections.append(
+                    _model_node(
+                        adapter=self,
+                        provider="anthropic",
+                        model_name=model_name,
+                        file_path=file_path,
+                        line=literal.line,
+                        snippet=f'Model = "{model_name}"',
+                        client_class="AnthropicClient",
+                    )
+                )
+
+            for match in _MODEL_ENUM_ASSIGNMENT_RE.finditer(code):
                 model_name = resolve_expression(
                     match.group("value"),
                     constants,
@@ -216,7 +244,7 @@ class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
                         model_name=model_name,
                         file_path=file_path,
                         line=line,
-                        snippet=" ".join(match.group(0).split()),
+                        snippet=" ".join(content[match.start() : match.end()].split()),
                         client_class="AnthropicClient",
                     )
                 )
@@ -270,13 +298,14 @@ def _provider_for_call(
     imported: set[str],
     client_providers: dict[str, str],
 ) -> str | None:
-    if name == "OpenAIClient" and imported == {"azure"}:
+    receiver_text = receiver or ""
+
+    if name == "OpenAIClient" and (imported == {"azure"} or "Azure.AI.OpenAI" in receiver_text):
         return "azure"
 
     if name in _CLIENT_CLASSES:
         return _CLIENT_CLASSES[name]
 
-    receiver_text = receiver or ""
     receiver_root = receiver_text.split(
         ".",
         1,

--- a/nuguard/sbom/adapters/csharp/mlnet.py
+++ b/nuguard/sbom/adapters/csharp/mlnet.py
@@ -41,7 +41,22 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
             parse_result,
         )
 
-        if not self._detect(result) and "MLContext" not in content:
+        calls = find_calls(content)
+        context_calls = [
+            call
+            for call in calls
+            if (
+                call.name == "MLContext"
+                and call.is_constructor
+                and (
+                    self._detect(result)
+                    or not call.receiver
+                    or (call.receiver or "").endswith("Microsoft.ML")
+                )
+            )
+        ]
+
+        if not self._detect(result) and not context_calls:
             return []
 
         root = "framework:mlnet"
@@ -72,9 +87,10 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
             )
         ]
 
-        pipeline_emitted = False
+        emitted_pipeline_ids: set[str] = set()
+        estimator_variables: set[str] = set()
 
-        for call in find_calls(content):
+        for call in calls:
             receiver = call.receiver or ""
 
             if call.name == "MLContext" and call.is_constructor:
@@ -111,6 +127,9 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 continue
 
             if ".Trainers" in receiver:
+                if call.assigned_to:
+                    estimator_variables.add(call.assigned_to)
+
                 task = _task_from_receiver(receiver)
                 display = call.name
                 canonical = canonicalize_text(f"mlnet:trainer:{task}:{display}")
@@ -147,10 +166,15 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 continue
 
             if ".Transforms" in receiver:
-                if pipeline_emitted:
+                pipeline_id = call.assigned_to or f"line:{call.line}"
+
+                if call.assigned_to:
+                    estimator_variables.add(call.assigned_to)
+
+                if pipeline_id in emitted_pipeline_ids:
                     continue
 
-                display = call.assigned_to or "ML.NET pipeline"
+                display = call.assigned_to or f"ML.NET pipeline {call.line}"
                 canonical = canonicalize_text(f"mlnet:pipeline:{display}")
                 detections.append(
                     ComponentDetection(
@@ -172,10 +196,23 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                         evidence_kind="ast_call",
                     )
                 )
-                pipeline_emitted = True
+                emitted_pipeline_ids.add(pipeline_id)
                 continue
 
             if call.name == "Fit" and call.receiver:
+                receiver_root = call.receiver.split(
+                    ".",
+                    1,
+                )[0]
+                is_known_estimator = (
+                    receiver_root in estimator_variables
+                    or ".Transforms" in call.receiver
+                    or ".Trainers" in call.receiver
+                )
+
+                if not is_known_estimator:
+                    continue
+
                 display = call.assigned_to or f"trained_model_{call.line}"
                 canonical = canonicalize_text(f"mlnet:model:{display}")
                 detections.append(

--- a/nuguard/sbom/adapters/csharp/mlnet.py
+++ b/nuguard/sbom/adapters/csharp/mlnet.py
@@ -1,0 +1,245 @@
+"""C# adapter for ML.NET contexts, pipelines, and trainers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import find_calls
+
+_TASK_SEGMENTS = {
+    "BinaryClassification": ("binary_classification"),
+    "MulticlassClassification": ("multiclass_classification"),
+    "Regression": "regression",
+    "Clustering": "clustering",
+    "Ranking": "ranking",
+    "Recommendation": "recommendation",
+    "Forecasting": "forecasting",
+    "AnomalyDetection": "anomaly_detection",
+}
+
+
+class CSharpMLNetAdapter(CSharpFrameworkAdapter):
+    """Detect ML.NET model-building and prediction pipelines."""
+
+    name = "csharp_mlnet"
+    priority = 55
+    handles_namespaces = ["Microsoft.ML"]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result) and "MLContext" not in content:
+            return []
+
+        root = "framework:mlnet"
+        import_line = next(
+            (
+                item.line
+                for item in result.using_directives
+                if (item.namespace == "Microsoft.ML" or item.namespace.startswith("Microsoft.ML."))
+            ),
+            0,
+        )
+        detections: list[ComponentDetection] = [
+            ComponentDetection(
+                component_type=(ComponentType.FRAMEWORK),
+                canonical_name=root,
+                display_name="ML.NET",
+                adapter_name=self.name,
+                priority=self.priority,
+                confidence=0.97,
+                metadata={
+                    "framework": "mlnet",
+                    "language": "csharp",
+                },
+                file_path=file_path,
+                line=import_line,
+                snippet="using Microsoft.ML",
+                evidence_kind="ast_import",
+            )
+        ]
+
+        pipeline_emitted = False
+
+        for call in find_calls(content):
+            receiver = call.receiver or ""
+
+            if call.name == "MLContext" and call.is_constructor:
+                display = call.assigned_to or "MLContext"
+                canonical = canonicalize_text(f"mlnet:context:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.FRAMEWORK),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.95,
+                        metadata={
+                            "framework": "mlnet",
+                            "context_class": ("MLContext"),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind=("ast_instantiation"),
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.FRAMEWORK),
+                                relationship_type=("CONTAINS"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if ".Trainers" in receiver:
+                task = _task_from_receiver(receiver)
+                display = call.name
+                canonical = canonicalize_text(f"mlnet:trainer:{task}:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.MODEL),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.92,
+                        metadata={
+                            "framework": "mlnet",
+                            "provider": "mlnet",
+                            "trainer": call.name,
+                            "task": task,
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.MODEL),
+                                relationship_type="USES",
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if ".Transforms" in receiver:
+                if pipeline_emitted:
+                    continue
+
+                display = call.assigned_to or "ML.NET pipeline"
+                canonical = canonicalize_text(f"mlnet:pipeline:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.FRAMEWORK),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.86,
+                        metadata={
+                            "framework": "mlnet",
+                            "pipeline": True,
+                            "first_stage": call.name,
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                    )
+                )
+                pipeline_emitted = True
+                continue
+
+            if call.name == "Fit" and call.receiver:
+                display = call.assigned_to or f"trained_model_{call.line}"
+                canonical = canonicalize_text(f"mlnet:model:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.MODEL),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.90,
+                        metadata={
+                            "framework": "mlnet",
+                            "provider": "mlnet",
+                            "trained_model": True,
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.MODEL),
+                                relationship_type="USES",
+                            )
+                        ],
+                    )
+                )
+
+        return _dedupe(detections)
+
+
+def _task_from_receiver(
+    receiver: str,
+) -> str:
+    for segment, task in _TASK_SEGMENTS.items():
+        if segment in receiver:
+            return task
+
+    return "machine_learning"
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpMLNetAdapter"]

--- a/nuguard/sbom/adapters/csharp/semantic_kernel.py
+++ b/nuguard/sbom/adapters/csharp/semantic_kernel.py
@@ -66,7 +66,30 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
             parse_result,
         )
 
-        if not self._detect(result) and "Microsoft.SemanticKernel" not in content:
+        calls = find_calls(
+            content,
+            _KERNEL_CALLS | set(_SERVICE_CALLS) | _PLUGIN_CALLS | _PLANNER_CLASSES,
+        )
+        has_kernel_call = any(
+            (call.name == "CreateBuilder" and (call.receiver or "").split(".")[-1] == "Kernel")
+            or (call.name == "KernelBuilder" and call.is_constructor)
+            or call.name in _SERVICE_CALLS
+            or call.name in _PLUGIN_CALLS
+            or (call.name in _PLANNER_CLASSES and call.is_constructor)
+            for call in calls
+        )
+        has_kernel_attribute = any(
+            any(
+                (
+                    attribute.split("(", 1)[0].split(".")[-1].removesuffix("Attribute")
+                    == "KernelFunction"
+                )
+                for attribute in method.attributes
+            )
+            for method in result.method_declarations
+        )
+
+        if not self._detect(result) and not has_kernel_call and not has_kernel_attribute:
             return []
 
         constants = string_constants(result)
@@ -97,11 +120,6 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
                 evidence_kind="ast_import",
             )
         ]
-
-        calls = find_calls(
-            content,
-            _KERNEL_CALLS | set(_SERVICE_CALLS) | _PLUGIN_CALLS | _PLANNER_CLASSES,
-        )
 
         builder_variables: set[str] = set()
 

--- a/nuguard/sbom/adapters/csharp/semantic_kernel.py
+++ b/nuguard/sbom/adapters/csharp/semantic_kernel.py
@@ -1,0 +1,418 @@
+"""C# adapter for Microsoft Semantic Kernel."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ..models_kb import get_model_details
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import (
+    find_calls,
+    first_argument,
+    string_constants,
+)
+
+_SERVICE_CALLS: dict[str, str] = {
+    "AddAzureOpenAIChatCompletion": "azure",
+    "AddAzureOpenAITextEmbeddingGeneration": "azure",
+    "AddOpenAIChatCompletion": "openai",
+    "AddOpenAITextEmbeddingGeneration": "openai",
+    "AddAnthropicChatCompletion": "anthropic",
+    "AddOllamaChatCompletion": "ollama",
+    "AddMistralChatCompletion": "mistral",
+}
+_PLUGIN_CALLS = {
+    "AddFromType",
+    "ImportPluginFromType",
+    "AddFromObject",
+    "ImportPluginFromObject",
+    "AddFromPromptDirectory",
+    "ImportPluginFromPromptDirectory",
+    "CreateFromType",
+}
+_PLANNER_CLASSES = {
+    "ActionPlanner",
+    "FunctionCallingStepwisePlanner",
+    "HandlebarsPlanner",
+    "SequentialPlanner",
+    "StepwisePlanner",
+}
+_KERNEL_CALLS = {
+    "CreateBuilder",
+    "Build",
+    "KernelBuilder",
+}
+
+
+class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
+    """Detect Semantic Kernel services, plugins, planners, and prompts."""
+
+    name = "csharp_semantic_kernel"
+    priority = 40
+    handles_namespaces = ["Microsoft.SemanticKernel"]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result) and "Microsoft.SemanticKernel" not in content:
+            return []
+
+        constants = string_constants(result)
+        root = "framework:semantic_kernel"
+        import_line = next(
+            (
+                item.line
+                for item in result.using_directives
+                if item.namespace.startswith("Microsoft.SemanticKernel")
+            ),
+            0,
+        )
+        detections: list[ComponentDetection] = [
+            ComponentDetection(
+                component_type=(ComponentType.FRAMEWORK),
+                canonical_name=root,
+                display_name=("Microsoft Semantic Kernel"),
+                adapter_name=self.name,
+                priority=self.priority,
+                confidence=0.98,
+                metadata={
+                    "framework": "semantic_kernel",
+                    "language": "csharp",
+                },
+                file_path=file_path,
+                line=import_line,
+                snippet=("using Microsoft.SemanticKernel"),
+                evidence_kind="ast_import",
+            )
+        ]
+
+        calls = find_calls(
+            content,
+            _KERNEL_CALLS | set(_SERVICE_CALLS) | _PLUGIN_CALLS | _PLANNER_CLASSES,
+        )
+
+        builder_variables: set[str] = set()
+
+        for call in calls:
+            if call.name in _KERNEL_CALLS:
+                receiver = call.receiver or ""
+                is_kernel_builder = (
+                    (call.name == "CreateBuilder" and receiver.split(".")[-1] == "Kernel")
+                    or (call.name == "KernelBuilder" and call.is_constructor)
+                    or (call.name == "Build" and receiver.split(".")[0] in builder_variables)
+                )
+
+                if not is_kernel_builder:
+                    continue
+
+                if (
+                    call.name
+                    in {
+                        "CreateBuilder",
+                        "KernelBuilder",
+                    }
+                    and call.assigned_to
+                ):
+                    builder_variables.add(call.assigned_to)
+
+                instance_name = call.assigned_to or "kernel"
+                canonical = canonicalize_text(f"semantic_kernel:{instance_name}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.FRAMEWORK),
+                        canonical_name=canonical,
+                        display_name=instance_name,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.94,
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "builder_call": (call.name),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.FRAMEWORK),
+                                relationship_type=("CONTAINS"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if call.name in _SERVICE_CALLS:
+                provider = _SERVICE_CALLS[call.name]
+                model_name = first_argument(
+                    call,
+                    (
+                        "modelId",
+                        "model_id",
+                        "deploymentName",
+                        "deployment",
+                        "aiModelId",
+                    ),
+                    constants,
+                    0,
+                )
+
+                if not model_name:
+                    model_name = call.name.removeprefix("Add").removesuffix("ChatCompletion")
+
+                canonical = canonicalize_text(model_name.lower())
+                details = get_model_details(
+                    model_name,
+                    provider,
+                    {},
+                )
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.MODEL),
+                        canonical_name=canonical,
+                        display_name=model_name,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=(0.91 if model_name else 0.82),
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "provider": provider,
+                            "registration": (call.name),
+                            "language": "csharp",
+                            **{key: value for key, value in details.items() if value is not None},
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.MODEL),
+                                relationship_type=("USES"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if call.name in _PLUGIN_CALLS:
+                plugin_type = call.generic_arguments[0] if call.generic_arguments else ""
+                plugin_name = first_argument(
+                    call,
+                    (
+                        "pluginName",
+                        "name",
+                    ),
+                    constants,
+                    0,
+                )
+                display = plugin_name or plugin_type or call.assigned_to or f"plugin_{call.line}"
+                canonical = canonicalize_text(f"semantic_kernel:plugin:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.TOOL),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.90,
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "registration": (call.name),
+                            "plugin_type": (plugin_type or None),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.TOOL),
+                                relationship_type=("USES"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if call.name in _PLANNER_CLASSES and call.is_constructor:
+                display = call.assigned_to or call.name
+                canonical = canonicalize_text(f"semantic_kernel:planner:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.AGENT),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.90,
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "planner_class": (call.name),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind=("ast_instantiation"),
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.AGENT),
+                                relationship_type=("USES"),
+                            )
+                        ],
+                    )
+                )
+
+        for method in result.method_declarations:
+            is_kernel_function = any(
+                (
+                    attribute.split(
+                        "(",
+                        1,
+                    )[0]
+                    .split(".")[-1]
+                    .removesuffix("Attribute")
+                    == "KernelFunction"
+                )
+                for attribute in method.attributes
+            )
+
+            if not is_kernel_function:
+                continue
+
+            canonical = canonicalize_text(f"semantic_kernel:function:{method.name}")
+            detections.append(
+                ComponentDetection(
+                    component_type=(ComponentType.TOOL),
+                    canonical_name=canonical,
+                    display_name=method.name,
+                    adapter_name=self.name,
+                    priority=self.priority,
+                    confidence=0.93,
+                    metadata={
+                        "framework": ("semantic_kernel"),
+                        "registration": ("KernelFunctionAttribute"),
+                        "containing_type": (method.containing_type),
+                        "language": "csharp",
+                    },
+                    file_path=file_path,
+                    line=method.line,
+                    snippet=method.signature,
+                    evidence_kind="ast_attribute",
+                    relationships=[
+                        RelationshipHint(
+                            source_canonical=root,
+                            source_type=(ComponentType.FRAMEWORK),
+                            target_canonical=(canonical),
+                            target_type=(ComponentType.TOOL),
+                            relationship_type="USES",
+                        )
+                    ],
+                )
+            )
+
+        for literal in result.string_literals:
+            assigned = (literal.assigned_to or "").lower()
+            prompt_name = any(
+                token in assigned
+                for token in (
+                    "prompt",
+                    "template",
+                    "instruction",
+                )
+            )
+
+            if not (literal.is_potential_prompt or prompt_name):
+                continue
+
+            if len(literal.value.strip()) < 12:
+                continue
+
+            display = literal.assigned_to or f"prompt_{literal.line}"
+            canonical = canonicalize_text(f"semantic_kernel:prompt:{display}")
+            detections.append(
+                ComponentDetection(
+                    component_type=(ComponentType.PROMPT),
+                    canonical_name=canonical,
+                    display_name=display,
+                    adapter_name=self.name,
+                    priority=self.priority,
+                    confidence=0.86,
+                    metadata={
+                        "framework": ("semantic_kernel"),
+                        "role": "system",
+                        "content": literal.value,
+                        "char_count": len(literal.value),
+                        "is_template": (literal.is_interpolated),
+                        "template_variables": list(literal.interpolation_expressions),
+                        "language": "csharp",
+                    },
+                    file_path=file_path,
+                    line=literal.line,
+                    snippet=literal.value[:160],
+                    evidence_kind=("ast_string_literal"),
+                    relationships=[
+                        RelationshipHint(
+                            source_canonical=root,
+                            source_type=(ComponentType.FRAMEWORK),
+                            target_canonical=(canonical),
+                            target_type=(ComponentType.PROMPT),
+                            relationship_type="USES",
+                        )
+                    ],
+                )
+            )
+
+        return _dedupe(detections)
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpSemanticKernelAdapter"]

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -17,6 +17,7 @@ from nuguard.sbom.adapters.csharp import (
 )
 from nuguard.sbom.adapters.csharp._source import (
     find_calls,
+    string_constants,
 )
 from nuguard.sbom.core.csharp_parser import (
     parse_csharp,
@@ -480,3 +481,202 @@ public class Greeter
         )
         == []
     )
+
+
+def test_review_fixes_use_only_const_strings() -> None:
+    source = """const string ModelName = "gpt-4o";
+var mutable = "first";
+mutable = "second";
+"""
+    result = parse_csharp(source)
+
+    assert string_constants(result) == {"ModelName": "gpt-4o"}
+
+
+def test_fully_qualified_legacy_azure_client_is_azure() -> None:
+    source = """var client =
+    new Azure.AI.OpenAI.OpenAIClient(
+        new Uri("https://example.openai.azure.com"),
+        credential);
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    providers = {
+        detection.metadata["provider"]
+        for detection in _by_type(
+            detections,
+            ComponentType.FRAMEWORK,
+        )
+    }
+
+    assert providers == {"azure"}
+
+
+def test_anthropic_model_scan_ignores_comments_and_strings() -> None:
+    source = """using Anthropic;
+var client = new AnthropicClient(apiKey);
+var text = "Model = \\"claude-fake\\"";
+// Model = Model.ClaudeFake;
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+
+    assert (
+        _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+        == []
+    )
+
+
+def test_anthropic_string_model_assignment_is_detected() -> None:
+    source = """using Anthropic;
+var client = new AnthropicClient(apiKey);
+var request = new MessageParameters
+{
+    Model = "claude-3-5-sonnet",
+};
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert [model.display_name for model in models] == ["claude-3-5-sonnet"]
+
+
+def test_semantic_kernel_marker_in_string_is_ignored() -> None:
+    source = 'var marker = "Microsoft.SemanticKernel";'
+
+    assert (
+        _extract(
+            CSharpSemanticKernelAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_mlnet_marker_in_string_is_ignored() -> None:
+    source = 'var marker = "MLContext";'
+
+    assert (
+        _extract(
+            CSharpMLNetAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_mlnet_emits_multiple_independent_pipelines() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext();
+var first = ml.Transforms.Text.FeaturizeText(
+    "Features1", "Text1");
+var second = ml.Transforms.Text.FeaturizeText(
+    "Features2", "Text2");
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+    pipelines = [
+        detection for detection in detections if detection.metadata.get("pipeline") is True
+    ]
+
+    assert {pipeline.display_name for pipeline in pipelines} == {
+        "first",
+        "second",
+    }
+
+
+def test_mlnet_ignores_unrelated_fit_calls() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext();
+var result = curveFitter.Fit(data);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+
+    assert not any(detection.metadata.get("trained_model") is True for detection in detections)
+
+
+def test_aspnet_builder_marker_in_string_is_ignored() -> None:
+    source = 'var marker = "WebApplication.CreateBuilder";'
+
+    assert (
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_controller_allow_anonymous_overrides_method_authorize() -> None:
+    source = """using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+[ApiController, AllowAnonymous, Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost, Authorize]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["auth_required"] is False
+
+
+def test_minimal_api_allow_anonymous_and_response_schema() -> None:
+    source = """using Microsoft.AspNetCore.Builder;
+public record ChatRequest(string Prompt);
+public record ChatResponse(string Answer);
+var app = WebApplication.CreateBuilder(args).Build();
+app.MapPost(
+    "/chat",
+    (ChatRequest request) =>
+        new ChatResponse("ok"))
+    .RequireAuthorization()
+    .AllowAnonymous();
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["auth_required"] is False
+    assert endpoint.metadata["response_body_schema"] == {"Answer": "string"}
+    assert endpoint.metadata["response_text_key"] == "Answer"

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -1,0 +1,482 @@
+"""Tests for C# AI and web framework adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nuguard.sbom.adapters.base import (
+    ComponentDetection,
+)
+from nuguard.sbom.adapters.csharp import (
+    CSharpAspNetCoreAdapter,
+    CSharpLLMClientsAdapter,
+    CSharpMLNetAdapter,
+    CSharpSemanticKernelAdapter,
+)
+from nuguard.sbom.adapters.csharp._source import (
+    find_calls,
+)
+from nuguard.sbom.core.csharp_parser import (
+    parse_csharp,
+)
+from nuguard.sbom.types import ComponentType
+
+
+def _extract(
+    adapter: Any,
+    source: str,
+    path: str = "App.cs",
+) -> list[ComponentDetection]:
+    return adapter.extract(
+        source,
+        path,
+        parse_csharp(source, path),
+    )
+
+
+def _by_type(
+    detections: list[ComponentDetection],
+    component_type: ComponentType,
+) -> list[ComponentDetection]:
+    return [detection for detection in detections if detection.component_type == component_type]
+
+
+def test_call_parser_extracts_generic_and_named_arguments() -> None:
+    source = (
+        "var plugin = "
+        "kernel.Plugins."
+        "AddFromType<WeatherPlugin>("
+        '"Weather", '
+        "serviceProvider: services);\n"
+    )
+
+    call = find_calls(
+        source,
+        {"AddFromType"},
+    )[0]
+
+    assert call.receiver == "kernel.Plugins"
+    assert call.generic_arguments == ("WeatherPlugin",)
+    assert call.positional_arguments == ('"Weather"',)
+    assert call.named_arguments == {"serviceProvider": "services"}
+    assert call.assigned_to == "plugin"
+
+
+def test_call_parser_ignores_comments_and_string_contents() -> None:
+    source = """// kernel.Plugins.AddFromType<FakePlugin>("Fake");
+var text = "client.GetChatClient(\\\"not-a-model\\\")";
+var actual = client.GetChatClient("gpt-4o");
+"""
+
+    calls = find_calls(
+        source,
+        {
+            "AddFromType",
+            "GetChatClient",
+        },
+    )
+
+    assert len(calls) == 1
+    assert calls[0].name == "GetChatClient"
+
+
+def test_llm_clients_detect_azure_and_openai_models() -> None:
+    source = """using Azure.AI.OpenAI;
+using OpenAI.Chat;
+var azure = new AzureOpenAIClient(
+    new Uri(endpoint), credential);
+var azureChat = azure.GetChatClient("gpt-4o");
+var direct = new ChatClient(
+    model: "gpt-4.1-mini",
+    apiKey: key);
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    frameworks = {
+        detection.metadata["provider"]
+        for detection in _by_type(
+            detections,
+            ComponentType.FRAMEWORK,
+        )
+    }
+    models = {
+        detection.display_name: detection
+        for detection in _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+    }
+
+    assert frameworks == {
+        "azure",
+        "openai",
+    }
+    assert {
+        "gpt-4o",
+        "gpt-4.1-mini",
+    } <= set(models)
+    assert models["gpt-4o"].metadata["framework"] == "azure_openai"
+    assert models["gpt-4o"].relationships[0].relationship_type == "USES"
+
+
+def test_llm_clients_detect_anthropic_model_constants() -> None:
+    source = """using Anthropic;
+var client = new AnthropicClient(apiKey);
+var request = new MessageParameters
+{
+    Model = Model.ClaudeSonnet4_20250514,
+};
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+        "Anthropic.cs",
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert len(models) == 1
+    assert models[0].display_name == "Model.ClaudeSonnet4_20250514"
+    assert models[0].metadata["provider"] == "anthropic"
+
+
+def test_generic_chat_client_without_supported_namespace_is_ignored() -> None:
+    source = """using Contoso.Chat;
+var client = new ChatClient("internal-model");
+"""
+
+    assert (
+        _extract(
+            CSharpLLMClientsAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_semantic_kernel_detects_services_plugins_planners_and_prompts() -> None:
+    source = """using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Planning.Handlebars;
+var builder = Kernel.CreateBuilder();
+builder.AddAzureOpenAIChatCompletion(
+    deploymentName: "gpt-4o",
+    endpoint: endpoint,
+    apiKey: key);
+var kernel = builder.Build();
+kernel.Plugins.AddFromType<WeatherPlugin>(
+    "Weather");
+var planner = new HandlebarsPlanner();
+public class WeatherPlugin
+{
+    [KernelFunction]
+    public string GetWeather() => "sunny";
+}
+var systemPrompt = "You are a weather assistant.";
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+        "Kernel.cs",
+    )
+
+    assert _by_type(
+        detections,
+        ComponentType.FRAMEWORK,
+    )
+    assert any(
+        detection.display_name == "gpt-4o"
+        for detection in _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+    )
+    assert {
+        "Weather",
+        "GetWeather",
+    } <= {
+        detection.display_name
+        for detection in _by_type(
+            detections,
+            ComponentType.TOOL,
+        )
+    }
+    assert _by_type(
+        detections,
+        ComponentType.AGENT,
+    )
+    assert _by_type(
+        detections,
+        ComponentType.PROMPT,
+    )
+
+
+def test_semantic_kernel_accepts_kernel_function_attribute_suffix() -> None:
+    source = """using Microsoft.SemanticKernel;
+public class SearchPlugin
+{
+    [KernelFunctionAttribute]
+    public string Search(string query) => query;
+}
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+
+    assert any(
+        detection.display_name == "Search"
+        for detection in _by_type(
+            detections,
+            ComponentType.TOOL,
+        )
+    )
+
+
+def test_semantic_kernel_ignores_unrelated_build_calls() -> None:
+    source = """using Microsoft.SemanticKernel;
+var result = unrelated.Build();
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+    frameworks = _by_type(
+        detections,
+        ComponentType.FRAMEWORK,
+    )
+
+    assert [detection.canonical_name for detection in frameworks] == ["framework:semantic_kernel"]
+
+
+def test_mlnet_detects_context_pipeline_trainer_and_fit() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext(seed: 1);
+var pipeline =
+    ml.Transforms.Conversion.MapValueToKey("Label")
+    .Append(
+        ml.Transforms.Text.FeaturizeText(
+            "Features", "Text"))
+    .Append(
+        ml.MulticlassClassification.Trainers
+        .SdcaMaximumEntropy());
+var model = pipeline.Fit(data);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+        "Train.cs",
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert _by_type(
+        detections,
+        ComponentType.FRAMEWORK,
+    )
+    assert any(detection.metadata.get("trainer") == "SdcaMaximumEntropy" for detection in models)
+    assert any(detection.metadata.get("trained_model") is True for detection in models)
+
+
+def test_mlnet_does_not_treat_unrelated_append_as_pipeline() -> None:
+    source = """using Microsoft.ML;
+items.Append(value);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+
+    assert not any(detection.metadata.get("pipeline") is True for detection in detections)
+
+
+def test_aspnet_controller_emits_ai_endpoint_metadata() -> None:
+    source = """using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenAI.Chat;
+public record ChatRequest(string Message);
+public record ChatResponse(string Answer);
+[ApiController]
+[Route("api/[controller]")]
+public class ChatController : ControllerBase
+{
+    [HttpPost("complete")]
+    [Authorize]
+    public async Task<ActionResult<ChatResponse>> Complete(
+        ChatRequest request)
+    {
+        var answer = await client.CompleteChatAsync(
+            request.Message);
+        return new ChatResponse(answer);
+    }
+}
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+        "ChatController.cs",
+    )
+    endpoints = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert endpoint.metadata["method"] == "POST"
+    assert endpoint.metadata["endpoint"] == "/api/Chat/complete"
+    assert endpoint.metadata["auth_required"] is True
+    assert endpoint.metadata["chat_payload_key"] == "Message"
+    assert endpoint.metadata["response_text_key"] == "Answer"
+
+
+def test_aspnet_controller_expands_action_route_token() -> None:
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/[controller]/[action]")]
+public class ChatController : ControllerBase
+{
+    [HttpPost]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["endpoint"] == "/api/Chat/Complete"
+
+
+def test_aspnet_allow_anonymous_overrides_controller_authorization() -> None:
+    source = """using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Authorize]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost]
+    [AllowAnonymous]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["auth_required"] is False
+
+
+def test_aspnet_minimal_api_emits_route_schema_and_auth() -> None:
+    source = """using Microsoft.AspNetCore.Builder;
+using OpenAI.Chat;
+public record ChatRequest(string Prompt);
+var app = WebApplication.CreateBuilder(args).Build();
+app.MapPost(
+    "/chat",
+    async (
+        ChatRequest request,
+        ChatClient client) =>
+    {
+        return await client.CompleteChatAsync(
+            request.Prompt);
+    }).RequireAuthorization();
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+        "Program.cs",
+    )
+    endpoints = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert endpoint.metadata["endpoint"] == "/chat"
+    assert endpoint.metadata["request_body_schema"] == {"Prompt": "string"}
+    assert endpoint.metadata["chat_payload_key"] == "Prompt"
+    assert endpoint.metadata["auth_required"] is True
+
+
+def test_non_ai_aspnet_route_is_not_emitted() -> None:
+    source = """using Microsoft.AspNetCore.Builder;
+var app = WebApplication.CreateBuilder(args).Build();
+app.MapGet("/health", () => Results.Ok());
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+        "Program.cs",
+    )
+
+    assert (
+        _by_type(
+            detections,
+            ComponentType.API_ENDPOINT,
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "adapter",
+    [
+        CSharpLLMClientsAdapter(),
+        CSharpSemanticKernelAdapter(),
+        CSharpMLNetAdapter(),
+        CSharpAspNetCoreAdapter(),
+    ],
+)
+def test_adapters_ignore_unrelated_csharp(
+    adapter: Any,
+) -> None:
+    source = """using System;
+public class Greeter
+{
+    public string Hello(string name) =>
+        $"Hello {name}";
+}
+"""
+
+    assert (
+        _extract(
+            adapter,
+            source,
+        )
+        == []
+    )


### PR DESCRIPTION
Closes #212

## PR Type

- [ ] Bug fix
- [x] Feature

## What

- Added direct C# LLM SDK detection for:
  - Azure OpenAI
  - OpenAI .NET
  - Anthropic C#
- Added Semantic Kernel detection for:
  - kernel builders and instances
  - registered AI model services
  - plugins
  - `[KernelFunction]` methods
  - planners
  - prompt strings
- Added ML.NET detection for:
  - `MLContext` instances
  - transformation pipelines
  - trainers
  - models produced through `Fit`
- Added ASP.NET Core detection for:
  - attribute-routed controllers
  - Minimal API endpoints
  - HTTP methods and expanded route templates
  - request and response schemas
  - conversational payload fields
  - endpoint authorization
- Added shared C# call-expression helpers.
- Added 19 focused adapter tests.

## Why

NuGuard can parse C# source after #211, but it does not yet recognize the AI frameworks and web surfaces used by .NET applications.

This PR implements the framework adapters requested in #212 and supports the broader C# pipeline work tracked in #170.

## How

- Added a source helper that:
  - masks comments, character literals, and string contents before matching calls
  - preserves source offsets and line numbers
  - handles constructor calls, chained calls, generic arguments, named arguments, and nested argument expressions
  - resolves literal strings, string constants, enum members, `nameof(...)`, and simple `Uri` construction
- Added `CSharpLLMClientsAdapter`.
  - Tracks provider identities through client variables.
  - Emits provider `FRAMEWORK` nodes and concrete `MODEL` nodes.
  - Preserves client class, provider, framework, model metadata, and source evidence.
- Added `CSharpSemanticKernelAdapter`.
  - Detects builder creation without treating unrelated `Build()` calls as Semantic Kernel.
  - Detects registered model services, plugins, planners, kernel functions, and prompts.
- Added `CSharpMLNetAdapter`.
  - Detects ML.NET contexts, transformation pipelines, trainers, and trained models.
  - Avoids treating unrelated `Append` calls as ML.NET pipelines.
- Added `CSharpAspNetCoreAdapter`.
  - Detects AI-relevant controller actions and Minimal API routes.
  - Expands `[controller]` and `[action]` route tokens.
  - Handles `Authorize` and `AllowAnonymous`.
  - Extracts record/property request and response schemas where available.
- Exported the adapters from `nuguard.sbom.adapters.csharp`.
- No runtime dependency was added.

## Test Steps

- [x] `uv run ruff format --check nuguard/sbom/adapters/csharp/_source.py nuguard/sbom/adapters/csharp/llm_clients.py nuguard/sbom/adapters/csharp/semantic_kernel.py nuguard/sbom/adapters/csharp/mlnet.py nuguard/sbom/adapters/csharp/aspnet_core.py nuguard/sbom/adapters/csharp/__init__.py nuguard/sbom/tests/test_csharp_framework_adapters.py`
- [x] `uv run pytest nuguard/sbom/tests/test_csharp_framework_adapters.py -v`
- [x] `uv run ruff check nuguard/`
- [x] `uv run mypy nuguard/`
- [x] `uv run pytest nuguard/ -q`
- [x] `uv run pytest tests/ --ignore=tests/apps/contact-center-ai-samples -v`
- [x] `make precommit-run`
- [x] `git diff --check`

## Checks

- [x] The final feature commit is based on `develop`
- [x] This PR targets `develop`
- [x] Changed Python files are Ruff-formatted
- [x] Ruff lint passes
- [x] Mypy passes
- [x] Package and integration tests pass
- [x] Focused tests cover supported detections and false-positive controls
- [x] No new runtime dependency was added
- [x] No adapter-registry or extraction-pipeline wiring was added

## Other Notes

The issue description refers to `LLM_CLIENT` nodes, but the current `ComponentType` enum does not contain an `LLM_CLIENT` value. Direct C# SDK usage therefore emits provider `FRAMEWORK` and `MODEL` nodes, matching the existing direct-client representation used by the other language adapters.

The following remain intentionally out of scope:

- adding `.cs` or `.csx` to source extension configuration
- adapter registry changes
- extraction-pipeline wiring
- C# Semgrep rules
- end-to-end C# fixture applications

Those concerns are tracked in #213, #214, and #215.

**Release note:** NuGuard can now structurally detect direct LLM SDK usage, Semantic Kernel, ML.NET, and AI-facing ASP.NET Core endpoints in C# source code.

Part of #170