### PR TITLE
Add Go provider Semgrep E2E coverage

### DIFF
--- a/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
@@ -1,0 +1,33 @@
+# Go provider Semgrep sample attribution
+
+Minimal, independently written regression fixtures for NuGuard's bundled Go
+AI-security Semgrep rules. They are inspired by / based on the API and
+configuration patterns documented in the linked provider sources. They are
+**not** full applications.
+
+No upstream application or source file is vendored wholesale. Linked upstream
+projects and docs retain their own applicable licenses.
+
+Official first-party SDK call shapes that do not match today's sink allowlist
+(for example `Chat.Completions.New`, Bedrock `Converse`, Anthropic
+`Messages.New`, or multi-arg `Models.GenerateContent`) are intentionally **not**
+exercised here. That work is tracked separately in issue **#223**
+("Extend Go AI security rules for official provider SDK patterns").
+
+Thin local compatibility wrappers exist only to exercise today's NuGuard sink
+allowlist (`CreateChatCompletion`, `CreateMessage`, `GenerateContent`,
+`SendMessage`, …). Official SDK call-shape support remains #223.
+
+| Provider | Patterns documented in | Fixture notes |
+|----------|------------------------|---------------|
+| OpenAI | [openai-go](https://github.com/openai/openai-go); community [go-openai](https://github.com/sashabaranov/go-openai) | Independently written sample using `CreateChatCompletion` / `DefaultConfig` shapes compatible with current rules. Official `Chat.Completions.New` coverage is #223. |
+| Azure | Azure OpenAI + [go-openai Azure config](https://github.com/sashabaranov/go-openai#azure-openai-chatgpt) docs | Independently written sample using Azure-style `DefaultAzureConfig` / `NewClientWithConfig` with an insecure TLS HTTP client. Official Azure/`openai-go` sinks are #223. |
+| AWS | [AWS SDK for Go v2 Bedrock Runtime examples](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/go_bedrock-runtime_code_examples.html) | Independently written sample; Bedrock Runtime import for flavour; LLM sink is a local `SendMessage(ctx, req)` wrapper because `Converse` / `InvokeModel` are #223. |
+| GCP | [google.golang.org/genai](https://pkg.go.dev/google.golang.org/genai) / Gemini Go docs | Independently written sample using `APIKey` + a two-arg local `GenerateContent(ctx, req)` wrapper; official multi-arg `Models.GenerateContent` is #223. |
+| Claude | [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) docs | Independently written sample using `AuthToken` + a local `CreateMessage(ctx, req)` wrapper; official `Messages.New` is #223. |
+
+LangGraph is intentionally omitted from this pack (no official LangGraph Go SDK;
+handled separately from this follow-up).
+
+All credentials in these fixtures are synthetic placeholders (`sk-…`, `AIza…`)
+and must never be treated as real secrets.

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/aws/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/aws/vulnerable.go
@@ -1,0 +1,44 @@
+// NuGuard minimal, independently written regression fixture (AWS-flavoured).
+// Inspired by AWS Bedrock Runtime Go v2 API patterns — not a runnable app and
+// not vendored upstream source. Bedrock Runtime import is for flavour only;
+// local SendMessage(ctx, req) wrapper exercises today's sink allowlist.
+// Converse/InvokeModel support is #223. See ../ATTRIBUTION.md.
+package aws_sample
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+)
+
+// bedrockChatRequest is a minimal stand-in for a chat request body.
+type bedrockChatRequest struct {
+	Prompt string
+}
+
+// bedrockCompatClient wraps Bedrock Runtime with a rule-compatible sink method.
+// Official Client.Converse / InvokeModel matching is issue #223.
+type bedrockCompatClient struct {
+	runtime *bedrockruntime.Client
+}
+
+func newBedrockCompatClient(runtime *bedrockruntime.Client) *bedrockCompatClient {
+	return &bedrockCompatClient{runtime: runtime}
+}
+
+// SendMessage is a compatibility sink matching the current Go Semgrep allowlist.
+func (c *bedrockCompatClient) SendMessage(ctx context.Context, req bedrockChatRequest) {
+	_ = c.runtime
+	_ = ctx
+	_ = req
+}
+
+// AskWithUserPrompt formats untrusted input and sends it via the compatibility
+// sink using an unbounded root context.
+func AskWithUserPrompt(userInput string) {
+	// runtime is nil in this offline fixture; Semgrep only needs the call graph.
+	client := newBedrockCompatClient(nil)
+	prompt := fmt.Sprintf("Summarize ticket: %s", userInput)
+	client.SendMessage(context.Background(), bedrockChatRequest{Prompt: prompt})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/azure/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/azure/vulnerable.go
@@ -1,0 +1,37 @@
+// NuGuard minimal, independently written regression fixture (Azure-flavoured).
+// Inspired by Azure OpenAI / go-openai Azure config patterns — not a runnable
+// app and not vendored upstream source. Uses DefaultAzureConfig +
+// CreateChatCompletion shapes for today's sinks; official Azure/openai-go
+// call shapes are #223. See ../ATTRIBUTION.md.
+package azure_sample
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// ChatWithInsecureTLS builds an Azure OpenAI client that disables TLS
+// verification and issues a chat completion on an unbounded context.
+func ChatWithInsecureTLS() {
+	cfg := openai.DefaultAzureConfig(
+		"SYNTHETIC_AZURE_OPENAI_KEY",
+		"https://example.openai.azure.com/",
+	)
+	cfg.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // intentional insecure fixture
+			},
+		},
+	}
+	client := openai.NewClientWithConfig(cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello from azure sample"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/claude/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/claude/vulnerable.go
@@ -1,0 +1,45 @@
+// NuGuard minimal, independently written regression fixture (Claude-flavoured).
+// Inspired by anthropic-sdk-go API patterns — not a runnable app and not
+// vendored upstream source. Local CreateMessage(ctx, req) wrapper exercises
+// today's sink allowlist; official Messages.New is #223.
+// See ../ATTRIBUTION.md.
+package claude_sample
+
+import (
+	"context"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// claudeMessageRequest is a minimal stand-in for a Messages API request.
+type claudeMessageRequest struct {
+	Prompt string
+}
+
+// claudeCompatClient provides a rule-compatible CreateMessage sink.
+type claudeCompatClient struct {
+	apiKey string
+}
+
+func newClaudeCompatClient(apiKey string) *claudeCompatClient {
+	return &claudeCompatClient{apiKey: apiKey}
+}
+
+// CreateMessage is a compatibility sink matching the current Go Semgrep allowlist.
+func (c *claudeCompatClient) CreateMessage(ctx context.Context, req claudeMessageRequest) {
+	_ = c.apiKey
+	_ = ctx
+	_ = req
+	_ = anthropic.ModelClaudeOpus4_6
+}
+
+// ChatWithHardcodedToken uses a synthetic Anthropic auth token and an
+// unbounded context for a create-message call.
+func ChatWithHardcodedToken() {
+	cfg := struct{ AuthToken string }{}
+	cfg.AuthToken = "sk-SYNTHETIC_CLAUDE_PROVIDER_KEY"
+	client := newClaudeCompatClient(cfg.AuthToken)
+	client.CreateMessage(context.Background(), claudeMessageRequest{
+		Prompt: "hello from claude sample",
+	})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/vulnerable.go
@@ -1,0 +1,44 @@
+// NuGuard minimal, independently written regression fixture (GCP-flavoured).
+// Inspired by google.golang.org/genai / Gemini Go API patterns — not a runnable
+// app and not vendored upstream source. Local two-arg GenerateContent(ctx, req)
+// wrapper exercises today's sink allowlist; official multi-arg
+// Models.GenerateContent is #223. See ../ATTRIBUTION.md.
+package gcp_sample
+
+import (
+	"context"
+
+	"google.golang.org/genai"
+)
+
+// geminiRequest is a minimal stand-in for a generate-content request.
+type geminiRequest struct {
+	Prompt string
+}
+
+// geminiCompatClient provides a rule-compatible GenerateContent sink.
+type geminiCompatClient struct {
+	cfg *genai.ClientConfig
+}
+
+func newGeminiCompatClient(cfg *genai.ClientConfig) *geminiCompatClient {
+	return &geminiCompatClient{cfg: cfg}
+}
+
+// GenerateContent is a compatibility sink matching the current Go Semgrep allowlist.
+func (c *geminiCompatClient) GenerateContent(ctx context.Context, req geminiRequest) {
+	_ = c.cfg
+	_ = ctx
+	_ = req
+}
+
+// GenerateWithHardcodedKey uses a synthetic Gemini API key and an unbounded
+// context for a generate-content call.
+func GenerateWithHardcodedKey() {
+	cfg := &genai.ClientConfig{}
+	cfg.APIKey = "AIzaSYNTHETIC_GCP_PROVIDER_KEY"
+	client := newGeminiCompatClient(cfg)
+	client.GenerateContent(context.Background(), geminiRequest{
+		Prompt: "hello from gcp sample",
+	})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/openai/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/openai/vulnerable.go
@@ -1,0 +1,27 @@
+// NuGuard minimal, independently written regression fixture (OpenAI-flavoured).
+// Inspired by go-openai / OpenAI Go API patterns — not a runnable app and not
+// vendored upstream source. Uses CreateChatCompletion / DefaultConfig shapes
+// that match today's sinks; official openai-go Chat.Completions.New is #223.
+// See ../ATTRIBUTION.md.
+package openai_sample
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// ChatWithUserPrompt interpolates untrusted input into a prompt and calls the
+// chat-completion API with an unbounded context and a hardcoded API key.
+func ChatWithUserPrompt(userInput string) {
+	cfg := openai.DefaultConfig("sk-SYNTHETIC_OPENAI_PROVIDER_KEY")
+	client := openai.NewClientWithConfig(cfg)
+	prompt := fmt.Sprintf("Answer the customer: %s", userInput)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}

--- a/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
+++ b/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
@@ -1,0 +1,178 @@
+"""Provider-style Go Semgrep E2E via SemgrepScannerPlugin.
+
+Exercises the NuGuard Semgrep integration path against minimal Azure / AWS /
+GCP / OpenAI / Claude flavoured fixtures under
+``fixtures/go_provider_samples/``.
+
+This is intentionally *not* a direct ``semgrep`` CLI invocation (see
+``test_semgrep_go_rules.py`` for rule-behaviour line tests). Official
+first-party SDK sink shapes are tracked in issue #223 and are out of scope.
+
+Semgrep's default ``.semgrepignore`` skips paths under ``tests/``, and the
+plugin scans directories (not explicit file args). Fixtures are therefore
+materialized into a temporary directory before
+``SemgrepScannerPlugin.run`` so discovery matches production source trees
+that are not nested under a ``tests/`` path segment.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from nuguard.analysis.plugins.semgrep_scanner import SemgrepScannerPlugin
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "go_provider_samples"
+
+_GO_RULE_IDS = frozenset(
+    {
+        "nuguard-go-llm-prompt-injection-sprintf",
+        "nuguard-go-hardcoded-api-key",
+        "nuguard-go-llm-missing-context-timeout",
+        "nuguard-go-llm-insecure-tls",
+    }
+)
+
+# Expected rule-ID sets per provider (normalized Semgrep check_id suffixes).
+_EXPECTED_BY_PROVIDER: dict[str, frozenset[str]] = {
+    "openai": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-hardcoded-api-key",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "azure": frozenset(
+        {
+            "nuguard-go-llm-insecure-tls",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "aws": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "gcp": frozenset(
+        {
+            "nuguard-go-hardcoded-api-key",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "claude": frozenset(
+        {
+            "nuguard-go-hardcoded-api-key",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+}
+
+
+def _semgrep_binary() -> str | None:
+    return shutil.which("semgrep")
+
+
+def _require_semgrep() -> None:
+    if _semgrep_binary() is not None:
+        return
+    if os.environ.get("CI"):
+        pytest.fail(
+            "semgrep is required in CI for Go provider Semgrep E2E tests; "
+            "install semgrep before running pytest"
+        )
+    pytest.skip("semgrep not installed — Go provider Semgrep E2E skipped")
+
+
+def _normalize_rule_id(check_id: str) -> str:
+    """Strip Semgrep config-path prefixes from a check_id."""
+    return str(check_id).rsplit(".", 1)[-1]
+
+
+@contextmanager
+def _materialize_provider(provider: str) -> Iterator[Path]:
+    """Copy one provider fixture into a temp dir suitable for Semgrep directory scans."""
+    source = _FIXTURES / provider
+    assert source.is_dir(), f"missing provider fixture directory: {source}"
+    go_files = sorted(source.glob("*.go"))
+    assert go_files, f"no Go fixtures in {source}"
+
+    temp_dir = Path(tempfile.mkdtemp(prefix=f"nuguard-go-provider-{provider}-"))
+    try:
+        for path in go_files:
+            shutil.copy2(path, temp_dir / path.name)
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _scan_provider(provider: str) -> frozenset[str]:
+    """Run SemgrepScannerPlugin on one provider fixture (via temp materialization)."""
+    with _materialize_provider(provider) as source_dir:
+        result = SemgrepScannerPlugin().run(
+            {"nodes": []},
+            {
+                "source_path": str(source_dir),
+                "semgrep_exclude_tests": False,
+                "semgrep_timeout": 120.0,
+            },
+        )
+        assert result.status != "skipped", (
+            f"SemgrepScannerPlugin skipped scan of {provider}: {result.message}"
+        )
+        assert result.plugin == "semgrep"
+
+        fired: set[str] = set()
+        for finding in result.findings:
+            rule_id = _normalize_rule_id(str(finding.get("rule_id", "")))
+            if rule_id:
+                fired.add(rule_id)
+        return frozenset(fired)
+
+
+@pytest.fixture(scope="module")
+def provider_semgrep_findings() -> Mapping[str, frozenset[str]]:
+    """Scan each provider once; share immutable results across this module's tests."""
+    _require_semgrep()
+    findings = {
+        provider: _scan_provider(provider) for provider in sorted(_EXPECTED_BY_PROVIDER)
+    }
+    return MappingProxyType(findings)
+
+
+@pytest.mark.parametrize("provider", sorted(_EXPECTED_BY_PROVIDER))
+def test_provider_fixture_emits_expected_go_rules(
+    provider: str,
+    provider_semgrep_findings: Mapping[str, frozenset[str]],
+) -> None:
+    """Each provider sample must surface its expected Go AI-security rule IDs."""
+    expected = _EXPECTED_BY_PROVIDER[provider]
+    fired = provider_semgrep_findings[provider]
+    missing = expected - fired
+    assert not missing, (
+        f"{provider}: missing expected Go rule IDs {sorted(missing)}; "
+        f"fired={sorted(fired)}"
+    )
+
+
+def test_provider_pack_covers_all_go_rules(
+    provider_semgrep_findings: Mapping[str, frozenset[str]],
+) -> None:
+    """Collectively, the provider pack must exercise all four Go rule IDs."""
+    fired: set[str] = set()
+    for rule_ids in provider_semgrep_findings.values():
+        fired |= rule_ids
+
+    missing = _GO_RULE_IDS - fired
+    assert not missing, (
+        f"provider pack missing Go rule coverage {sorted(missing)}; "
+        f"fired={sorted(fired)}"
+    )
+    assert fired & _GO_RULE_IDS == _GO_RULE_IDS


### PR DESCRIPTION
## Summary

Adds provider-style Go regression fixtures and end-to-end Semgrep coverage as a follow-up to #199.

The fixtures exercise the existing Go AI-security rules through NuGuard's real `SemgrepScannerPlugin` path so future changes to source discovery, bundled rule loading, Semgrep integration, result parsing, or rule matching are caught by CI.

## Provider coverage

Adds minimal, offline fixtures for:

- OpenAI
- Azure
- AWS Bedrock
- GCP / Gemini
- Claude / Anthropic

Collectively the fixtures exercise all four existing Go AI-security rule IDs:

- `nuguard-go-llm-prompt-injection-sprintf`
- `nuguard-go-hardcoded-api-key`
- `nuguard-go-llm-missing-context-timeout`
- `nuguard-go-llm-insecure-tls`

Each provider fixture triggers at least one expected rule.

## E2E path

The new tests exercise:

provider-style Go source
→ `SemgrepScannerPlugin`
→ bundled `ai-security.yaml`
→ parsed NuGuard findings
→ expected rule IDs

Each provider is scanned once per test module and the resulting rule sets are reused for both provider-specific and aggregate coverage assertions.

The fixtures are deterministic, credential-free, compile-independent, and require no network/API calls.

## Scope

This PR intentionally keeps the existing Go rule definitions unchanged.

Support for additional first-party SDK call shapes such as OpenAI `Chat.Completions.New`, AWS Bedrock `Converse` / `InvokeModel`, Anthropic `Messages.New`, and the official GCP `GenerateContent` shape is tracked separately in #223.

`mcp-go` / `langchaingo` fixtures and adapter-level coverage are also being handled separately to avoid overlapping work.

## Validation

- `test_semgrep_go_rules.py`: 12 passed
- `test_go_provider_semgrep_e2e.py`: 6 passed
- `ruff check nuguard/`: passed
- `mypy nuguard/`: success across 461 files
- `pytest nuguard/ -q`: 1456 passed, 1 skipped
- `git diff --check`: clean

No existing rule, CI, or benchmark files are modified.

Closes #225