### PR TITLE
Extend Go AI security rules for official provider SDK patterns

### DIFF
--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -173,7 +173,9 @@ rules:
       nuguard_rule: NGA-008
 
   # -------------------------------------------------------------------------
-  # Go AI/LLM security rules (issue #180)
+  # Go AI/LLM security rules (issues #180 / #223)
+  # #223 adds qualified official non-streaming SDK sinks; TLS / credential
+  # option flows remain unchanged (WithHTTPClient follow-up).
   # -------------------------------------------------------------------------
 
   - id: nuguard-go-llm-prompt-injection-sprintf
@@ -184,6 +186,8 @@ rules:
     # Trusted literals/constants/config fields are not USER sources, so
     # trusted fmt.Sprintf -> LLM is not reported. Direct string-param -> LLM
     # (no sprintf) keeps only USER and therefore does not match.
+    # Issue #223: qualified official sinks (never bare New); Bedrock uses
+    # Converse/InvokeModel with optional trailing optFns (...).
     pattern-sources:
       - label: USER
         patterns:
@@ -216,6 +220,24 @@ rules:
           - metavariable-regex:
               metavariable: $METHOD
               regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Responses.New($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Messages.New($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Converse($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
     message: >
       Potential prompt injection: untrusted string input is interpolated into an
       LLM prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
@@ -406,6 +428,726 @@ rules:
               $CTX, $_ = context.WithDeadline($CTX, ...)
               ...
               $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: $CLIENT.Chat.Completions.New(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Responses.New(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Messages.New(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Converse(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.InvokeModel(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Models.GenerateContent(context.Background(), $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: $CLIENT.Chat.Completions.New(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Responses.New(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Messages.New(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Converse(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.InvokeModel(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Models.GenerateContent(context.TODO(), $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
     message: >
       AI/LLM request uses an unbounded root context (context.Background or
       context.TODO) with no timeout or deadline. Unbounded LLM calls can hang

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
@@ -8,23 +8,29 @@ configuration patterns documented in the linked provider sources. They are
 No upstream application or source file is vendored wholesale. Linked upstream
 projects and docs retain their own applicable licenses.
 
-Official first-party SDK call shapes that do not match today's sink allowlist
-(for example `Chat.Completions.New`, Bedrock `Converse`, Anthropic
-`Messages.New`, or multi-arg `Models.GenerateContent`) are intentionally **not**
-exercised here. That work is tracked separately in issue **#223**
-("Extend Go AI security rules for official provider SDK patterns").
+Each provider directory includes:
 
-Thin local compatibility wrappers exist only to exercise today's NuGuard sink
-allowlist (`CreateChatCompletion`, `CreateMessage`, `GenerateContent`,
-`SendMessage`, …). Official SDK call-shape support remains #223.
+- `vulnerable.go` — community / provider-neutral compatibility shapes that
+  exercise today's baseline sink allowlist (`CreateChatCompletion`,
+  `CreateMessage`, local two-arg `GenerateContent`, `SendMessage`, …), from
+  PR #224. Azure TLS coverage remains on this community `CFG.HTTPClient` path.
+- `official_vulnerable.go` — independently written structural samples of the
+  official non-streaming SDK call shapes added in issue **#223**
+  (`Chat.Completions.New`, `Responses.New`, Bedrock `Converse` /
+  `InvokeModel` including optional trailing optFns, Anthropic `Messages.New`,
+  multi-arg `Models.GenerateContent`). Azure is covered via OpenAI-compatible
+  nested New call shapes only (not official TLS).
+
+Streaming APIs, credential-option patterns (`option.WithAPIKey`, …), and
+official `option.WithHTTPClient` TLS flows remain out of scope.
 
 | Provider | Patterns documented in | Fixture notes |
 |----------|------------------------|---------------|
-| OpenAI | [openai-go](https://github.com/openai/openai-go); community [go-openai](https://github.com/sashabaranov/go-openai) | Independently written sample using `CreateChatCompletion` / `DefaultConfig` shapes compatible with current rules. Official `Chat.Completions.New` coverage is #223. |
-| Azure | Azure OpenAI + [go-openai Azure config](https://github.com/sashabaranov/go-openai#azure-openai-chatgpt) docs | Independently written sample using Azure-style `DefaultAzureConfig` / `NewClientWithConfig` with an insecure TLS HTTP client. Official Azure/`openai-go` sinks are #223. |
-| AWS | [AWS SDK for Go v2 Bedrock Runtime examples](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/go_bedrock-runtime_code_examples.html) | Independently written sample; Bedrock Runtime import for flavour; LLM sink is a local `SendMessage(ctx, req)` wrapper because `Converse` / `InvokeModel` are #223. |
-| GCP | [google.golang.org/genai](https://pkg.go.dev/google.golang.org/genai) / Gemini Go docs | Independently written sample using `APIKey` + a two-arg local `GenerateContent(ctx, req)` wrapper; official multi-arg `Models.GenerateContent` is #223. |
-| Claude | [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) docs | Independently written sample using `AuthToken` + a local `CreateMessage(ctx, req)` wrapper; official `Messages.New` is #223. |
+| OpenAI | [openai-go](https://github.com/openai/openai-go); community [go-openai](https://github.com/sashabaranov/go-openai) | `vulnerable.go`: `CreateChatCompletion` / `DefaultConfig`. `official_vulnerable.go`: `Chat.Completions.New` / `Responses.New`. |
+| Azure | Azure OpenAI + [go-openai Azure config](https://github.com/sashabaranov/go-openai#azure-openai-chatgpt) docs | `vulnerable.go`: `DefaultAzureConfig` + insecure TLS + `CreateChatCompletion`. `official_vulnerable.go`: OpenAI-compatible `Chat.Completions.New` / `Responses.New` (no official TLS). |
+| AWS | [AWS SDK for Go v2 Bedrock Runtime examples](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/go_bedrock-runtime_code_examples.html) | `vulnerable.go`: local `SendMessage` wrapper. `official_vulnerable.go`: `Converse` / `InvokeModel` with trailing optFns. |
+| GCP | [google.golang.org/genai](https://pkg.go.dev/google.golang.org/genai) / Gemini Go docs | `vulnerable.go`: two-arg local `GenerateContent`. `official_vulnerable.go`: multi-arg `Models.GenerateContent`. |
+| Claude | [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) docs | `vulnerable.go`: local `CreateMessage`. `official_vulnerable.go`: `Messages.New`. |
 
 LangGraph is intentionally omitted from this pack (no official LangGraph Go SDK;
 handled separately from this follow-up).

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/aws/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/aws/official_vulnerable.go
@@ -1,0 +1,31 @@
+// NuGuard minimal official Bedrock Runtime call-shape fixture (issue #223).
+// Independently written structural sample — not vendored upstream source.
+// Includes a trailing optFn argument to exercise variadic sink matching.
+// See ../ATTRIBUTION.md.
+package aws_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type bedrockOfficialClient struct{}
+
+func (bedrockOfficialClient) Converse(ctx context.Context, req any, _ ...any) {}
+
+func (bedrockOfficialClient) InvokeModel(ctx context.Context, req any, _ ...any) {}
+
+// OfficialConverseWithUserPromptAndOptFn exercises Client.Converse with optFns.
+func OfficialConverseWithUserPromptAndOptFn(userInput string) {
+	client := bedrockOfficialClient{}
+	prompt := fmt.Sprintf("Summarize ticket: %s", userInput)
+	optFn := func() {}
+	client.Converse(context.Background(), prompt, optFn)
+}
+
+// OfficialInvokeModelMissingTimeoutWithOptFn exercises Client.InvokeModel with optFns.
+func OfficialInvokeModelMissingTimeoutWithOptFn() {
+	client := bedrockOfficialClient{}
+	optFn := func() {}
+	client.InvokeModel(context.Background(), "hello from aws official sample", optFn)
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/azure/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/azure/official_vulnerable.go
@@ -1,0 +1,41 @@
+// NuGuard minimal Azure OpenAI-compatible official call-shape fixture (#223).
+// Independently written structural sample — not vendored upstream source.
+// Exercises Chat.Completions.New / Responses.New only. Official
+// option.WithHTTPClient TLS coverage is intentionally out of scope.
+// See ../ATTRIBUTION.md.
+package azure_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type azureChatCompletions struct{}
+
+func (azureChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+type azureChatService struct {
+	Completions azureChatCompletions
+}
+
+type azureResponsesService struct{}
+
+func (azureResponsesService) New(ctx context.Context, req any, _ ...any) {}
+
+type azureOfficialClient struct {
+	Chat      azureChatService
+	Responses azureResponsesService
+}
+
+// OfficialChatCompletionsWithUserPrompt exercises Chat.Completions.New.
+func OfficialChatCompletionsWithUserPrompt(userInput string) {
+	client := azureOfficialClient{}
+	prompt := fmt.Sprintf("Answer the customer: %s", userInput)
+	client.Chat.Completions.New(context.Background(), prompt)
+}
+
+// OfficialResponsesMissingTimeout exercises Responses.New on an unbounded context.
+func OfficialResponsesMissingTimeout() {
+	client := azureOfficialClient{}
+	client.Responses.New(context.Background(), "hello from azure official sample")
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/claude/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/claude/official_vulnerable.go
@@ -1,0 +1,24 @@
+// NuGuard minimal official anthropic-sdk-go call-shape fixture (issue #223).
+// Independently written structural sample — not vendored upstream source.
+// See ../ATTRIBUTION.md.
+package claude_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type claudeMessagesService struct{}
+
+func (claudeMessagesService) New(ctx context.Context, req any, _ ...any) {}
+
+type claudeOfficialClient struct {
+	Messages claudeMessagesService
+}
+
+// OfficialMessagesWithUserPrompt exercises Messages.New.
+func OfficialMessagesWithUserPrompt(userInput string) {
+	client := claudeOfficialClient{}
+	prompt := fmt.Sprintf("Discuss: %s", userInput)
+	client.Messages.New(context.Background(), prompt)
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/official_vulnerable.go
@@ -1,0 +1,25 @@
+// NuGuard minimal official google.golang.org/genai call-shape fixture (#223).
+// Independently written structural sample — not vendored upstream source.
+// See ../ATTRIBUTION.md.
+package gcp_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type geminiModelsService struct{}
+
+func (geminiModelsService) GenerateContent(ctx context.Context, model string, contents any, config any, _ ...any) {
+}
+
+type geminiOfficialClient struct {
+	Models geminiModelsService
+}
+
+// OfficialGenerateContentWithUserPrompt exercises Models.GenerateContent.
+func OfficialGenerateContentWithUserPrompt(userInput string) {
+	client := geminiOfficialClient{}
+	prompt := fmt.Sprintf("Summarize: %s", userInput)
+	client.Models.GenerateContent(context.Background(), "gemini-2.0-flash", prompt, nil)
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/openai/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/openai/official_vulnerable.go
@@ -1,0 +1,39 @@
+// NuGuard minimal official openai-go call-shape fixture (issue #223).
+// Independently written structural sample — not vendored upstream source.
+// See ../ATTRIBUTION.md.
+package openai_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type openaiChatCompletions struct{}
+
+func (openaiChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+type openaiChatService struct {
+	Completions openaiChatCompletions
+}
+
+type openaiResponsesService struct{}
+
+func (openaiResponsesService) New(ctx context.Context, req any, _ ...any) {}
+
+type openaiOfficialClient struct {
+	Chat      openaiChatService
+	Responses openaiResponsesService
+}
+
+// OfficialChatCompletionsWithUserPrompt exercises Chat.Completions.New.
+func OfficialChatCompletionsWithUserPrompt(userInput string) {
+	client := openaiOfficialClient{}
+	prompt := fmt.Sprintf("Answer the customer: %s", userInput)
+	client.Chat.Completions.New(context.Background(), prompt)
+}
+
+// OfficialResponsesMissingTimeout exercises Responses.New on an unbounded context.
+func OfficialResponsesMissingTimeout() {
+	client := openaiOfficialClient{}
+	client.Responses.New(context.Background(), "hello from openai official sample")
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_negative.go
@@ -1,0 +1,23 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+)
+
+// Bare .New(ctx, ...) must not become an LLM sink (issue #223).
+
+type arbitraryStore struct{}
+
+func (arbitraryStore) New(ctx context.Context, name string, _ ...any) {}
+
+func BareNewNotLLMSink(userInput string) {
+	store := arbitraryStore{}
+	name := fmt.Sprintf("order-%s", userInput)
+	store.New(context.Background(), name)
+}
+
+func BareNewMissingTimeoutNotLLM() {
+	store := arbitraryStore{}
+	store.New(context.Background(), "widget")
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_positive.go
@@ -1,0 +1,91 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+)
+
+// Minimal structural stand-ins for official SDK call shapes (issue #223).
+// Not runnable and not vendored upstream source.
+
+type officialChatCompletions struct{}
+
+func (officialChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+type officialChatService struct {
+	Completions officialChatCompletions
+}
+
+type officialResponsesService struct{}
+
+func (officialResponsesService) New(ctx context.Context, req any, _ ...any) {}
+
+type officialMessagesService struct{}
+
+func (officialMessagesService) New(ctx context.Context, req any, _ ...any) {}
+
+type officialModelsService struct{}
+
+func (officialModelsService) GenerateContent(ctx context.Context, model string, contents any, config any, _ ...any) {
+}
+
+type officialOpenAIClient struct {
+	Chat      officialChatService
+	Responses officialResponsesService
+}
+
+type officialAnthropicClient struct {
+	Messages officialMessagesService
+}
+
+type officialBedrockClient struct{}
+
+func (officialBedrockClient) Converse(ctx context.Context, req any, _ ...any) {}
+
+func (officialBedrockClient) InvokeModel(ctx context.Context, req any, _ ...any) {}
+
+type officialGeminiClient struct {
+	Models officialModelsService
+}
+
+func OfficialOpenAIChatCompletionsPromptInjection(userInput string) {
+	client := officialOpenAIClient{}
+	prompt := fmt.Sprintf("Answer: %s", userInput)
+	client.Chat.Completions.New(context.Background(), prompt)
+}
+
+func OfficialOpenAIResponsesMissingTimeout() {
+	client := officialOpenAIClient{}
+	client.Responses.New(context.Background(), "hello")
+}
+
+func OfficialAnthropicMessagesPromptInjection(userInput string) {
+	client := officialAnthropicClient{}
+	prompt := fmt.Sprintf("Discuss: %s", userInput)
+	client.Messages.New(context.Background(), prompt)
+}
+
+func OfficialBedrockConverseMissingTimeout() {
+	client := officialBedrockClient{}
+	client.Converse(context.Background(), "hello")
+}
+
+// OfficialBedrockInvokeModelWithOptFn proves variadic optFns matching (#223).
+func OfficialBedrockInvokeModelWithOptFn() {
+	client := officialBedrockClient{}
+	optFn := func() {}
+	client.InvokeModel(context.Background(), "hello", optFn)
+}
+
+func OfficialBedrockConversePromptInjectionWithOptFn(userInput string) {
+	client := officialBedrockClient{}
+	prompt := fmt.Sprintf("Summarize ticket: %s", userInput)
+	optFn := func() {}
+	client.Converse(context.Background(), prompt, optFn)
+}
+
+func OfficialGeminiGenerateContentPromptInjection(userInput string) {
+	client := officialGeminiClient{}
+	prompt := fmt.Sprintf("Summarize: %s", userInput)
+	client.Models.GenerateContent(context.Background(), "gemini-2.0-flash", prompt, nil)
+}

--- a/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
+++ b/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
@@ -5,14 +5,17 @@ GCP / OpenAI / Claude flavoured fixtures under
 ``fixtures/go_provider_samples/``.
 
 This is intentionally *not* a direct ``semgrep`` CLI invocation (see
-``test_semgrep_go_rules.py`` for rule-behaviour line tests). Official
-first-party SDK sink shapes are tracked in issue #223 and are out of scope.
+``test_semgrep_go_rules.py`` for rule-behaviour line tests). Each provider
+directory covers community/compat shapes (``vulnerable.go``, PR #224) and
+official non-streaming SDK call shapes (``official_vulnerable.go``, #223).
 
-Semgrep's default ``.semgrepignore`` skips paths under ``tests/``, and the
-plugin scans directories (not explicit file args). Fixtures are therefore
-materialized into a temporary directory before
-``SemgrepScannerPlugin.run`` so discovery matches production source trees
-that are not nested under a ``tests/`` path segment.
+``SemgrepScannerPlugin`` adds ``--exclude tests/`` by default when
+``semgrep_exclude_tests`` is true, and the plugin scans directories (not
+explicit file args). Fixtures under this test tree are therefore materialized
+into a temporary source-like directory before ``SemgrepScannerPlugin.run`` so
+discovery matches production source trees that are not nested under a
+``tests/`` path segment. E2E cases pass ``semgrep_exclude_tests=False`` on the
+materialized temp dir as belt-and-suspenders.
 """
 
 from __future__ import annotations
@@ -20,6 +23,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from collections import defaultdict
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
@@ -41,6 +45,7 @@ _GO_RULE_IDS = frozenset(
 )
 
 # Expected rule-ID sets per provider (normalized Semgrep check_id suffixes).
+# These #224 community/compat expectations remain the regression baseline.
 _EXPECTED_BY_PROVIDER: dict[str, frozenset[str]] = {
     "openai": frozenset(
         {
@@ -75,6 +80,44 @@ _EXPECTED_BY_PROVIDER: dict[str, frozenset[str]] = {
     ),
 }
 
+# Official (#223) fixtures must themselves produce at least these rule IDs.
+# Kept distinct from #224 so community findings cannot satisfy official coverage.
+_EXPECTED_OFFICIAL_BY_PROVIDER: dict[str, frozenset[str]] = {
+    "openai": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "azure": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "aws": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "gcp": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "claude": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+}
+
+_OFFICIAL_FIXTURE_NAME = "official_vulnerable.go"
+_COMMUNITY_FIXTURE_NAME = "vulnerable.go"
+
 
 def _semgrep_binary() -> str | None:
     return shutil.which("semgrep")
@@ -96,6 +139,17 @@ def _normalize_rule_id(check_id: str) -> str:
     return str(check_id).rsplit(".", 1)[-1]
 
 
+def _finding_filename(finding: Mapping[str, object]) -> str:
+    """Best-effort filename from SemgrepScannerPlugin finding ``affected`` paths."""
+    affected = finding.get("affected") or []
+    if not isinstance(affected, list) or not affected:
+        return ""
+    location = str(affected[0])
+    # location is typically "<path>:<line>"
+    path_part = location.rsplit(":", 1)[0]
+    return Path(path_part).name
+
+
 @contextmanager
 def _materialize_provider(provider: str) -> Iterator[Path]:
     """Copy one provider fixture into a temp dir suitable for Semgrep directory scans."""
@@ -113,8 +167,8 @@ def _materialize_provider(provider: str) -> Iterator[Path]:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
 
-def _scan_provider(provider: str) -> frozenset[str]:
-    """Run SemgrepScannerPlugin on one provider fixture (via temp materialization)."""
+def _scan_provider(provider: str) -> Mapping[str, frozenset[str]]:
+    """Run SemgrepScannerPlugin; return rule IDs keyed by fixture filename."""
     with _materialize_provider(provider) as source_dir:
         result = SemgrepScannerPlugin().run(
             {"nodes": []},
@@ -129,32 +183,45 @@ def _scan_provider(provider: str) -> frozenset[str]:
         )
         assert result.plugin == "semgrep"
 
-        fired: set[str] = set()
+        by_file: dict[str, set[str]] = defaultdict(set)
         for finding in result.findings:
             rule_id = _normalize_rule_id(str(finding.get("rule_id", "")))
-            if rule_id:
-                fired.add(rule_id)
-        return frozenset(fired)
+            if not rule_id:
+                continue
+            filename = _finding_filename(finding)
+            if filename:
+                by_file[filename].add(rule_id)
+        return MappingProxyType({name: frozenset(ids) for name, ids in by_file.items()})
 
 
 @pytest.fixture(scope="module")
-def provider_semgrep_findings() -> Mapping[str, frozenset[str]]:
-    """Scan each provider once; share immutable results across this module's tests."""
+def provider_semgrep_findings_by_file() -> Mapping[str, Mapping[str, frozenset[str]]]:
+    """Scan each provider once; share immutable per-file results across tests."""
     _require_semgrep()
     findings = {
-        provider: _scan_provider(provider) for provider in sorted(_EXPECTED_BY_PROVIDER)
+        provider: _scan_provider(provider)
+        for provider in sorted(_EXPECTED_BY_PROVIDER)
     }
     return MappingProxyType(findings)
+
+
+def _provider_union(
+    by_file: Mapping[str, frozenset[str]],
+) -> frozenset[str]:
+    fired: set[str] = set()
+    for rule_ids in by_file.values():
+        fired |= set(rule_ids)
+    return frozenset(fired)
 
 
 @pytest.mark.parametrize("provider", sorted(_EXPECTED_BY_PROVIDER))
 def test_provider_fixture_emits_expected_go_rules(
     provider: str,
-    provider_semgrep_findings: Mapping[str, frozenset[str]],
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
 ) -> None:
     """Each provider sample must surface its expected Go AI-security rule IDs."""
     expected = _EXPECTED_BY_PROVIDER[provider]
-    fired = provider_semgrep_findings[provider]
+    fired = _provider_union(provider_semgrep_findings_by_file[provider])
     missing = expected - fired
     assert not missing, (
         f"{provider}: missing expected Go rule IDs {sorted(missing)}; "
@@ -162,13 +229,45 @@ def test_provider_fixture_emits_expected_go_rules(
     )
 
 
+@pytest.mark.parametrize("provider", sorted(_EXPECTED_BY_PROVIDER))
+def test_community_vulnerable_fixture_still_fires(
+    provider: str,
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
+) -> None:
+    """#224 regression: community ``vulnerable.go`` must satisfy expected rule IDs."""
+    expected = _EXPECTED_BY_PROVIDER[provider]
+    by_file = provider_semgrep_findings_by_file[provider]
+    fired = by_file.get(_COMMUNITY_FIXTURE_NAME, frozenset())
+    missing = expected - fired
+    assert not missing, (
+        f"{provider}: {_COMMUNITY_FIXTURE_NAME} missing expected Go rule IDs "
+        f"{sorted(missing)}; fired={sorted(fired)}"
+    )
+
+
+@pytest.mark.parametrize("provider", sorted(_EXPECTED_OFFICIAL_BY_PROVIDER))
+def test_official_vulnerable_fixture_emits_expected_go_rules(
+    provider: str,
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
+) -> None:
+    """#223: official_vulnerable.go must itself fire expected rule IDs."""
+    expected = _EXPECTED_OFFICIAL_BY_PROVIDER[provider]
+    by_file = provider_semgrep_findings_by_file[provider]
+    fired = by_file.get(_OFFICIAL_FIXTURE_NAME, frozenset())
+    missing = expected - fired
+    assert not missing, (
+        f"{provider}: official fixture missing rule IDs {sorted(missing)}; "
+        f"fired={sorted(fired)}; files={sorted(by_file)}"
+    )
+
+
 def test_provider_pack_covers_all_go_rules(
-    provider_semgrep_findings: Mapping[str, frozenset[str]],
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
 ) -> None:
     """Collectively, the provider pack must exercise all four Go rule IDs."""
     fired: set[str] = set()
-    for rule_ids in provider_semgrep_findings.values():
-        fired |= rule_ids
+    for by_file in provider_semgrep_findings_by_file.values():
+        fired |= set(_provider_union(by_file))
 
     missing = _GO_RULE_IDS - fired
     assert not missing, (

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -221,6 +221,38 @@ class TestGoInsecureTls:
         )
 
 
+class TestGoOfficialSdkSinks:
+    """Issue #223: qualified official SDK sinks (never bare New)."""
+
+    def test_official_positive_prompt_injection(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "official_sdk_positive.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+        # Chat.Completions.New, Messages.New, Converse(...optFn), GenerateContent
+        assert lines == [54, 65, 84, 90]
+
+    def test_official_positive_missing_timeout(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "official_sdk_positive.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+        # Includes Bedrock InvokeModel/Converse calls that pass a trailing optFn.
+        assert lines == [54, 59, 65, 70, 77, 84, 90]
+
+    def test_bare_new_is_not_llm_sink(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        for rule_id in _GO_RULE_IDS:
+            _assert_no_rule(semgrep_findings, "official_sdk_negative.go", rule_id)
+
+
 class TestGoRuleInventory:
     def test_only_expected_go_rules_fire_on_fixtures(
         self, semgrep_findings: dict[str, list[dict[str, object]]]


### PR DESCRIPTION
## Summary

Extends NuGuard's Go AI-security Semgrep rules with explicit support for official non-streaming provider SDK call shapes while preserving the existing rule IDs and community/provider-neutral patterns.

Adds support for:

- OpenAI `Chat.Completions.New` and `Responses.New`
- AWS Bedrock `Converse` and `InvokeModel`, including trailing option functions
- Anthropic `Messages.New`
- Google Gemini `Models.GenerateContent`
- Azure through the OpenAI-compatible nested call shapes

## Implementation

- Keeps all existing Go AI-security rule IDs unchanged
- Uses qualified nested patterns rather than a broad `.New(...)` matcher
- Preserves existing community/provider-neutral sinks
- Leaves the hardcoded API-key rule unchanged
- Extends prompt-injection and missing-context-timeout detection to the official SDK shapes
- Adds focused negative coverage to ensure arbitrary `.New(ctx, ...)` calls are not treated as LLM sinks

## Tests

Added focused rule fixtures plus provider-level E2E fixtures for OpenAI, Azure, AWS, GCP, and Claude.

The existing PR #224 community fixtures remain independently validated so the new official fixtures cannot mask regressions in the previous coverage.

Validation:

- `test_semgrep_go_rules.py`: 15 passed
- `test_go_provider_semgrep_e2e.py`: 16 passed
- focused Go Semgrep suite: 31 passed
- `ruff check nuguard/`: passed
- `mypy nuguard/`: passed
- full test suite: 1949 passed, 34 skipped
- `git diff --check`: clean

## Out of scope

As discussed, this PR intentionally does not add:

- streaming variants
- new credential-option patterns
- official `option.WithHTTPClient` TLS flows

Those can be handled in a separate follow-up issue.

Closes #223
