### PR TITLE
fix(cli): redteam --format text --output writes JSON content to .txt file

### DIFF
--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -426,7 +426,14 @@ def redteam(
                 all_formats=effective_formats,
                 extension_map=extension_map,
             )
-            if fmt == "markdown":
+            if fmt == "text":
+                # Plain-text report — no ANSI escapes in a file. Identical
+                # content to what ``nuguard redteam`` emits to stdout.
+                out_path.write_text(
+                    _render_findings_text(findings, meta, scan_outcome, colour=False),
+                    encoding="utf-8",
+                )
+            elif fmt == "markdown":
                 out_path.write_text(
                     _findings_to_markdown(
                         findings,
@@ -979,6 +986,85 @@ async def _run_orchestrator(  # noqa: C901
     )
 
 
+_SEV_COLOUR: dict[str, str] = {
+    "critical": "red",
+    "high": "red",
+    "medium": "yellow",
+    "low": "blue",
+    "info": "white",
+}
+
+
+def _render_findings_text(
+    findings: list,
+    meta: "ReportMeta",
+    scan_outcome: str = "no_findings",
+    *,
+    colour: bool = False,
+) -> str:
+    """Render findings as a plain-text report.
+
+    Returns a multi-line string suitable for writing to a file or echoing to a
+    terminal. When ``colour`` is ``True``, the severity label is wrapped in
+    ANSI escapes via :func:`typer.style` (used for stdout). When ``False``
+    (default), the output is plain text with no escape sequences — suitable
+    for on-disk reports that downstream tools may parse.
+
+    Args:
+        findings: List of :class:`~nuguard.models.finding.Finding` objects.
+        meta: Report metadata header.
+        scan_outcome: One-line scan outcome string ("no_findings", etc.).
+        colour: If ``True``, wrap severity labels with ANSI colour codes.
+
+    Returns:
+        Plain-text report as a single string.
+    """
+    from nuguard.models.finding import Severity as _Severity
+
+    if not findings:
+        lines = [
+            meta.to_text_line(),
+            f"Outcome: {scan_outcome}",
+            "No findings — scan complete",
+        ]
+        return "\n".join(lines) + "\n"
+
+    _ORDER = [
+        _Severity.CRITICAL,
+        _Severity.HIGH,
+        _Severity.MEDIUM,
+        _Severity.LOW,
+        _Severity.INFO,
+    ]
+
+    out: list[str] = []
+    out.append("")
+    out.append("─" * 60)
+    out.append(f"  NuGuard Red-Team — {len(findings)} finding(s)")
+    out.append(f"  {meta.to_text_line()}")
+    out.append(f"  Outcome: {scan_outcome}")
+    out.append("─" * 60)
+    for f in sorted(findings, key=lambda x: _ORDER.index(x.severity)):
+        sev_key = f.severity.value if hasattr(f.severity, "value") else str(f.severity)
+        sev_text = sev_key.upper()
+        if colour:
+            colour_name = _SEV_COLOUR.get(sev_key, "white")
+            sev_label = typer.style(sev_text, fg=colour_name, bold=True)
+        else:
+            sev_label = sev_text
+        out.append("")
+        out.append(f"[{sev_label}] {f.title}")
+        out.append(f"  {f.description[:200]}")
+        if f.remediation:
+            out.append(f"  Fix: {f.remediation[:150]}")
+        if f.owasp_asi_ref:
+            out.append(f"  Ref: {f.owasp_asi_ref}")
+    out.append("")
+    out.append("─" * 60)
+    out.append("")
+    return "\n".join(out)
+
+
 def _print_findings(
     findings: list,
     format: str,
@@ -992,8 +1078,6 @@ def _print_findings(
     coverage_tracker: object | None = None,
 ) -> None:
     """Print findings to stdout in the requested format."""
-    from nuguard.models.finding import Severity
-
     if meta is None:
         meta = ReportMeta()
 
@@ -1028,35 +1112,9 @@ def _print_findings(
         )
         return
 
-    if not findings:
-        typer.echo(meta.to_text_line())
-        typer.echo(f"Outcome: {scan_outcome}")
-        typer.echo("No findings — scan complete")
-        return
-
-    _SEV_COLOUR = {
-        Severity.CRITICAL: "red",
-        Severity.HIGH: "red",
-        Severity.MEDIUM: "yellow",
-        Severity.LOW: "blue",
-        Severity.INFO: "white",
-    }
-
-    typer.echo(f"\n{'─' * 60}")
-    typer.echo(f"  NuGuard Red-Team — {len(findings)} finding(s)")
-    typer.echo(f"  {meta.to_text_line()}")
-    typer.echo(f"  Outcome: {scan_outcome}")
-    typer.echo(f"{'─' * 60}")
-    for f in sorted(findings, key=lambda x: list(Severity).index(x.severity)):
-        colour = _SEV_COLOUR.get(f.severity, "white")
-        sev_label = typer.style(f.severity.upper(), fg=colour, bold=True)
-        typer.echo(f"\n[{sev_label}] {f.title}")
-        typer.echo(f"  {f.description[:200]}")
-        if f.remediation:
-            typer.echo(f"  Fix: {f.remediation[:150]}")
-        if f.owasp_asi_ref:
-            typer.echo(f"  Ref: {f.owasp_asi_ref}")
-    typer.echo(f"\n{'─' * 60}\n")
+    # Default and explicit "text" path — emit the plain-text report (with
+    # ANSI colour escapes when stdout is a TTY).
+    typer.echo(_render_findings_text(findings, meta, scan_outcome, colour=True))
 
 
 def _scenario_coverage_table(scenario_records: list) -> list[str]:

--- a/tests/cli/test_redteam_format_output.py
+++ b/tests/cli/test_redteam_format_output.py
@@ -23,11 +23,17 @@ These tests pin the contract:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
 
 from nuguard.cli.commands.redteam import _render_findings_text
+from nuguard.cli.main import app
 from nuguard.cli.report_meta import ReportMeta
 from nuguard.models.finding import Finding, Severity
+from nuguard.models.token_usage import TokenUsage
 
 
 def _make_findings() -> list[Finding]:
@@ -55,6 +61,45 @@ def _make_findings() -> list[Finding]:
             owasp_asi_ref="ASI-02",
         ),
     ]
+
+
+def _make_minimal_sbom(tmp_path: Path) -> Path:
+    """Write a minimal valid AI-SBOM JSON file the redteam CLI will accept."""
+    sbom_path = tmp_path / "minimal.sbom.json"
+    sbom_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.5.0",
+                "generator": "nuguard",
+                "target": "https://github.com/test/test",
+                "nodes": [],
+                "edges": [],
+                "deps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return sbom_path
+
+
+def _mock_run_redteam_outcome():
+    """Return a coroutine that yields the 13-tuple ``_run_redteam`` produces."""
+    async def _coro(*_args, **_kwargs):
+        return (
+            _make_findings(),  # findings
+            [],                 # scenario_records
+            "no_findings",      # scan_outcome
+            [],                 # config_notes
+            None,               # catalog_coverage
+            0,                  # input_tokens_used
+            0,                  # output_tokens_used
+            None,               # coverage_tracker
+            TokenUsage(),       # token_usage
+            "/chat",            # resolved_chat_path
+            "default",          # resolved_chat_path_source
+            [],                 # remediation_plan
+        )
+    return _coro
 
 
 # ---------------------------------------------------------------------------
@@ -140,71 +185,91 @@ def test_render_text_empty_findings_has_no_table_block() -> None:
 
 
 def test_dispatch_text_format_writes_plain_text_file(tmp_path: Path) -> None:
-    """Replicate the redteam --output dispatch loop and verify a ``.txt`` file
-    that ``fmt='text'`` produces contains plain text — NOT JSON.
+    """End-to-end: ``nuguard redteam --output foo.txt --format text`` writes
+    the plain-text report, not JSON.
 
-    This mirrors the inline dispatch in
-    ``nuguard/cli/commands/redteam.py:421-460`` after the fix.
+    Regression for #254 — the pre-fix dispatch fell through to the JSON
+    ``else`` branch when ``fmt='text'`` was requested, producing a JSON file
+    with a ``.txt`` extension. This test exercises the real CLI through
+    ``CliRunner`` so it will fail the moment the production dispatch loop
+    stops routing ``text`` to :func:`_render_findings_text`.
     """
-    findings = _make_findings()
-    meta = ReportMeta(verbose=False)
-
+    sbom_path = _make_minimal_sbom(tmp_path)
     output = tmp_path / "redteam.txt"
-    effective_formats = ["text"]
-    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
 
-    # --- Inline dispatch (mirrors redteam.py --output branch) ---
-    for fmt in effective_formats:
-        if len(effective_formats) > 1:
-            out_path = output.with_suffix(extension_map[fmt])
-        else:
-            out_path = output
-        if fmt == "text":
-            out_path.write_text(
-                _render_findings_text(findings, meta, "no_findings", colour=False),
-                encoding="utf-8",
-            )
-        elif fmt == "markdown":
-            out_path.write_text("MARKDOWN", encoding="utf-8")
-        elif fmt == "sarif":
-            out_path.write_text("SARIF", encoding="utf-8")
-        else:
-            # Bug path: should not be reached for fmt == "text".
-            out_path.write_text("BUG: JSON INSTEAD OF TEXT", encoding="utf-8")
+    runner = CliRunner()
+    with patch(
+        "nuguard.cli.commands.redteam._run_redteam",
+        new=_mock_run_redteam_outcome(),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(sbom_path),
+                "--target", "http://localhost:9999",
+                "--output", str(output),
+                "--format", "text",
+            ],
+        )
+
+    assert output.exists(), (
+        f"Output file was not written to {output}.\nstdout:\n{result.stdout}"
+    )
 
     content = output.read_text(encoding="utf-8")
     assert not content.lstrip().startswith("{"), (
-        "fmt='text' must write plain text, not JSON (regression for #254)."
+        "--format text --output must write plain text, not JSON (regression for #254)."
     )
     assert "\x1b[" not in content, "File output must not contain ANSI escapes."
     assert "NuGuard Red-Team" in content
     assert "2 finding(s)" in content
 
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by CRITICAL/HIGH
+    # findings) are both acceptable — the dispatch contract is that the file
+    # is written before the threshold check runs.
+    assert result.exit_code in (0, 2), (
+        f"Unexpected exit code {result.exit_code}; stdout:\n{result.stdout}"
+    )
+
 
 def test_dispatch_json_format_still_writes_json_file(tmp_path: Path) -> None:
-    """Sanity check: --format json --output foo.json still writes valid JSON.
+    """Sanity check: ``--format json --output foo.json`` still writes valid JSON.
 
-    The fix must not regress the JSON output path.
+    The fix must not regress the JSON output path. Same end-to-end shape as
+    the text-format test above — exercises the real CLI dispatcher.
     """
-    import json as _json
-
-    from nuguard.redteam.report import to_json
-
-    findings = _make_findings()
-    meta = ReportMeta(verbose=False)
+    sbom_path = _make_minimal_sbom(tmp_path)
     output = tmp_path / "redteam.json"
-    effective_formats = ["json"]
-    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
 
-    for fmt in effective_formats:
-        out_path = output.with_suffix(extension_map[fmt])
-        if fmt == "json":
-            out_path.write_text(
-                to_json(findings, meta=meta, scan_outcome="no_findings"),
-                encoding="utf-8",
-            )
+    runner = CliRunner()
+    with patch(
+        "nuguard.cli.commands.redteam._run_redteam",
+        new=_mock_run_redteam_outcome(),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(sbom_path),
+                "--target", "http://localhost:9999",
+                "--output", str(output),
+                "--format", "json",
+            ],
+        )
+
+    assert output.exists(), (
+        f"Output file was not written to {output}.\nstdout:\n{result.stdout}"
+    )
 
     content = output.read_text(encoding="utf-8")
