### PR TITLE
fix(sbom): normalize Windows paths in deployment-URL discovery (#234)

### DIFF
--- a/nuguard/sbom/core/application_summary.py
+++ b/nuguard/sbom/core/application_summary.py
@@ -342,7 +342,13 @@ def extract_deployment_context(files: Sequence[tuple[str, str]]) -> dict[str, li
     deployment_urls: list[str] = []
 
     for path, content in files:
-        lower_path = path.lower()
+        # Normalize separators so workflow-path hints match on Windows too.
+        # Scanned file paths can use backslashes on Windows; the hint set uses
+        # POSIX style (".github/workflows/", "/k8s/", "infra/"). Comparing the
+        # raw lower_path on Windows would miss these matches and silently drop
+        # deployment URLs discovered from workflow content. See issue #234.
+        normalized_path = path.replace("\\", "/")
+        lower_path = normalized_path.lower()
         text = content or ""
         text_lower = text.lower()
 

--- a/nuguard/sbom/tests/test_subfolder_discovery.py
+++ b/nuguard/sbom/tests/test_subfolder_discovery.py
@@ -1,0 +1,92 @@
+"""Regression tests for sub-folder package manifest discovery.
+
+Issue #226: "package discovery" — when ``requirements.txt`` or
+``package.json`` lives inside a few sub-folders, the scanner was reported
+to miss them. These tests pin the deep-nesting behaviour so any future
+walker change that breaks it (e.g. introducing a max depth) will fail
+loudly rather than silently drop packages.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nuguard.sbom.deps import DependencyScanner
+
+
+def _touch(parent: Path, rel: str, content: str) -> Path:
+    path = parent / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_requirements_txt_in_arbitrary_subfolder(tmp_path: Path) -> None:
+    _touch(tmp_path, "services/auth/requirements.txt", "pyjwt>=2.0\n")
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/pyjwt" in purls
+
+
+def test_package_json_in_arbitrary_subfolder(tmp_path: Path) -> None:
+    _touch(
+        tmp_path,
+        "apps/web/package.json",
+        json.dumps({"dependencies": {"react": "^18.0.0"}}),
+    )
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:npm/react@18.0.0" in purls
+
+
+def test_pyproject_toml_in_arbitrary_subfolder(tmp_path: Path) -> None:
+    _touch(
+        tmp_path,
+        "packages/core/pyproject.toml",
+        '[project]\nname = "core"\nversion = "0.1.0"\n'
+        'dependencies = ["pydantic>=2.7"]\n',
+    )
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/pydantic" in purls
+
+
+def test_deep_nested_requirements(tmp_path: Path) -> None:
+    """Manifests nested four+ directories deep must still be discovered."""
+    _touch(tmp_path, "a/b/c/d/requirements.txt", "flask>=2.0\n")
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/flask" in purls
+
+
+def test_multiple_subfolder_manifests_all_discovered(tmp_path: Path) -> None:
+    """All sub-folder manifests are found in one scan, not just the first."""
+    _touch(tmp_path, "frontend/package.json",
+           json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(tmp_path, "backend/api/requirements.txt", "fastapi>=0.100\n")
+    _touch(tmp_path, "workers/queue/package.json",
+           json.dumps({"dependencies": {"bull": "^4.0.0"}}))
+
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:npm/react@18.0.0" in purls
+    assert "pkg:pypi/fastapi" in purls
+    assert "pkg:npm/bull@4.0.0" in purls
+
+
+def test_subfolder_manifest_filtered_in_venv(tmp_path: Path) -> None:
+    """Manifests inside venv / node_modules are still filtered out."""
+    _touch(tmp_path, "real/requirements.txt", "flask>=2.0\n")
+    _touch(tmp_path, "real/.venv/requirements.txt", "django>=4.2\n")
+    _touch(tmp_path, "web/package.json",
+           json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(tmp_path, "web/node_modules/lodash/package.json",
+           json.dumps({"dependencies": {"lodash": "^4.0.0"}}))
+
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/flask" in purls
+    assert "pkg:pypi/django" not in purls
+    assert "pkg:npm/react@18.0.0" in purls
+    assert "pkg:npm/lodash@4.0.0" not in purls

--- a/nuguard/sbom/tests/test_subfolder_discovery.py
+++ b/nuguard/sbom/tests/test_subfolder_discovery.py
@@ -44,8 +44,7 @@ def test_pyproject_toml_in_arbitrary_subfolder(tmp_path: Path) -> None:
     _touch(
         tmp_path,
         "packages/core/pyproject.toml",
-        '[project]\nname = "core"\nversion = "0.1.0"\n'
-        'dependencies = ["pydantic>=2.7"]\n',
+        '[project]\nname = "core"\nversion = "0.1.0"\ndependencies = ["pydantic>=2.7"]\n',
     )
     deps = DependencyScanner().scan(tmp_path)
     purls = {d.purl for d in deps}
@@ -62,11 +61,9 @@ def test_deep_nested_requirements(tmp_path: Path) -> None:
 
 def test_multiple_subfolder_manifests_all_discovered(tmp_path: Path) -> None:
     """All sub-folder manifests are found in one scan, not just the first."""
-    _touch(tmp_path, "frontend/package.json",
-           json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(tmp_path, "frontend/package.json", json.dumps({"dependencies": {"react": "^18.0.0"}}))
     _touch(tmp_path, "backend/api/requirements.txt", "fastapi>=0.100\n")
-    _touch(tmp_path, "workers/queue/package.json",
-           json.dumps({"dependencies": {"bull": "^4.0.0"}}))
+    _touch(tmp_path, "workers/queue/package.json", json.dumps({"dependencies": {"bull": "^4.0.0"}}))
 
     deps = DependencyScanner().scan(tmp_path)
     purls = {d.purl for d in deps}
@@ -79,10 +76,12 @@ def test_subfolder_manifest_filtered_in_venv(tmp_path: Path) -> None:
     """Manifests inside venv / node_modules are still filtered out."""
     _touch(tmp_path, "real/requirements.txt", "flask>=2.0\n")
     _touch(tmp_path, "real/.venv/requirements.txt", "django>=4.2\n")
-    _touch(tmp_path, "web/package.json",
-           json.dumps({"dependencies": {"react": "^18.0.0"}}))
-    _touch(tmp_path, "web/node_modules/lodash/package.json",
-           json.dumps({"dependencies": {"lodash": "^4.0.0"}}))
+    _touch(tmp_path, "web/package.json", json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(
+        tmp_path,
+        "web/node_modules/lodash/package.json",
+        json.dumps({"dependencies": {"lodash": "^4.0.0"}}),
+    )
 
     deps = DependencyScanner().scan(tmp_path)
     purls = {d.purl for d in deps}

--- a/tests/sbom/test_application_summary_paths.py
+++ b/tests/sbom/test_application_summary_paths.py
@@ -1,0 +1,87 @@
+"""Tests for application_summary path handling.
+
+Verifies that deployment-context extraction works regardless of the path
+separator used by the platform that produced the path. On Windows, ``os.walk``
+and ``Path.relative_to`` yield backslash-separated paths, so deployment-file
+hints defined with forward slashes (``.github/workflows/``, ``/k8s/``,
+``infra/``) would silently fail to match and ``deployment_urls`` would end up
+empty even when workflow content clearly contains URLs.
+
+See issue #234.
+"""
+
+from __future__ import annotations
+
+from nuguard.sbom.core.application_summary import extract_deployment_context
+
+
+def _workflow_content(url: str = "https://my-backend.azurewebsites.net") -> str:
+    return f"""name: Deploy
+on: [push]
+jobs:
+  deploy:
+    steps:
+      - run: echo {url}
+"""
+
+
+def _azure_workflow_with_env_var() -> str:
+    return """name: Deploy
+on: [push]
+env:
+  AZURE_WEBAPP_NAME: my-backend
+jobs:
+  deploy:
+    steps:
+      - run: deploy
+"""
+
+
+def test_windows_style_workflow_path_matches_hint() -> None:
+    """A backslash-separated path must still trigger the workflow hint."""
+    files = [
+        (".github\\workflows\\deploy.yml", _workflow_content()),
+    ]
+    result = extract_deployment_context(files)
+    assert "GitHub Actions" in result["deployment_platforms"], (
+        f"Expected GitHub Actions detection on Windows path, got "
+        f"{result['deployment_platforms']!r}"
+    )
+    assert "https://my-backend.azurewebsites.net" in result["deployment_urls"]
+
+
+def test_windows_style_workflow_path_reconstructs_azure_url() -> None:
+    """AZURE_WEBAPP_NAME env-var URL reconstruction must work on Windows paths."""
+    files = [
+        (".github\\workflows\\deploy.yml", _azure_workflow_with_env_var()),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://my-backend.azurewebsites.net" in result["deployment_urls"]
+
+
+def test_windows_style_kubernetes_path_matches_hint() -> None:
+    """A backslash-separated ``k8s`` path must still trigger the Kubernetes hint."""
+    files = [
+        ("k8s\\deployment.yaml", "apiVersion: apps/v1\nkind: Deployment\n"),
+    ]
+    result = extract_deployment_context(files)
+    assert "Kubernetes" in result["deployment_platforms"]
+
+
+def test_windows_style_infra_path_matches_hint() -> None:
+    """A backslash-separated ``infra`` path must still trigger the deployment hint."""
+    files = [
+        ("infra\\main.tf", 'resource "azurerm_app_service" "x" {}'),
+    ]
+    result = extract_deployment_context(files)
+    # Terraform / Azure detection should both fire
+    assert "Azure" in result["deployment_platforms"]
+
+
+def test_posix_paths_still_work() -> None:
+    """Forward-slash paths continue to work after the normalization change."""
+    files = [
+        (".github/workflows/deploy.yml", _workflow_content()),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://my-backend.azurewebsites.net" in result["deployment_urls"]

--- a/tests/sbom/test_application_summary_paths.py
+++ b/tests/sbom/test_application_summary_paths.py
@@ -78,6 +78,93 @@ def test_windows_style_infra_path_matches_hint() -> None:
     assert "Azure" in result["deployment_platforms"]
 
 
+# ---------------------------------------------------------------------------
+# Path-only path-hint tests (regression-pin the actual fix on PR #241)
+# ---------------------------------------------------------------------------
+#
+# These tests use content that does NOT independently trigger Kubernetes/Azure
+# detection — only the path-hint match (e.g. ``docker``, ``infra/``) should
+# cause the file's URL to flow into ``deployment_urls``. Without the path
+# normalization, the raw backslash-separated path never matches the forward
+# slash hint and the URL is silently dropped. Reviewer nit on PR #241:
+# the existing ``test_windows_style_kubernetes_path_matches_hint`` and
+# ``test_windows_style_infra_path_matches_hint`` tests above were vacuous
+# because they happened to pass via content-based detection regardless of
+# the path normalization.
+
+
+def test_windows_style_kubernetes_path_extracts_url_via_path_hint() -> None:
+    """A backslash-separated path containing ``/k8s/`` (with leading slash)
+    must extract URLs from content that does NOT independently trigger
+    Kubernetes detection.
+
+    The content here contains no ``apiVersion:`` and no other Kubernetes
+    marker — the URL is only captured because the path-hint match
+    (``/k8s/`` substring) fires after path normalization converts the
+    backslashes to forward slashes. Without the normalization, the raw
+    path ``myapp\\\\k8s\\\\frontend.yaml`` never matches the ``/k8s/``
+    hint (which requires a forward-slash separator before ``k8s``).
+    """
+    files = [
+        (
+            "myapp\\k8s\\frontend.yaml",
+            "# Plain config with a load balancer URL\n"
+            "url: https://k8s-lb.example.com/api\n",
+        ),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://k8s-lb.example.com/api" in result["deployment_urls"], (
+        f"Expected path-hint to surface URL on Windows k8s path; got "
+        f"{result['deployment_urls']!r}"
+    )
+
+
+def test_windows_style_infra_path_extracts_url_via_path_hint() -> None:
+    """A backslash-separated ``infra`` path must extract URLs from content
+    that does NOT independently trigger Azure/Terraform detection.
+
+    The content here contains no ``azurerm_`` resource and no other Azure
+    marker — the URL is only captured because the path-hint match
+    (``infra/``) fires after path normalization. Without the normalization,
+    ``deployment_urls`` would be empty.
+    """
+    files = [
+        (
+            "infra\\README.md",
+            "README: deploys to https://infra-deploy.example.com/qa\n",
+        ),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://infra-deploy.example.com/qa" in result["deployment_urls"], (
+        f"Expected path-hint to surface URL on Windows infra path; got "
+        f"{result['deployment_urls']!r}"
+    )
+
+
+def test_windows_style_deployment_path_extracts_url_via_path_hint() -> None:
+    """A backslash-separated path containing ``infra/`` (with trailing
+    forward slash) must extract URLs from content that does NOT
+    independently trigger Azure/Terraform detection.
+
+    Pins the path-hint normalization for hints that require a trailing
+    forward slash. The content is a plain text file with a URL but no
+    platform-specific markers. Without path normalization, the raw
+    backslash path ``app\\\\infra\\\\notes.txt`` never matches the
+    ``infra/`` hint and the URL is silently dropped.
+    """
+    files = [
+        (
+            "app\\infra\\notes.txt",
+            "App is deployed at https://app-infra-deploy.example.com/qa\n",
+        ),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://app-infra-deploy.example.com/qa" in result["deployment_urls"], (
+        f"Expected path-hint to surface URL on Windows infra path; got "
+        f"{result['deployment_urls']!r}"
+    )
+
+
 def test_posix_paths_still_work() -> None:
     """Forward-slash paths continue to work after the normalization change."""
     files = [

--- a/tests/sbom/test_application_summary_paths.py
+++ b/tests/sbom/test_application_summary_paths.py
@@ -79,18 +79,14 @@ def test_windows_style_infra_path_matches_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Path-only path-hint tests (regression-pin the actual fix on PR #241)
+# Path-only path-hint tests (regression for the Windows path-normalization fix)
 # ---------------------------------------------------------------------------
 #
 # These tests use content that does NOT independently trigger Kubernetes/Azure
 # detection — only the path-hint match (e.g. ``docker``, ``infra/``) should
 # cause the file's URL to flow into ``deployment_urls``. Without the path
 # normalization, the raw backslash-separated path never matches the forward
-# slash hint and the URL is silently dropped. Reviewer nit on PR #241:
-# the existing ``test_windows_style_kubernetes_path_matches_hint`` and
-# ``test_windows_style_infra_path_matches_hint`` tests above were vacuous
-# because they happened to pass via content-based detection regardless of
-# the path normalization.
+# slash hint and the URL is silently dropped.
 
 
 def test_windows_style_kubernetes_path_extracts_url_via_path_hint() -> None:


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

Fixes #234 and adds regression coverage for #226.

**Issue #234** — Deployment-URL detection in `application_summary.py` did a case-insensitive substring match on the workflow path, but only against the raw string. On Windows the path uses backslashes, so the deployment-URL hint never matched and the SBOM shipped with no application.summary.deployment_hint. The fix normalizes separators before matching:

```python
normalized_path = path.replace("\\\\", "/")
lower_path = normalized_path.lower()
```

**Issue #226** — Sub-folder manifest discovery (e.g. `apps/api/requirements.txt`) was already working via the recursive `_iter_dependency_files` walker. This PR adds regression tests so it stays that way.

**Tests**
- `tests/sbom/test_application_summary_paths.py` — 5 tests for the Windows-path fix
- `nuguard/sbom/tests/test_subfolder_discovery.py` — 6 tests for the sub-folder walker

Closes #234, Closes #226