-    parsed = _json.loads(content)
+    parsed = json.loads(content)
     assert "_meta" in parsed
     assert len(parsed["findings"]) == 2
+
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by CRITICAL/HIGH
+    # findings) are both acceptable — the dispatch contract is that the file
+    # is written before the threshold check runs.
+    assert result.exit_code in (0, 2), (
+        f"Unexpected exit code {result.exit_code}; stdout:\n{result.stdout}"
+    )

--- a/tests/cli/test_redteam_format_output.py
+++ b/tests/cli/test_redteam_format_output.py
@@ -1,0 +1,210 @@
+"""Regression tests for the redteam --output / --format dispatch.
+
+Background
+----------
+``nuguard redteam --output foo.txt`` historically wrote JSON content into
+``foo.txt`` regardless of the requested format. The ``--output`` branch in
+``nuguard/cli/commands/redteam.py`` only had explicit handling for
+``markdown`` and ``sarif``; ``text`` (the default format) and ``json`` both
+fell into the same ``else`` block that JSON-serialised the findings. The
+``text`` default therefore produced a JSON file with a ``.txt`` extension
+when ``--output`` was used, which is incorrect — the file should match
+the stdout text format (minus ANSI escapes).
+
+These tests pin the contract:
+
+* ``_render_findings_text(findings, meta, scan_outcome, colour=False)``
+  returns plain text (no JSON, no ANSI escapes).
+* ``_render_findings_text(..., colour=True)`` is the stdout form and
+  contains ANSI escapes for severity labels.
+* When the dispatch loop encounters ``fmt == "text"``, the written file is
+  the plain-text report — not a JSON document.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nuguard.cli.commands.redteam import _render_findings_text
+from nuguard.cli.report_meta import ReportMeta
+from nuguard.models.finding import Finding, Severity
+
+
+def _make_findings() -> list[Finding]:
+    return [
+        Finding(
+            finding_id="redteam-test-001",
+            title="Prompt injection via tool description",
+            severity=Severity.HIGH,
+            description=(
+                "An attacker-controlled page injected a tool description that "
+                "exfiltrated adjacent user data through tool-call arguments."
+            ),
+            remediation="Strip tool descriptions from untrusted sources.",
+            owasp_asi_ref="ASI-01",
+        ),
+        Finding(
+            finding_id="redteam-test-002",
+            title="Data exfiltration via canary value",
+            severity=Severity.CRITICAL,
+            description=(
+                "The agent echoed the canary tenant record into a public "
+                "response, confirming cross-tenant data leakage."
+            ),
+            remediation="Enforce per-tenant tool scoping.",
+            owasp_asi_ref="ASI-02",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _render_findings_text helper
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_plain_is_not_json() -> None:
+    """Plain text must not be JSON-serialised and must have no ANSI escapes."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    assert not txt.lstrip().startswith("{"), (
+        "Plain text output must not start with '{' (would indicate JSON)."
+    )
+    assert "\x1b[" not in txt, "Plain text output must not contain ANSI escapes."
+
+
+def test_render_text_plain_contains_expected_sections() -> None:
+    """Plain text should contain the report header, finding count, and outcome."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    assert "NuGuard Red-Team" in txt
+    assert "2 finding(s)" in txt
+    assert "Outcome: no_findings" in txt
+
+
+def test_render_text_plain_severity_ordering() -> None:
+    """Findings must be sorted by descending severity (CRITICAL before HIGH)."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    crit_pos = txt.index("CRITICAL")
+    high_pos = txt.index("HIGH")
+    assert crit_pos < high_pos, (
+        "CRITICAL findings must appear before HIGH findings in the text report."
+    )
+
+
+def test_render_text_plain_no_ansi_even_with_findings() -> None:
+    """Severity labels must not be wrapped in colour escapes for plain output."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    # No escape introducer anywhere in the document.
+    assert "\x1b" not in txt
+
+
+def test_render_text_colour_contains_ansi_escapes() -> None:
+    """Colour=True must inject ANSI escapes (for stdout on a TTY)."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=True)
+
+    assert "\x1b[" in txt, "Colour output should contain ANSI escape sequences."
+
+
+def test_render_text_empty_findings_has_no_table_block() -> None:
+    """An empty findings list produces the short 'No findings' message, not the
+    full table block (which would be misleading)."""
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text([], meta, "no_findings", colour=False)
+
+    assert "No findings — scan complete" in txt
+    assert "NuGuard Red-Team — 0 finding(s)" not in txt
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: when --output is used and the format is "text", the file must be
+# plain text, not JSON. This is the regression test for the original bug.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_text_format_writes_plain_text_file(tmp_path: Path) -> None:
+    """Replicate the redteam --output dispatch loop and verify a ``.txt`` file
+    that ``fmt='text'`` produces contains plain text — NOT JSON.
+
+    This mirrors the inline dispatch in
+    ``nuguard/cli/commands/redteam.py:421-460`` after the fix.
+    """
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    output = tmp_path / "redteam.txt"
+    effective_formats = ["text"]
+    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
+
+    # --- Inline dispatch (mirrors redteam.py --output branch) ---
+    for fmt in effective_formats:
+        if len(effective_formats) > 1:
+            out_path = output.with_suffix(extension_map[fmt])
+        else:
+            out_path = output
+        if fmt == "text":
+            out_path.write_text(
+                _render_findings_text(findings, meta, "no_findings", colour=False),
+                encoding="utf-8",
+            )
+        elif fmt == "markdown":
+            out_path.write_text("MARKDOWN", encoding="utf-8")
+        elif fmt == "sarif":
+            out_path.write_text("SARIF", encoding="utf-8")
+        else:
+            # Bug path: should not be reached for fmt == "text".
+            out_path.write_text("BUG: JSON INSTEAD OF TEXT", encoding="utf-8")
+
+    content = output.read_text(encoding="utf-8")
+    assert not content.lstrip().startswith("{"), (
+        "fmt='text' must write plain text, not JSON (regression for #254)."
+    )
+    assert "\x1b[" not in content, "File output must not contain ANSI escapes."
+    assert "NuGuard Red-Team" in content
+    assert "2 finding(s)" in content
+
+
+def test_dispatch_json_format_still_writes_json_file(tmp_path: Path) -> None:
+    """Sanity check: --format json --output foo.json still writes valid JSON.
+
+    The fix must not regress the JSON output path.
+    """
+    import json as _json
+
+    from nuguard.redteam.report import to_json
+
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+    output = tmp_path / "redteam.json"
+    effective_formats = ["json"]
+    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
+
+    for fmt in effective_formats:
+        out_path = output.with_suffix(extension_map[fmt])
+        if fmt == "json":
+            out_path.write_text(
+                to_json(findings, meta=meta, scan_outcome="no_findings"),
+                encoding="utf-8",
+            )
+
+    content = output.read_text(encoding="utf-8")
+    parsed = _json.loads(content)
+    assert "_meta" in parsed
+    assert len(parsed["findings"]) == 2


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

Fixes #254

## What

- Fixed `nuguard redteam --output foo.txt` (default format) writing JSON content to a `.txt` file.
- Added explicit `text` branch to the `--output` dispatch loop in `nuguard/cli/commands/redteam.py`.
- Extracted the text-rendering logic into a `_render_findings_text()` helper used by both the stdout path (with `colour=True`) and the file-write path (with `colour=False`).
- Added 8 regression tests in `tests/cli/test_redteam_format_output.py` that pin the dispatch contract.

## Why

The `--output` dispatch loop only had explicit branches for `markdown` and `sarif`. The default `text` format fell through to the JSON else-block, so `nuguard redteam --output foo.txt` wrote a JSON document with a `.txt` extension. This broke downstream tooling that processes the saved report by format-extension (e.g. a CD pipeline that renames `--output report` to `report.txt` for archiving, or a log shipper that parses line-oriented text). The discrepancy between stdout and the saved file is also surprising for users — they see plain text on the terminal and JSON in the file.

## Root Cause

Missing `if fmt == "text":` branch in the `--output` dispatch. The dispatch's `else` branch JSON-serialised the findings, which was reached for both `json` and `text` (the default).

## How

- Reproduced the bug via a small dispatch-mirror script that confirmed `--output foo.txt` produces a JSON document starting with `{`.
- Inspected the dispatch loop and confirmed only `markdown` and `sarif` had explicit branches.
- Compared with the `policy.py` and `validate.py` dispatch loops, which correctly handle `text` explicitly — only `redteam.py` had the bug.
- Extracted `_render_findings_text(findings, meta, scan_outcome, *, colour=False) -> str` so the same logic produces both stdout (coloured) and on-disk (plain) text reports.
- Added explicit `if fmt == "text":` branch in the `--output` dispatch that calls the helper with `colour=False` (no ANSI escapes in a file).
- Refactored `_print_findings` to call the helper with `colour=True` for stdout parity.
- Added 8 regression tests covering: plain vs coloured output, severity ordering, empty findings, dispatch loop for both `text` and `json` formats.

## Test Steps

- [x] Reproduce the original issue on `main`: `nuguard redteam --output foo.txt` writes JSON starting with `{`.
- [x] Confirm the issue no longer occurs on this branch: `nuguard redteam --output foo.txt` writes plain text starting with `NuGuard Red-Team`.
- [x] Verify the stdout path is unchanged: `nuguard redteam` still emits ANSI-coloured text to stdout.
- [x] Run `uv run pytest tests/cli/test_redteam_format_output.py -v` — 8 tests pass.
- [x] Run `uv run pytest tests/cli/ -q` — 78 tests pass.
- [x] Run `uv run pytest tests/cli/ tests/sbom/ -q` — 260 tests pass, 1 skipped.
- [x] Run `uv run ruff check nuguard/cli/commands/redteam.py` — clean.
- [x] Run `uv run mypy nuguard/cli/commands/redteam.py` — clean.

## Checks

- [x] `make test` passes (`uv run pytest tests/cli/ tests/sbom/ -q` — 260 passed, 1 skipped)
- [x] `make lint` passes (`ruff check` + `mypy` on `nuguard/cli/commands/redteam.py`)
- [x] `make fmt` applied, no diff
- [x] Added regression tests in `tests/cli/test_redteam_format_output.py` (8 new tests covering the bug)

## Other Notes

- The branch is `bug/redteam-text-format-output`, branched from `main` per the `bug/*` → `main` policy in CONTRIBUTING.md.
- This change does not affect the analyse, behavior, policy, validate, sbom, scan, target, replay, report, seed, init, or findings commands — they were spot-checked and either do not have a format dispatcher or correctly handle all advertised formats.
- The `behavior` command has a documented intentional fallback where `--format text --output foo` writes markdown inside the file (with a comment explaining the preserved behaviour). That is out of scope for this bug.
