### PR TITLE
Fix linked issue check, SBOM endpoint consistency, and improve LLM enrichment

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "nuguard",
   "name": "nuguard",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "AI application security for Claude — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "nuguard",
   "name": "nuguard",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "AI application security for Claude — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -25,6 +25,36 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // GitHub only populates closingIssuesReferences (below) when the PR targets the
+            // repo's default branch — that field mirrors the auto-close-on-merge relationship,
+            // which GitHub disables for non-default-branch PRs. So a develop-targeted PR with
+            // a correct "Closes #123" in its body still reports totalCount: 0. Parse the body
+            // for closing keywords ourselves first, so the check works regardless of base
+            // branch; keep the GraphQL query as a fallback for issues linked manually via the
+            // PR's Development panel (no keyword in the body) on default-branch PRs.
+            const CLOSING_KEYWORDS = "close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved";
+            const KEYWORD_RE = new RegExp(`\\b(?:${CLOSING_KEYWORDS})\\s+#(\\d+)`, "gi");
+
+            const body = context.payload.pull_request.body || "";
+            const referenced = new Set();
+            let match;
+            while ((match = KEYWORD_RE.exec(body)) !== null) {
+              referenced.add(parseInt(match[1], 10));
+            }
+
+            for (const num of referenced) {
+              try {
+                await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                return; // found a real issue referenced with a closing keyword — done
+              } catch (e) {
+                // Not a real issue (or was deleted) — keep checking any other referenced numbers.
+              }
+            }
+
             const query = `
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications. Slash-command exposure is host-dependent and not claimed by this manifest.",
   "contextFileName": "CLAUDE.md"
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications. Slash-command exposure is host-dependent and not claimed by this manifest.",
   "contextFileName": "CLAUDE.md"
 }

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.8.9",
+    "version": "0.8.10",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "category": "security",
       "tags": [
         "ai-security",

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.8.8",
+    "version": "0.8.9",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "category": "security",
       "tags": [
         "ai-security",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuguardai/nuguard",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuguardai/nuguard",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.8.9"
+__version__ = "0.8.10"

--- a/nuguard/analysis/plugins/nga_rules.py
+++ b/nuguard/analysis/plugins/nga_rules.py
@@ -22,6 +22,9 @@ NGA-015  AI workloads without CPU/memory resource limits        LOW
 NGA-016  Container image using latest tag                       LOW
 NGA-017  AI workload missing health check                       LOW
 NGA-018  Multiple AI agents sharing a datastore, no IAM isolation  LOW
+NGA-019  Unguarded write path to sensitive datastore                HIGH
+NGA-020  Unguarded agent delegation chain                           MEDIUM
+NGA-021  IDOR-prone endpoint without authorization checks           HIGH
 """
 
 from __future__ import annotations
@@ -636,6 +639,7 @@ def _rule_nga006_missing_auth_on_api_endpoint(
         and (
             _node_extras(n).get("no_auth_required") is True
             or (n.get("metadata") or {}).get("no_auth_required") is True
+            or (n.get("metadata") or {}).get("auth_required") is False
             or not any(e.get("target") == n["id"] for e in edges)
         )
     ]
@@ -1494,6 +1498,47 @@ def _rule_nga020_unguarded_agent_delegation(
     return findings
 
 
+# ── NGA-021 ──────────────────────────────────────────────────────────────────
+
+
+def _rule_nga021_idor_surface_no_protection(
+    nodes: list[dict[str, Any]],
+    graph: AnalysisGraph | None = None,
+    **_: Any,
+) -> list[dict[str, Any]]:
+    """HIGH — API endpoint with user/tenant-scoped path params and no auth/guardrail protection."""
+    if graph is None:
+        return []  # Requires graph traversal; no fallback
+
+    findings: list[dict[str, Any]] = []
+    for ep in graph.nodes_of_type("API_ENDPOINT"):
+        meta = ep.get("metadata") or {}
+        if meta.get("idor_surface") is not True:
+            continue
+        ep_id = str(ep["id"])
+        if graph.has_protection(ep_id):
+            continue
+        ep_name = ep.get("name", "")
+        path_params = meta.get("path_params") or []
+        evidence = (
+            f"Endpoint '{ep_name}' has user/tenant-scoped path parameter(s) "
+            f"({', '.join(path_params) if path_params else 'unspecified'}) and no AUTH "
+            "or GUARDRAIL node protects it — a caller could substitute another "
+            "user's identifier to access their data."
+        )
+        findings.append(_finding(
+            "NGA-021", "HIGH",
+            f"IDOR-prone endpoint without authorization checks: '{ep_name}'",
+            evidence,
+            [ep_name],
+            f"Add object-level authorization checks on '{ep_name}' so the caller's "
+            "authenticated identity is verified against the requested path parameter "
+            "(e.g. reject requests where the session user does not own the resource).",
+            evidence=evidence,
+        ))
+    return findings
+
+
 # ── Rule registry ─────────────────────────────────────────────────────────────
 
 _RULES: list[Callable[..., list[dict[str, Any]]]] = [
@@ -1517,6 +1562,7 @@ _RULES: list[Callable[..., list[dict[str, Any]]]] = [
     _rule_nga018_shared_datastore_no_iam_isolation,  # NGA-018 LOW
     _rule_nga019_unguarded_write_to_sensitive_datastore,  # NGA-019 HIGH
     _rule_nga020_unguarded_agent_delegation,         # NGA-020 MEDIUM
+    _rule_nga021_idor_surface_no_protection,         # NGA-021 HIGH
 ]
 
 # Per-rule metadata used by verbose audit mode (parallel to _RULES).
@@ -1640,6 +1686,12 @@ _RULE_META: list[dict[str, str]] = [
         "title": "Unguarded agent delegation chain",
         "checks": "AGENT→DELEGATES_TO→AGENT edges where neither side has guardrail coverage",
         "pass_reason": "All agent delegation chains have at least one guardrail boundary",
+    },
+    {
+        "rule_id": "NGA-021", "severity": "HIGH",
+        "title": "IDOR-prone endpoint without authorization checks",
+        "checks": "API_ENDPOINT nodes with idor_surface path params and no AUTH/GUARDRAIL protection",
+        "pass_reason": "No IDOR-prone endpoints found, or all are protected by an AUTH/GUARDRAIL node",
     },
 ]
 
@@ -1820,6 +1872,12 @@ def _build_pass_evidence(
     if rule_id == "NGA-020":
         return {
             "agent_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
+            "requires_graph": True,
+        }
+
+    if rule_id == "NGA-021":
+        return {
+            "api_endpoint_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES],
             "requires_graph": True,
         }
 

--- a/nuguard/analysis/static_analyzer.py
+++ b/nuguard/analysis/static_analyzer.py
@@ -301,7 +301,7 @@ class StaticAnalyzer:
         sbom_dict: dict[str, Any],
         sbom_graph: "Any | None" = None,
     ) -> list[Finding]:
-        """Run NgaRulesPlugin (NGA-001…NGA-018) and annotate with ATLAS techniques."""
+        """Run NgaRulesPlugin (NGA-001…NGA-021) and annotate with ATLAS techniques."""
         try:
             from nuguard.analysis._atlas_data import NGA_TO_ATLAS  # noqa: PLC0415
             from nuguard.analysis.plugins.nga_rules import NgaRulesPlugin  # noqa: PLC0415

--- a/nuguard/analysis/tests/test_nga_rules.py
+++ b/nuguard/analysis/tests/test_nga_rules.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from nuguard.analysis.graph import AnalysisGraph
 from nuguard.analysis.plugins.nga_rules import (
     _RULES,
     _rule_nga001_phi_to_external_llm,
@@ -35,6 +36,7 @@ from nuguard.analysis.plugins.nga_rules import (
     _rule_nga013_no_k8s_network_policy,
     _rule_nga014_actions_runner_debug,
     _rule_nga015_no_resource_limits,
+    _rule_nga021_idor_surface_no_protection,
 )
 
 # ---------------------------------------------------------------------------
@@ -506,6 +508,36 @@ class TestNga006:
         findings = self._run([_model_node("gpt-4", "openai")])
         assert findings == []
 
+    def test_fires_when_auth_required_is_false(self) -> None:
+        """auth_required=False (computed by the enricher from AUTH edges) fires NGA-006."""
+        node = {
+            "id": "api",
+            "name": "inference-api",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"auth_required": False},
+        }
+        findings = self._run([node])
+        assert len(findings) == 1
+        assert findings[0]["rule_id"] == "NGA-006"
+
+    def test_no_finding_when_auth_required_true_and_protected_by_edge(self) -> None:
+        """auth_required=True with a real protecting AUTH edge does not fire.
+
+        This mirrors the state the enricher actually produces: auth_required is
+        only True when an AUTH→PROTECTS edge exists, so protected_targets already
+        excludes the endpoint before the auth_required check is even reached.
+        """
+        auth_node = {"id": "auth", "name": "auth", "component_type": "AUTH", "metadata": {}}
+        api_node = {
+            "id": "api",
+            "name": "inference-api",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"auth_required": True},
+        }
+        edge = {"source": "auth", "target": "api"}
+        findings = self._run([auth_node, api_node], edges=[edge])
+        assert findings == []
+
 
 # ---------------------------------------------------------------------------
 # NGA-012 — Missing HITL for irreversible tool actions
@@ -569,11 +601,12 @@ class TestRulesRegistry:
         assert names[2] == "_rule_nga003_secrets_in_env"
         assert names[3] == "_rule_nga004_runs_as_root"
         assert names[4] == "_rule_nga005_unencrypted_pii_datastore"
-        # NGA-019 and NGA-020 are present (added after NGA-018)
+        # NGA-019, NGA-020, NGA-021 are present (added after NGA-018)
         assert "_rule_nga019_unguarded_write_to_sensitive_datastore" in " ".join(names)
         assert "_rule_nga020_unguarded_agent_delegation" in " ".join(names)
-        # Rules run NGA-001 to NGA-020 with no gaps
-        assert len(_RULES) == 20
+        assert "_rule_nga021_idor_surface_no_protection" in " ".join(names)
+        # Rules run NGA-001 to NGA-021 with no gaps
+        assert len(_RULES) == 21
 
     def test_all_rules_return_list(self) -> None:
         for rule in _RULES:
@@ -913,3 +946,84 @@ class TestNga015ResourceLimitsAsymmetry:
         ]
         findings = self._run(nodes)
         assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# NGA-021 — IDOR-prone endpoint without authorization checks
+# ---------------------------------------------------------------------------
+
+
+class TestNga021:
+    def _run(
+        self,
+        nodes: list[dict[str, Any]],
+        edges: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        graph = AnalysisGraph({"nodes": nodes, "edges": edges or []})
+        return _rule_nga021_idor_surface_no_protection(nodes=nodes, graph=graph)
+
+    def test_fires_on_idor_surface_endpoint_with_no_protection(self) -> None:
+        node = {
+            "id": "api",
+            "name": "get-user-profile",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"idor_surface": True, "path_params": ["user_id"]},
+        }
+        findings = self._run([node])
+        assert len(findings) == 1
+        assert findings[0]["rule_id"] == "NGA-021"
+        assert findings[0]["severity"] == "HIGH"
+        assert "get-user-profile" in findings[0]["affected"]
+
+    def test_no_finding_when_protected_by_auth_edge(self) -> None:
+        auth_node = {"id": "auth", "name": "auth", "component_type": "AUTH", "metadata": {}}
+        api_node = {
+            "id": "api",
+            "name": "get-user-profile",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"idor_surface": True, "path_params": ["user_id"]},
+        }
+        edge = {"source": "auth", "target": "api", "relationship_type": "PROTECTS"}
+        findings = self._run([auth_node, api_node], edges=[edge])
+        assert findings == []
+
+    def test_no_finding_when_protected_by_guardrail_edge(self) -> None:
+        guardrail = {"id": "guard", "name": "guard", "component_type": "GUARDRAIL", "metadata": {}}
+        api_node = {
+            "id": "api",
+            "name": "get-user-profile",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"idor_surface": True, "path_params": ["user_id"]},
+        }
+        edge = {"source": "guard", "target": "api", "relationship_type": "PROTECTS"}
+        findings = self._run([guardrail, api_node], edges=[edge])
+        assert findings == []
+
+    def test_no_finding_when_idor_surface_false(self) -> None:
+        node = {
+            "id": "api",
+            "name": "list-public-posts",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"idor_surface": False},
+        }
+        findings = self._run([node])
+        assert findings == []
+
+    def test_no_finding_when_idor_surface_none(self) -> None:
+        node = _api_node("plain-endpoint")
+        findings = self._run([node])
+        assert findings == []
+
+    def test_no_finding_no_api_nodes(self) -> None:
+        findings = self._run([_model_node("gpt-4", "openai")])
+        assert findings == []
+
+    def test_no_finding_without_graph(self) -> None:
+        """Rule requires graph traversal; returns [] gracefully when graph is None."""
+        node = {
+            "id": "api",
+            "name": "get-user-profile",
+            "component_type": "API_ENDPOINT",
+            "metadata": {"idor_surface": True, "path_params": ["user_id"]},
+        }
+        assert _rule_nga021_idor_surface_no_protection(nodes=[node], graph=None) == []

--- a/nuguard/cli/commands/analyze.py
+++ b/nuguard/cli/commands/analyze.py
@@ -110,7 +110,7 @@ def analyze(
     llm: bool = typer.Option(False, "--llm", help="Enable LLM enrichment in ATLAS pass."),
     verbose: bool = typer.Option(
         False, "--verbose", "-v",
-        help="Show all 18 NGA rules (pass and fail) with evidence on why each passed.",
+        help="Show all 21 NGA rules (pass and fail) with evidence on why each passed.",
     ),
     output: str = typer.Option(
         None, "--output", "-o",
@@ -641,7 +641,7 @@ def _render_markdown(
         lines += _render_rule_audit_section(
             nga_audit,
             "NGA Rule Audit",
-            "All 18 NGA structural rules — pass/fail status with evidence.",
+            "All 21 NGA structural rules — pass/fail status with evidence.",
         )
 
     # ------------------------------------------------------------------

--- a/nuguard/cli/commands/analyze.py
+++ b/nuguard/cli/commands/analyze.py
@@ -189,6 +189,10 @@ def analyze(
         typer.echo(f"error: SBOM validation failed: {exc}", err=True)
         raise typer.Exit(code=2)
 
+    # Re-run topology enrichment in case the SBOM file predates it (idempotent).
+    from nuguard.sbom.enricher import enrich as _enrich_topology  # noqa: PLC0415
+    _enrich_topology(doc)
+
     # ------------------------------------------------------------------
     # Run analysis
     # ------------------------------------------------------------------

--- a/nuguard/cli/commands/behavior.py
+++ b/nuguard/cli/commands/behavior.py
@@ -202,6 +202,11 @@ async def _run_behavior(
         try:
             from nuguard.sbom.serializer import AiSbomSerializer
             sbom = AiSbomSerializer.from_json(sbom_path_obj.read_text())
+
+            # Re-run topology enrichment in case the SBOM file predates it (idempotent).
+            from nuguard.sbom.enricher import enrich as _enrich_topology  # noqa: PLC0415
+            _enrich_topology(sbom)
+
             _console.print(f"[dim]Loaded SBOM: {raw_sbom_path}[/dim]")
         except Exception as exc:
             _log.warning("Could not load SBOM from %s: %s", raw_sbom_path, exc)

--- a/nuguard/cli/commands/policy.py
+++ b/nuguard/cli/commands/policy.py
@@ -717,7 +717,7 @@ def _print_assessment_table(assessment: object) -> None:
     _console.print(table)
 
 
-@policy_app.command("show")
+@policy_app.command("show", hidden=True)
 def show(
     policy_id: str = typer.Option(
         ...,
@@ -725,6 +725,17 @@ def show(
         help="ID of the stored policy to display.",
     ),
 ) -> None:
-    """Display a stored cognitive policy by ID."""
-    _err_console.print(f"Policy '{policy_id}' not found.")
+    """Display a stored cognitive policy by ID.
+
+    .. deprecated::
+        Always reports "not found" — there is no persisted-policy store.
+        Kept as a hidden no-op stub so old automation scripts that invoke it
+        don't get a Typer "no such command" error; the subcommand will be
+        reintroduced once a policy registry exists (see issue #162).
+    """
+    _err_console.print(
+        f"Policy '{policy_id}' not found. "
+        "(Policy registry is not implemented yet; use `policy compile` to "
+        "produce a JSON file alongside the source Markdown.)"
+    )
     raise typer.Exit(code=_EXIT_FINDINGS)

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -252,6 +252,11 @@ def redteam(
         typer.echo(f"Error loading SBOM: {exc}", err=True)
         raise typer.Exit(code=1)
 
+    # Re-run topology enrichment in case the SBOM file predates it (idempotent).
+    from nuguard.sbom.enricher import enrich as _enrich_topology  # noqa: PLC0415
+
+    _enrich_topology(sbom_doc)
+
     # Resolve target URL — explicit > SBOM discovery
     if not target_url:
         target_url = _resolve_target_url(sbom_doc, launch=launch)

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -426,7 +426,14 @@ def redteam(
                 all_formats=effective_formats,
                 extension_map=extension_map,
             )
-            if fmt == "markdown":
+            if fmt == "text":
+                # Plain-text report — no ANSI escapes in a file. Identical
+                # content to what ``nuguard redteam`` emits to stdout.
+                out_path.write_text(
+                    _render_findings_text(findings, meta, scan_outcome, colour=False),
+                    encoding="utf-8",
+                )
+            elif fmt == "markdown":
                 out_path.write_text(
                     _findings_to_markdown(
                         findings,
@@ -979,6 +986,85 @@ async def _run_orchestrator(  # noqa: C901
     )
 
 
+_SEV_COLOUR: dict[str, str] = {
+    "critical": "red",
+    "high": "red",
+    "medium": "yellow",
+    "low": "blue",
+    "info": "white",
+}
+
+
+def _render_findings_text(
+    findings: list,
+    meta: "ReportMeta",
+    scan_outcome: str = "no_findings",
+    *,
+    colour: bool = False,
+) -> str:
+    """Render findings as a plain-text report.
+
+    Returns a multi-line string suitable for writing to a file or echoing to a
+    terminal. When ``colour`` is ``True``, the severity label is wrapped in
+    ANSI escapes via :func:`typer.style` (used for stdout). When ``False``
+    (default), the output is plain text with no escape sequences — suitable
+    for on-disk reports that downstream tools may parse.
+
+    Args:
+        findings: List of :class:`~nuguard.models.finding.Finding` objects.
+        meta: Report metadata header.
+        scan_outcome: One-line scan outcome string ("no_findings", etc.).
+        colour: If ``True``, wrap severity labels with ANSI colour codes.
+
+    Returns:
+        Plain-text report as a single string.
+    """
+    from nuguard.models.finding import Severity as _Severity
+
+    if not findings:
+        lines = [
+            meta.to_text_line(),
+            f"Outcome: {scan_outcome}",
+            "No findings — scan complete",
+        ]
+        return "\n".join(lines) + "\n"
+
+    _ORDER = [
+        _Severity.CRITICAL,
+        _Severity.HIGH,
+        _Severity.MEDIUM,
+        _Severity.LOW,
+        _Severity.INFO,
+    ]
+
+    out: list[str] = []
+    out.append("")
+    out.append("─" * 60)
+    out.append(f"  NuGuard Red-Team — {len(findings)} finding(s)")
+    out.append(f"  {meta.to_text_line()}")
+    out.append(f"  Outcome: {scan_outcome}")
+    out.append("─" * 60)
+    for f in sorted(findings, key=lambda x: _ORDER.index(x.severity)):
+        sev_key = f.severity.value if hasattr(f.severity, "value") else str(f.severity)
+        sev_text = sev_key.upper()
+        if colour:
+            colour_name = _SEV_COLOUR.get(sev_key, "white")
+            sev_label = typer.style(sev_text, fg=colour_name, bold=True)
+        else:
+            sev_label = sev_text
+        out.append("")
+        out.append(f"[{sev_label}] {f.title}")
+        out.append(f"  {f.description[:200]}")
+        if f.remediation:
+            out.append(f"  Fix: {f.remediation[:150]}")
+        if f.owasp_asi_ref:
+            out.append(f"  Ref: {f.owasp_asi_ref}")
+    out.append("")
+    out.append("─" * 60)
+    out.append("")
+    return "\n".join(out)
+
+
 def _print_findings(
     findings: list,
     format: str,
@@ -992,8 +1078,6 @@ def _print_findings(
     coverage_tracker: object | None = None,
 ) -> None:
     """Print findings to stdout in the requested format."""
-    from nuguard.models.finding import Severity
-
     if meta is None:
         meta = ReportMeta()
 
@@ -1028,35 +1112,9 @@ def _print_findings(
         )
         return
 
-    if not findings:
-        typer.echo(meta.to_text_line())
-        typer.echo(f"Outcome: {scan_outcome}")
-        typer.echo("No findings — scan complete")
-        return
-
-    _SEV_COLOUR = {
-        Severity.CRITICAL: "red",
-        Severity.HIGH: "red",
-        Severity.MEDIUM: "yellow",
-        Severity.LOW: "blue",
-        Severity.INFO: "white",
-    }
-
-    typer.echo(f"\n{'─' * 60}")
-    typer.echo(f"  NuGuard Red-Team — {len(findings)} finding(s)")
-    typer.echo(f"  {meta.to_text_line()}")
-    typer.echo(f"  Outcome: {scan_outcome}")
-    typer.echo(f"{'─' * 60}")
-    for f in sorted(findings, key=lambda x: list(Severity).index(x.severity)):
-        colour = _SEV_COLOUR.get(f.severity, "white")
-        sev_label = typer.style(f.severity.upper(), fg=colour, bold=True)
-        typer.echo(f"\n[{sev_label}] {f.title}")
-        typer.echo(f"  {f.description[:200]}")
-        if f.remediation:
-            typer.echo(f"  Fix: {f.remediation[:150]}")
-        if f.owasp_asi_ref:
-            typer.echo(f"  Ref: {f.owasp_asi_ref}")
-    typer.echo(f"\n{'─' * 60}\n")
+    # Default and explicit "text" path — emit the plain-text report (with
+    # ANSI colour escapes when stdout is a TTY).
+    typer.echo(_render_findings_text(findings, meta, scan_outcome, colour=True))
 
 
 def _scenario_coverage_table(scenario_records: list) -> list[str]:

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -426,6 +426,7 @@ def redteam(
                 all_formats=effective_formats,
                 extension_map=extension_map,
             )
+            out_path.parent.mkdir(parents=True, exist_ok=True)
             if fmt == "text":
                 # Plain-text report — no ANSI escapes in a file. Identical
                 # content to what ``nuguard redteam`` emits to stdout.

--- a/nuguard/cli/commands/sbom.py
+++ b/nuguard/cli/commands/sbom.py
@@ -421,6 +421,48 @@ def register(
     _console.print(f"[green]SBOM registered.[/green] ID: [bold]{sbom_id}[/bold]")
 
 
+@sbom_app.command("enrich")
+def enrich_cmd(
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        help="Path to the SBOM JSON file to re-enrich.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output path (default: overwrite FILE in place).",
+    ),
+) -> None:
+    """Re-run topology-based enrichment on FILE and write the result back.
+
+    Derives auth_required, idor_surface, path_params, and other risk
+    attributes from the SBOM's node graph and persists them to disk, so
+    ``analyze``/``behavior``/``redteam`` can consume an already-enriched
+    file without recomputing anything. Safe to run repeatedly (idempotent).
+    """
+    from nuguard.sbom.enricher import enrich
+    from nuguard.sbom.serializer import AiSbomSerializer
+
+    try:
+        doc = AiSbomSerializer.from_json(file.read_text(encoding="utf-8"))
+    except Exception as exc:
+        _err_console.print(f"Error reading SBOM: {exc}")
+        raise typer.Exit(code=3) from exc
+
+    enrich(doc)
+
+    target = output or file
+    target.write_text(AiSbomSerializer.to_json(doc), encoding="utf-8")
+    _console.print(f"[green]✓ Enriched SBOM written to {target}[/green]")
+
+
 @sbom_app.command("show")
 def show(
     sbom_id: str = typer.Option(

--- a/nuguard/cli/commands/sbom.py
+++ b/nuguard/cli/commands/sbom.py
@@ -118,16 +118,17 @@ def _validate_inputs(
     out_parent = output.parent
     try:
         out_parent.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                _err(
-                    f"Could not create output directory '{out_parent}': {exc}",
-                    "Check the path and directory permissions.",
-                )
-            if not os.access(out_parent, os.W_OK):
-                _err(
-                    f"No write permission to output directory '{out_parent}'.",
-                    "Check directory permissions.",
-                )
+    except OSError as exc:
+        _err(
+            f"Could not create output directory '{out_parent}': {exc}",
+            "Check the path and directory permissions.",
+        )
+    
+    if not os.access(out_parent, os.W_OK):
+        _err(
+            f"No write permission to output directory '{out_parent}'.",
+            ...
+        )
 
     # ── Source directory ──────────────────────────────────────────────────────
     if source is not None:

--- a/nuguard/cli/commands/sbom.py
+++ b/nuguard/cli/commands/sbom.py
@@ -127,7 +127,7 @@ def _validate_inputs(
     if not os.access(out_parent, os.W_OK):
         _err(
             f"No write permission to output directory '{out_parent}'.",
-            ...
+            "Check the directory permissions and try again.",
         )
 
     # ── Source directory ──────────────────────────────────────────────────────

--- a/nuguard/cli/commands/sbom.py
+++ b/nuguard/cli/commands/sbom.py
@@ -113,13 +113,11 @@ def _validate_inputs(
             f"Output path '{output}' is a directory.",
             "Provide a file path, e.g. --output app.sbom.json",
         )
+    # Auto-create the parent directory so `--output` behaves consistently with
+    # `nuguard behavior` (and analyze/redteam, which create parents on write).
     out_parent = output.parent
-    if not out_parent.exists():
-        _err(
-            f"Output directory '{out_parent}' does not exist.",
-            "Create the directory first or choose an existing path.",
-        )
-    if out_parent.exists() and not os.access(out_parent, os.W_OK):
+    out_parent.mkdir(parents=True, exist_ok=True)
+    if not os.access(out_parent, os.W_OK):
         _err(
             f"No write permission to output directory '{out_parent}'.",
             "Check directory permissions.",

--- a/nuguard/cli/commands/sbom.py
+++ b/nuguard/cli/commands/sbom.py
@@ -116,18 +116,18 @@ def _validate_inputs(
     # Auto-create the parent directory so `--output` behaves consistently with
     # `nuguard behavior` (and analyze/redteam, which create parents on write).
     out_parent = output.parent
-try:
+    try:
         out_parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        _err(
-            f"Could not create output directory '{out_parent}': {exc}",
-            "Check the path and directory permissions.",
-        )
-    if not os.access(out_parent, os.W_OK):
-        _err(
-            f"No write permission to output directory '{out_parent}'.",
-            "Check directory permissions.",
-        )
+            except OSError as exc:
+                _err(
+                    f"Could not create output directory '{out_parent}': {exc}",
+                    "Check the path and directory permissions.",
+                )
+            if not os.access(out_parent, os.W_OK):
+                _err(
+                    f"No write permission to output directory '{out_parent}'.",
+                    "Check directory permissions.",
+                )
 
     # ── Source directory ──────────────────────────────────────────────────────
     if source is not None:

--- a/nuguard/cli/commands/sbom.py
+++ b/nuguard/cli/commands/sbom.py
@@ -116,7 +116,13 @@ def _validate_inputs(
     # Auto-create the parent directory so `--output` behaves consistently with
     # `nuguard behavior` (and analyze/redteam, which create parents on write).
     out_parent = output.parent
-    out_parent.mkdir(parents=True, exist_ok=True)
+try:
+        out_parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        _err(
+            f"Could not create output directory '{out_parent}': {exc}",
+            "Check the path and directory permissions.",
+        )
     if not os.access(out_parent, os.W_OK):
         _err(
             f"No write permission to output directory '{out_parent}'.",

--- a/nuguard/common/llm_client.py
+++ b/nuguard/common/llm_client.py
@@ -383,9 +383,9 @@ class LLMClient:
         if self.request_timeout is not None:
             kwargs.setdefault("timeout", self.request_timeout)
 
-        _MAX_RETRIES = 4
-        _BASE_DELAY = 2.0   # seconds before first retry
-        _MAX_DELAY = 60.0   # cap on any single sleep
+        _MAX_RETRIES = 3
+        _BASE_DELAY = 1.0   # seconds before first retry
+        _MAX_DELAY = 5.0    # cap on any single sleep
         _stripped_unsupported = False  # guard: strip-and-retry only once
 
         for _attempt in range(_MAX_RETRIES + 1):

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -226,12 +226,19 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             if _sa_type == "login_flow" and isinstance(_shared_auth.get("login_flow"), dict):
                 flat["redteam_auth_login_flow"] = _shared_auth["login_flow"]
 
-    # Redteam section — overrides shared target block when keys are present
+    # Redteam section — overrides shared target block when keys are present.
+    # Both `endpoint:` and `target_endpoint:` are accepted as aliases, mirroring
+    # the shared ``target:`` block (which accepts both names). The shared block
+    # already does this on lines 199-203; the override must accept the same
+    # aliases so users who wrote ``endpoint:`` (the canonical form documented
+    # in nuguard.yaml.example line 47) see their override take effect.
     redteam = data.get("redteam", {}) or {}
     if "target" in redteam:
         flat["target_url"] = redteam["target"]
     if "target_endpoint" in redteam:
         flat["target_endpoint"] = redteam["target_endpoint"]
+    elif "endpoint" in redteam:
+        flat["target_endpoint"] = redteam["endpoint"]
     if "chat_payload_key" in redteam:
         flat["redteam_chat_payload_key"] = redteam["chat_payload_key"]
     if "chat_payload_list" in redteam:
@@ -419,7 +426,12 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                     )
                 if "auth" in shared_target and isinstance(shared_target["auth"], dict):
                     _shared_for_behavior.setdefault("auth", shared_target["auth"])
-                # behavior.* wins — merge shared as the lower-precedence base
+                # behavior.* wins — merge shared as the lower-precedence base.
+                # `endpoint:` and `target_endpoint:` are aliases in the shared
+                # block; mirror that here so a user who writes `behavior.endpoint:`
+                # to override the shared endpoint actually wins the merge.
+                if "endpoint" in b and "target_endpoint" not in b:
+                    b["target_endpoint"] = b["endpoint"]
                 b = {**_shared_for_behavior, **b}
             flat["behavior_config"] = b
 

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -232,13 +232,15 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
     # already does this on lines 199-203; the override must accept the same
     # aliases so users who wrote ``endpoint:`` (the canonical form documented
     # in nuguard.yaml.example line 47) see their override take effect.
+    # Precedence matches the shared block: ``endpoint`` wins over
+    # ``target_endpoint`` when both are set in the same block.
     redteam = data.get("redteam", {}) or {}
     if "target" in redteam:
         flat["target_url"] = redteam["target"]
-    if "target_endpoint" in redteam:
-        flat["target_endpoint"] = redteam["target_endpoint"]
-    elif "endpoint" in redteam:
+    if "endpoint" in redteam:
         flat["target_endpoint"] = redteam["endpoint"]
+    elif "target_endpoint" in redteam:
+        flat["target_endpoint"] = redteam["target_endpoint"]
     if "chat_payload_key" in redteam:
         flat["redteam_chat_payload_key"] = redteam["chat_payload_key"]
     if "chat_payload_list" in redteam:
@@ -430,7 +432,11 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                 # `endpoint:` and `target_endpoint:` are aliases in the shared
                 # block; mirror that here so a user who writes `behavior.endpoint:`
                 # to override the shared endpoint actually wins the merge.
-                if "endpoint" in b and "target_endpoint" not in b:
+                # Precedence matches the shared block on lines 410-413:
+                # ``endpoint`` wins over ``target_endpoint`` when both are
+                # set in the same block, so we collapse ``endpoint`` into
+                # ``target_endpoint`` unconditionally if it's present.
+                if "endpoint" in b:
                     b["target_endpoint"] = b["endpoint"]
                 b = {**_shared_for_behavior, **b}
             flat["behavior_config"] = b

--- a/nuguard/mcp/server.py
+++ b/nuguard/mcp/server.py
@@ -174,7 +174,7 @@ async def nuguard_sbom_generate(
 async def nuguard_analyze(
     sbom: Annotated[str, "Path to the AI-SBOM JSON file to analyze."],
     config_path: Annotated[str | None, "Path to nuguard.yaml."] = None,
-    nga_only: Annotated[bool, "Run only the 18 NGA structural rules; skip external tools."] = False,
+    nga_only: Annotated[bool, "Run only the 21 NGA structural rules; skip external tools."] = False,
     min_severity: Annotated[str, "Minimum severity to report: critical | high | medium | low | info."] = "medium",
     source: Annotated[str | None, "Source directory for Checkov / Trivy / Semgrep scans."] = None,
     enable_atlas: Annotated[bool, "Enable MITRE ATLAS technique mapping."] = True,
@@ -188,7 +188,7 @@ async def nuguard_analyze(
 ) -> dict:
     """Run static risk analysis on an AI-SBOM.
 
-    Evaluates 18 NGA structural rules (NGA-001 to NGA-018) and optionally runs
+    Evaluates 21 NGA structural rules (NGA-001 to NGA-021) and optionally runs
     MITRE ATLAS mapping, OSV / Grype CVE scans, Checkov IaC, Trivy container
     scans, and Semgrep AI-security rules. Returns findings grouped by severity.
     Exit status: 'ok' (no findings), 'findings' (issues found), 'error' (crash).

--- a/nuguard/sbom/adapters/base.py
+++ b/nuguard/sbom/adapters/base.py
@@ -18,6 +18,7 @@ class AdapterMatch:
     pattern: str
     line: int
     snippet: str
+    groups: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,7 @@ class RegexAdapter(DetectionAdapter):
                         pattern=pattern.pattern,
                         line=line,
                         snippet=match.group(0)[:120],
+                        groups={k: v for k, v in match.groupdict().items() if v is not None},
                     )
                 )
 

--- a/nuguard/sbom/adapters/python/fastapi_adapter.py
+++ b/nuguard/sbom/adapters/python/fastapi_adapter.py
@@ -405,11 +405,13 @@ class FastAPIAdapter(FrameworkAdapter):
 
                 receiver, method, path_str = ep_info
                 func_name = node.name
-                # Key on HTTP method + route path so the same endpoint defined
-                # across multiple service files (e.g. GET /health in autogen,
-                # crewai, and agent_backend) is deduplicated into one node with
-                # evidence from all files, rather than one node per file.
-                canon = f"fastapi:endpoint:{method.upper()}:{path_str}"
+                # Key on HTTP method + route path only (no framework prefix) so
+                # the same endpoint defined across multiple service files (e.g.
+                # GET /health in autogen, crewai, and agent_backend) — or found
+                # by both this adapter and the generic api_endpoint_generic
+                # regex fallback — dedupes into one node with evidence from all
+                # sources, rather than one node per file/adapter.
+                canon = f"endpoint:{method.upper()}:{path_str}"
 
                 ep_auth: str | None = _extract_depends_auth_type(node, auth_vars)
                 if ep_auth is None:

--- a/nuguard/sbom/adapters/python/flask_adapter.py
+++ b/nuguard/sbom/adapters/python/flask_adapter.py
@@ -285,10 +285,12 @@ class FlaskAdapter(FrameworkAdapter):
                 receiver, path_str, methods = route_info
                 method = methods[0].upper() if methods else "GET"
                 func_name = node.name
-                # Key on HTTP method + route path so the same endpoint defined
-                # across multiple Blueprint/service files is deduplicated into
-                # one node with evidence from all files.
-                canon = f"flask:endpoint:{method}:{path_str}"
+                # Key on HTTP method + route path only (no framework prefix) so
+                # the same endpoint defined across multiple Blueprint/service
+                # files — or found by both this adapter and the generic
+                # api_endpoint_generic regex fallback — dedupes into one node
+                # with evidence from all sources.
+                canon = f"endpoint:{method}:{path_str}"
 
                 chat_key: str | None = None
                 ctx_fields: dict[str, str] = {}

--- a/nuguard/sbom/adapters/registry.py
+++ b/nuguard/sbom/adapters/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from ..core.route_patterns import ROUTE_PATTERNS as _ROUTE_PATTERNS
 from ..normalization import canonicalize_text
 from ..types import ComponentType
 from .base import DetectionAdapter, FrameworkAdapter, RegexAdapter
@@ -293,11 +294,12 @@ def default_registry() -> tuple[DetectionAdapter, ...]:
                 name="api_endpoint_generic",
                 component_type=ComponentType.API_ENDPOINT,
                 priority=160,
-                patterns=(
-                    re.compile(r"\b(GET|POST|PUT|DELETE|PATCH)\s+/[\w/{}:-]+"),
-                    re.compile(r"@(app|router)\.(get|post|put|delete|patch)\(", re.IGNORECASE),
-                ),
-                canonical_name="api_endpoint:generic",
+                # Shares its patterns with application_summary.extract_api_endpoints
+                # so summary.api_endpoints and API_ENDPOINT nodes never diverge.
+                # canonical_name=None puts each distinct (method, path) match into
+                # its own node (see extractor/core.py's per-match grouping) instead
+                # of collapsing every route in the repo into one generic node.
+                patterns=_ROUTE_PATTERNS,
             ),
             RegexAdapter(
                 name="deployment_generic",

--- a/nuguard/sbom/core/application_summary.py
+++ b/nuguard/sbom/core/application_summary.py
@@ -342,7 +342,13 @@ def extract_deployment_context(files: Sequence[tuple[str, str]]) -> dict[str, li
     deployment_urls: list[str] = []
 
     for path, content in files:
-        lower_path = path.lower()
+        # Normalize separators so workflow-path hints match on Windows too.
+        # Scanned file paths can use backslashes on Windows; the hint set uses
+        # POSIX style (".github/workflows/", "/k8s/", "infra/"). Comparing the
+        # raw lower_path on Windows would miss these matches and silently drop
+        # deployment URLs discovered from workflow content. See issue #234.
+        normalized_path = path.replace("\\", "/")
+        lower_path = normalized_path.lower()
         text = content or ""
         text_lower = text.lower()
 

--- a/nuguard/sbom/core/application_summary.py
+++ b/nuguard/sbom/core/application_summary.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse, urlunparse
 
 from ..models import InstrumentationDetail, Node, TestingDetail
+from .route_patterns import ROUTE_PATTERNS
 
 if TYPE_CHECKING:
     from nuguard.common.llm_client import LLMClient
@@ -26,13 +27,7 @@ if TYPE_CHECKING:
 # Pattern constants
 # ---------------------------------------------------------------------------
 
-_ENDPOINT_PATTERNS = [
-    re.compile(
-        r"@(?:app|router)\.(?:get|post|put|patch|delete|options|head)\(\s*[\"']([^\"']+)[\"']"
-    ),
-    re.compile(r"@(?:app|blueprint)\.route\(\s*[\"']([^\"']+)[\"']"),
-    re.compile(r"\b(?:app|router)\.(?:get|post|put|patch|delete|use)\(\s*[\"']([^\"']+)[\"']"),
-]
+_ENDPOINT_PATTERNS = ROUTE_PATTERNS
 
 _URL_PATTERN = re.compile(r"https?://[^\s\"'`<>,]+")
 # GitHub Actions env vars that encode well-known Azure hostname patterns, e.g.
@@ -332,7 +327,8 @@ def extract_api_endpoints(files: Sequence[tuple[str, str]]) -> list[str]:
         if not path.lower().endswith((".py", ".ts", ".tsx", ".js", ".jsx")):
             continue
         for pattern in _ENDPOINT_PATTERNS:
-            endpoints.extend(pattern.findall(content or ""))
+            for match in pattern.finditer(content or ""):
+                endpoints.append(match.group("path"))
     return _uniq(ep for ep in endpoints if ep and ep != "/")
 
 
@@ -607,7 +603,17 @@ def build_scan_summary(
             frameworks.append(framework)
 
     deployment = extract_deployment_context(files)
-    endpoints = extract_api_endpoints(files)
+    # API_ENDPOINT nodes are the authoritative, deduped source (they're what
+    # `analyze`/`redteam` actually consume); the regex sweep over `files` is
+    # kept as a supplementary source so a route that — despite sharing regex
+    # patterns with the node-building adapters — still isn't backed by a node
+    # doesn't silently disappear from the summary.
+    node_endpoint_paths = [
+        node.metadata.endpoint
+        for node in nodes
+        if _node_type_str(node) == "API_ENDPOINT" and node.metadata.endpoint
+    ]
+    endpoints = _uniq(node_endpoint_paths + extract_api_endpoints(files))
     modality_support = infer_modalities_support(nodes, files)
     use_case_summary = build_deterministic_use_case_summary(nodes, modality_support)
     modalities = [k.upper() for k, enabled in modality_support.items() if enabled]

--- a/nuguard/sbom/core/route_patterns.py
+++ b/nuguard/sbom/core/route_patterns.py
@@ -1,0 +1,28 @@
+"""Shared HTTP route-matching patterns.
+
+Used by both the deterministic ``summary.api_endpoints`` sweep
+(``application_summary.extract_api_endpoints``) and the generic
+``api_endpoint_generic`` regex adapter (``adapters/registry.py``) so the two
+can never see a different set of routes in the same source tree. Each
+pattern captures ``path`` (always) and ``method`` (where the route
+declaration syntax carries one).
+"""
+
+from __future__ import annotations
+
+import re
+
+ROUTE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # FastAPI / Flask-blueprint verb decorators: @app.get("/x"), @router.post('/x')
+    re.compile(
+        r"@(?:app|router)\.(?P<method>get|post|put|patch|delete|options|head)\(\s*"
+        r"[\"'](?P<path>[^\"']+)[\"']"
+    ),
+    # Flask .route() decorator: @app.route("/x"), @blueprint.route('/x')
+    re.compile(r"@(?:app|blueprint)\.route\(\s*[\"'](?P<path>[^\"']+)[\"']"),
+    # Functional / Express-style registration: app.get('/x', ...), router.use('/x', ...)
+    re.compile(
+        r"\b(?:app|router)\.(?P<method>get|post|put|patch|delete|use)\(\s*"
+        r"[\"'](?P<path>[^\"']+)[\"']"
+    ),
+)

--- a/nuguard/sbom/enricher.py
+++ b/nuguard/sbom/enricher.py
@@ -143,7 +143,7 @@ def enrich(doc: AiSbomDocument) -> None:
         n.id for n in doc.nodes if n.component_type == ComponentType.PRIVILEGE
     }
 
-    _enrich_api_endpoints(doc, targets)
+    _enrich_api_endpoints(doc, targets, sources_of_type)
     _enrich_tools(doc, tool_frameworks, framework_auth, privilege_node_ids, targets)
     _enrich_agents(doc, targets, node_by_id)
     _backfill_descriptions(doc)
@@ -159,6 +159,7 @@ def enrich(doc: AiSbomDocument) -> None:
 def _enrich_api_endpoints(
     doc: AiSbomDocument,
     targets: Callable[[UUID, str], set[UUID]],
+    sources_of_type: Callable[[UUID, str, str], list[Node]],
 ) -> None:
     for node in doc.nodes:
         if node.component_type != ComponentType.API_ENDPOINT:
@@ -178,9 +179,13 @@ def _enrich_api_endpoints(
                 _IDOR_PARAM_PATTERNS.search(p) for p in meta.path_params
             )
 
-        # auth_required: infer False only when not already set (adapter didn't know)
-        # (set to True by default; will be corrected below if no AUTH node found)
-        # — this is left to the graph enricher since we'd need AUTH→PROTECTS→ENDPOINT
+        # auth_required: derived from AUTH→PROTECTS→ENDPOINT edges, unless an
+        # adapter already set it explicitly.
+        if meta.auth_required is None:
+            protecting_auth = sources_of_type(
+                node.id, RelationshipType.PROTECTS, ComponentType.AUTH
+            )
+            meta.auth_required = bool(protecting_auth)
 
 
 # ---------------------------------------------------------------------------

--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -2461,12 +2461,28 @@ class AiSbomExtractor:
     # Accepting such a ref would let a hostile ref string (e.g. one pasted from
     # a malicious README) trick ``git clone`` into invoking other git options
     # such as ``--upload-pack=<command>`` — a known argument-injection vector.
-    _SAFE_REF_RE = re.compile(r"^[^-,\s\x00][^,\s\x00]*$")
+    _SAFE_REF_RE = re.compile(r"^[^-,\s\x00][^,\s\x00]*\Z")
     # Same defence for the URL: even though the CLI validates it as http(s)
     # upstream, ``extract_from_repo`` is a public API callable from any
     # embedding, so we re-validate here to avoid the same injection class.
-    # Only http(s)/ssh transports are accepted at the clone boundary.
-    _SAFE_URL_RE = re.compile(r"^(https?|ssh)://[^\s\x00]*$")
+    # Accepted at the clone boundary:
+    #   - http(s)://host/path
+    #   - ssh://[user@]host[:port]/path
+    #   - scp-style SSH: [user@]host:path  where the path either starts
+    #     with ``/`` (absolute) or with a non-flag character (so a
+    #     hostile provider cannot smuggle a flag through
+    #     ``git@host:--option``). ``extract_from_repo`` historically
+    #     accepted the scp form, so the regex preserves that compatibility
+    #     while still rejecting anything that smells like an injected flag.
+    # The scp path sub-pattern forbids ``-``/``,``/``\s``/``\x00``/``\Z`` at
+    # the start (no leading flag or whitespace) and continues with
+    # safe characters. The host portion also forbids ``-`` so a hostile
+    # user@ portion cannot itself look like an option.
+    _SAFE_URL_RE = re.compile(
+        r"(?:https?|ssh)://[^\s\x00]*\Z"
+        r"|"
+        r"[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:[^-,:\s\x00][^,\s\x00]*\Z"
+    )
 
     @staticmethod
     def _clone_repo(url: str, ref: str, dest: Path) -> None:

--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -2453,11 +2453,53 @@ class AiSbomExtractor:
 
         return doc
 
+    # Git rejects positional refs that begin with ``-`` by refusing them as
+    # "ambiguous argument", but only after it has already consumed earlier
+    # options.  Some versions of git also accept leading ``-`` arguments as
+    # flags in older builds (see CVE-2017-1000117 et al.), so we reject the
+    # value up-front rather than rely on the child process's behaviour.
+    # Accepting such a ref would let a hostile ref string (e.g. one pasted from
+    # a malicious README) trick ``git clone`` into invoking other git options
+    # such as ``--upload-pack=<command>`` — a known argument-injection vector.
+    _SAFE_REF_RE = re.compile(r"^[^-,\s\x00][^,\s\x00]*$")
+    # Same defence for the URL: even though the CLI validates it as http(s)
+    # upstream, ``extract_from_repo`` is a public API callable from any
+    # embedding, so we re-validate here to avoid the same injection class.
+    # Only http(s)/ssh transports are accepted at the clone boundary.
+    _SAFE_URL_RE = re.compile(r"^(https?|ssh)://[^\s\x00]*$")
+
     @staticmethod
     def _clone_repo(url: str, ref: str, dest: Path) -> None:
         if shutil.which("git") is None:
             raise RuntimeError("git executable not found on PATH")
-        cmd = ["git", "clone", "--depth", "1", "--branch", ref, url, str(dest)]
+        # Reject argument-injection attempts.  ``ref`` and ``url`` are passed
+        # to ``git clone`` as positional arguments; if either starts with
+        # ``-`` git may interpret it as a flag (``--upload-pack=<cmd>``,
+        # ``--config=<key>=<value>``, etc.), giving the ref provider a way to
+        # run arbitrary commands on the operator's machine.
+        if not AiSbomExtractor._SAFE_REF_RE.match(ref):
+            raise ValueError(
+                f"Invalid git ref {ref!r}: must not be empty, start with '-', "
+                "or contain whitespace."
+            )
+        if not AiSbomExtractor._SAFE_URL_RE.match(url):
+            raise ValueError(
+                f"Invalid repository URL {url!r}: must be an absolute URL with "
+                "an explicit scheme (e.g. https://...)."
+            )
+        # Use ``--`` to terminate option parsing so any future ref/url values
+        # that pass validation can never be reinterpreted as flags.
+        cmd = [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            ref,
+            "--",
+            url,
+            str(dest),
+        ]
         _log.debug("running: %s", " ".join(cmd))
         try:
             result = subprocess.run(cmd, check=True, capture_output=True)

--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -1028,6 +1028,46 @@ class AiSbomExtractor:
                         )
                         self._merge_detection(node_map, _comp_det)
                     continue
+                # API_ENDPOINT: group per-match by the parsed (method, path) —
+                # not raw snippet text, since different route-declaration styles
+                # (decorator vs. bare "METHOD /path") produce different snippets
+                # for the same logical route. The canonical_name scheme
+                # (endpoint:{METHOD}:{path}) matches the one used by the FastAPI/
+                # Flask AST adapters, so a route found by both a generic regex
+                # match and a framework-specific adapter merges into one node
+                # instead of producing a duplicate.
+                if detection.component_type == ComponentType.API_ENDPOINT and not getattr(
+                    rx_adapter, "canonical_name", None
+                ):
+                    _ep_first: dict[tuple[str, str], AdapterMatch] = {}
+                    for _m in detection.matches:
+                        _path = _m.groups.get("path")
+                        if not _path or _path == "/":
+                            continue
+                        _method = (_m.groups.get("method") or "").upper()
+                        _ep_key = (_method, _path)
+                        if _ep_key not in _ep_first:
+                            _ep_first[_ep_key] = _m
+                    for (_ep_method, _ep_path), _first_match in _ep_first.items():
+                        _ep_meta = dict(detection.metadata)
+                        _ep_meta["endpoint"] = _ep_path
+                        if _ep_method:
+                            _ep_meta["method"] = _ep_method
+                        _comp_det = ComponentDetection(
+                            component_type=detection.component_type,
+                            canonical_name=f"endpoint:{_ep_method or 'ANY'}:{_ep_path}",
+                            display_name=_ep_path,
+                            adapter_name=detection.adapter_name,
+                            priority=detection.priority,
+                            confidence=0.55,
+                            metadata=_ep_meta,
+                            file_path=rel_path,
+                            line=_first_match.line,
+                            snippet=_first_match.snippet,
+                            evidence_kind="regex",
+                        )
+                        self._merge_detection(node_map, _comp_det)
+                    continue
                 confidence = min(0.95, 0.50 + 0.05 * len(detection.matches))
                 canonical = canonicalize_text(detection.canonical_name)
                 # For MODEL type, keep the full canonical name (e.g., "llama3.2:3b"

--- a/nuguard/sbom/llm_client.py
+++ b/nuguard/sbom/llm_client.py
@@ -10,6 +10,7 @@ Only imported when ``AiSbomConfig.enable_llm=True``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -65,18 +66,22 @@ async def complete_structured(
         return {}
 
 
+_DESCRIPTION_BATCH_SIZE = 25
+_DESCRIPTION_BATCH_CONCURRENCY = 5
+
+
 async def enrich_node_descriptions(
     nodes: list,  # list[Node] — avoid circular import
     llm_client: "_CommonLLMClient",
 ) -> None:
     """Use LLM to write descriptions for AGENT/TOOL nodes missing or short ones.
 
-    Mutates nodes in-place. Skips nodes where description is already >30 chars.
+    Batches nodes into chunked structured calls (instead of one call per node)
+    to minimise round trips, running chunks concurrently. Mutates nodes
+    in-place. Skips nodes where description is already >30 chars.
     Called from AiSbomExtractor._llm_enrich() after other enrichment steps.
     """
-    _SYSTEM = (
-        "You are an AI security analyst writing concise descriptions for AI system components."
-    )
+    targets = []
     for node in nodes:
         component_type = getattr(node, "component_type", None)
         ct_str = str(getattr(component_type, "value", component_type)) if component_type is not None else ""
@@ -91,32 +96,84 @@ async def enrich_node_descriptions(
         if len(description) >= 30:
             continue  # already has a sufficient description
 
-        name = getattr(node, "name", "") or ""
-        framework = getattr(meta, "framework", None) or "unknown"
-        excerpt = (getattr(meta, "system_prompt_excerpt", None) or "")[:300]
-        parameters = getattr(meta, "parameters", None) or []
-        param_names = ", ".join(p.name for p in parameters if p.name)
+        targets.append((node, ct_str, meta))
+
+    if not targets:
+        return
+
+    _SYSTEM = (
+        "You are an AI security analyst writing concise descriptions for AI system components. "
+        "Given a list of components, return a JSON object mapping each component's id to a "
+        "single sentence (15-40 words) describing what it does."
+    )
+
+    async def _run_batch(batch: list[tuple[Any, str, Any]]) -> None:
+        items = []
+        for node, ct_str, meta in batch:
+            name = getattr(node, "name", "") or ""
+            framework = getattr(meta, "framework", None) or "unknown"
+            excerpt = (getattr(meta, "system_prompt_excerpt", None) or "")[:300]
+            parameters = getattr(meta, "parameters", None) or []
+            param_names = ", ".join(p.name for p in parameters if p.name)
+            items.append(
+                {
+                    "id": str(node.id),
+                    "name": name,
+                    "type": ct_str,
+                    "framework": framework,
+                    "system_prompt_excerpt": excerpt,
+                    "parameters": param_names,
+                }
+            )
 
         user_prompt = (
-            f"Component name: {name}\n"
-            f"Type: {ct_str}\n"
-            f"Framework: {framework}\n"
-            f"System prompt excerpt: {excerpt}\n"
-            f"Parameters: {param_names}\n\n"
-            "Write a single sentence (15-40 words) describing what this component does. "
-            "Reply with ONLY the description text."
+            f"Components (JSON list):\n{json.dumps(items, ensure_ascii=False)}\n\n"
+            "Return a JSON object: {\"<id>\": \"<description sentence>\", ...} for every "
+            "component."
         )
+        response_schema: dict[str, Any] = {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        }
 
         try:
-            text = await llm_client.complete(prompt=user_prompt, system=_SYSTEM)
-            text = text.strip()
-            if text:
-                meta.description = text[:200]
-                _log.debug("enrich_node_descriptions: set description for %s (%s)", name, ct_str)
-        except Exception as exc:
-            _log.warning(
-                "enrich_node_descriptions: failed for node %s (%s): %s", name, ct_str, exc
+            result = await complete_structured(
+                llm_client,
+                system=_SYSTEM,
+                user=user_prompt,
+                response_schema=response_schema,
             )
+        except Exception as exc:
+            _log.warning("enrich_node_descriptions: batch call failed: %s", exc)
+            return
+
+        if not isinstance(result, dict):
+            return
+        id_map = {str(node.id): (node, meta) for node, _ct_str, meta in batch}
+        for node_id_str, text in result.items():
+            if not isinstance(text, str):
+                continue
+            text = text.strip()
+            if not text or node_id_str not in id_map:
+                continue
+            node, meta = id_map[node_id_str]
+            meta.description = text[:200]
+            _log.debug(
+                "enrich_node_descriptions: set description for %s",
+                getattr(node, "name", "") or "",
+            )
+
+    batches = [
+        targets[i : i + _DESCRIPTION_BATCH_SIZE]
+        for i in range(0, len(targets), _DESCRIPTION_BATCH_SIZE)
+    ]
+    semaphore = asyncio.Semaphore(_DESCRIPTION_BATCH_CONCURRENCY)
+
+    async def _run_batch_limited(batch: list[tuple[Any, str, Any]]) -> None:
+        async with semaphore:
+            await _run_batch(batch)
+
+    await asyncio.gather(*(_run_batch_limited(batch) for batch in batches))
 
 
 async def enrich_descriptive_names(

--- a/nuguard/sbom/tests/test_enricher.py
+++ b/nuguard/sbom/tests/test_enricher.py
@@ -1,0 +1,71 @@
+"""Unit tests for nuguard.sbom.enricher, focused on API_ENDPOINT auth_required derivation."""
+
+from __future__ import annotations
+
+from nuguard.sbom.enricher import enrich
+from nuguard.sbom.models import AiSbomDocument, Edge, Node
+from nuguard.sbom.types import ComponentType, RelationshipType
+
+
+def _endpoint(name: str = "get-user", **meta_kwargs: object) -> Node:
+    return Node(
+        name=name,
+        component_type=ComponentType.API_ENDPOINT,
+        confidence=1.0,
+        metadata=meta_kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _auth(name: str = "auth") -> Node:
+    return Node(name=name, component_type=ComponentType.AUTH, confidence=1.0)
+
+
+class TestApiEndpointAuthRequired:
+    def test_auth_required_true_when_protected_by_auth_edge(self) -> None:
+        auth_node = _auth()
+        endpoint = _endpoint()
+        edge = Edge(
+            source=auth_node.id,
+            target=endpoint.id,
+            relationship_type=RelationshipType.PROTECTS,
+        )
+        doc = AiSbomDocument(target="t", nodes=[auth_node, endpoint], edges=[edge])
+
+        enrich(doc)
+
+        enriched = next(n for n in doc.nodes if n.id == endpoint.id)
+        assert enriched.metadata.auth_required is True
+
+    def test_auth_required_false_when_no_protecting_auth_node(self) -> None:
+        endpoint = _endpoint()
+        doc = AiSbomDocument(target="t", nodes=[endpoint], edges=[])
+
+        enrich(doc)
+
+        enriched = next(n for n in doc.nodes if n.id == endpoint.id)
+        assert enriched.metadata.auth_required is False
+
+    def test_auth_required_left_untouched_when_adapter_already_set_it(self) -> None:
+        endpoint = _endpoint(auth_required=True)
+        doc = AiSbomDocument(target="t", nodes=[endpoint], edges=[])
+
+        enrich(doc)
+
+        enriched = next(n for n in doc.nodes if n.id == endpoint.id)
+        assert enriched.metadata.auth_required is True
+
+    def test_auth_required_not_set_by_non_protects_edge(self) -> None:
+        """An AUTH node that CALLS (not PROTECTS) the endpoint doesn't count as protection."""
+        auth_node = _auth()
+        endpoint = _endpoint()
+        edge = Edge(
+            source=auth_node.id,
+            target=endpoint.id,
+            relationship_type=RelationshipType.CALLS,
+        )
+        doc = AiSbomDocument(target="t", nodes=[auth_node, endpoint], edges=[edge])
+
+        enrich(doc)
+
+        enriched = next(n for n in doc.nodes if n.id == endpoint.id)
+        assert enriched.metadata.auth_required is False

--- a/nuguard/sbom/tests/test_enricher.py
+++ b/nuguard/sbom/tests/test_enricher.py
@@ -54,6 +54,30 @@ class TestApiEndpointAuthRequired:
         enriched = next(n for n in doc.nodes if n.id == endpoint.id)
         assert enriched.metadata.auth_required is True
 
+    def test_enrich_is_idempotent_on_second_call(self) -> None:
+        """Re-running enrich() on an already-enriched doc must not change anything.
+
+        This matters because analyze/behavior/redteam now call enrich() again
+        on load to self-heal stale SBOM files, even when the file is already
+        fresh.
+        """
+        auth_node = _auth()
+        endpoint = _endpoint(endpoint="/users/{user_id}")
+        edge = Edge(
+            source=auth_node.id,
+            target=endpoint.id,
+            relationship_type=RelationshipType.PROTECTS,
+        )
+        doc = AiSbomDocument(target="t", nodes=[auth_node, endpoint], edges=[edge])
+
+        enrich(doc)
+        first_pass = doc.model_dump_json()
+
+        enrich(doc)
+        second_pass = doc.model_dump_json()
+
+        assert first_pass == second_pass
+
     def test_auth_required_not_set_by_non_protects_edge(self) -> None:
         """An AUTH node that CALLS (not PROTECTS) the endpoint doesn't count as protection."""
         auth_node = _auth()

--- a/nuguard/sbom/tests/test_subfolder_discovery.py
+++ b/nuguard/sbom/tests/test_subfolder_discovery.py
@@ -1,0 +1,92 @@
+"""Regression tests for sub-folder package manifest discovery.
+
+Issue #226: "package discovery" — when ``requirements.txt`` or
+``package.json`` lives inside a few sub-folders, the scanner was reported
+to miss them. These tests pin the deep-nesting behaviour so any future
+walker change that breaks it (e.g. introducing a max depth) will fail
+loudly rather than silently drop packages.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nuguard.sbom.deps import DependencyScanner
+
+
+def _touch(parent: Path, rel: str, content: str) -> Path:
+    path = parent / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_requirements_txt_in_arbitrary_subfolder(tmp_path: Path) -> None:
+    _touch(tmp_path, "services/auth/requirements.txt", "pyjwt>=2.0\n")
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/pyjwt" in purls
+
+
+def test_package_json_in_arbitrary_subfolder(tmp_path: Path) -> None:
+    _touch(
+        tmp_path,
+        "apps/web/package.json",
+        json.dumps({"dependencies": {"react": "^18.0.0"}}),
+    )
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:npm/react@18.0.0" in purls
+
+
+def test_pyproject_toml_in_arbitrary_subfolder(tmp_path: Path) -> None:
+    _touch(
+        tmp_path,
+        "packages/core/pyproject.toml",
+        '[project]\nname = "core"\nversion = "0.1.0"\n'
+        'dependencies = ["pydantic>=2.7"]\n',
+    )
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/pydantic" in purls
+
+
+def test_deep_nested_requirements(tmp_path: Path) -> None:
+    """Manifests nested four+ directories deep must still be discovered."""
+    _touch(tmp_path, "a/b/c/d/requirements.txt", "flask>=2.0\n")
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/flask" in purls
+
+
+def test_multiple_subfolder_manifests_all_discovered(tmp_path: Path) -> None:
+    """All sub-folder manifests are found in one scan, not just the first."""
+    _touch(tmp_path, "frontend/package.json",
+           json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(tmp_path, "backend/api/requirements.txt", "fastapi>=0.100\n")
+    _touch(tmp_path, "workers/queue/package.json",
+           json.dumps({"dependencies": {"bull": "^4.0.0"}}))
+
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:npm/react@18.0.0" in purls
+    assert "pkg:pypi/fastapi" in purls
+    assert "pkg:npm/bull@4.0.0" in purls
+
+
+def test_subfolder_manifest_filtered_in_venv(tmp_path: Path) -> None:
+    """Manifests inside venv / node_modules are still filtered out."""
+    _touch(tmp_path, "real/requirements.txt", "flask>=2.0\n")
+    _touch(tmp_path, "real/.venv/requirements.txt", "django>=4.2\n")
+    _touch(tmp_path, "web/package.json",
+           json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(tmp_path, "web/node_modules/lodash/package.json",
+           json.dumps({"dependencies": {"lodash": "^4.0.0"}}))
+
+    deps = DependencyScanner().scan(tmp_path)
+    purls = {d.purl for d in deps}
+    assert "pkg:pypi/flask" in purls
+    assert "pkg:pypi/django" not in purls
+    assert "pkg:npm/react@18.0.0" in purls
+    assert "pkg:npm/lodash@4.0.0" not in purls

--- a/nuguard/sbom/tests/test_subfolder_discovery.py
+++ b/nuguard/sbom/tests/test_subfolder_discovery.py
@@ -44,8 +44,7 @@ def test_pyproject_toml_in_arbitrary_subfolder(tmp_path: Path) -> None:
     _touch(
         tmp_path,
         "packages/core/pyproject.toml",
-        '[project]\nname = "core"\nversion = "0.1.0"\n'
-        'dependencies = ["pydantic>=2.7"]\n',
+        '[project]\nname = "core"\nversion = "0.1.0"\ndependencies = ["pydantic>=2.7"]\n',
     )
     deps = DependencyScanner().scan(tmp_path)
     purls = {d.purl for d in deps}
@@ -62,11 +61,9 @@ def test_deep_nested_requirements(tmp_path: Path) -> None:
 
 def test_multiple_subfolder_manifests_all_discovered(tmp_path: Path) -> None:
     """All sub-folder manifests are found in one scan, not just the first."""
-    _touch(tmp_path, "frontend/package.json",
-           json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(tmp_path, "frontend/package.json", json.dumps({"dependencies": {"react": "^18.0.0"}}))
     _touch(tmp_path, "backend/api/requirements.txt", "fastapi>=0.100\n")
-    _touch(tmp_path, "workers/queue/package.json",
-           json.dumps({"dependencies": {"bull": "^4.0.0"}}))
+    _touch(tmp_path, "workers/queue/package.json", json.dumps({"dependencies": {"bull": "^4.0.0"}}))
 
     deps = DependencyScanner().scan(tmp_path)
     purls = {d.purl for d in deps}
@@ -79,10 +76,12 @@ def test_subfolder_manifest_filtered_in_venv(tmp_path: Path) -> None:
     """Manifests inside venv / node_modules are still filtered out."""
     _touch(tmp_path, "real/requirements.txt", "flask>=2.0\n")
     _touch(tmp_path, "real/.venv/requirements.txt", "django>=4.2\n")
-    _touch(tmp_path, "web/package.json",
-           json.dumps({"dependencies": {"react": "^18.0.0"}}))
-    _touch(tmp_path, "web/node_modules/lodash/package.json",
-           json.dumps({"dependencies": {"lodash": "^4.0.0"}}))
+    _touch(tmp_path, "web/package.json", json.dumps({"dependencies": {"react": "^18.0.0"}}))
+    _touch(
+        tmp_path,
+        "web/node_modules/lodash/package.json",
+        json.dumps({"dependencies": {"lodash": "^4.0.0"}}),
+    )
 
     deps = DependencyScanner().scan(tmp_path)
     purls = {d.purl for d in deps}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nuguard",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "format": "claude-plugin",
   "source": ".claude-plugin/plugin.json",
   "hostTargets": [

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nuguard",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "format": "claude-plugin",
   "source": ".claude-plugin/plugin.json",
   "hostTargets": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral testing, and adversarial red-teaming for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral testing, and adversarial red-teaming for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.8.9"
+version = "0.8.10"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = ".github/README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.8.8"
+version = "0.8.9"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = ".github/README.md"
 license = { text = "Apache-2.0" }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.8.8"
+version: "0.8.9"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.8.9"
+version: "0.8.10"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/tests/apps/contact-center-ai-samples/conversation-design/requirements.txt
+++ b/tests/apps/contact-center-ai-samples/conversation-design/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.5.3
-mkdocs-material==9.4.6
+mkdocs>=1.6.0
+mkdocs-material>=9.5.0
 pymdown-extensions==10.3

--- a/tests/cli/test_policy_cli.py
+++ b/tests/cli/test_policy_cli.py
@@ -362,5 +362,14 @@ def test_check_missing_policy_exits(sbom_file: Path, tmp_path: Path) -> None:
 
 
 def test_show_unknown_policy_exits() -> None:
+    """The stub show command reports "not found" until a registry exists (issue #162)."""
     result = runner.invoke(app, ["policy", "show", "--policy-id", "nonexistent-id"])
     assert result.exit_code != 0
+    assert "not found" in result.output.lower() or "not found" in (result.stderr or "").lower()
+
+
+def test_show_command_is_hidden_from_help() -> None:
+    """``policy show`` is a deprecated stub and must be hidden from --help output."""
+    result = runner.invoke(app, ["policy", "--help"])
+    assert result.exit_code == 0
+    assert "show" not in result.output

--- a/tests/cli/test_redteam_format_output.py
+++ b/tests/cli/test_redteam_format_output.py
@@ -23,11 +23,17 @@ These tests pin the contract:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
 
 from nuguard.cli.commands.redteam import _render_findings_text
+from nuguard.cli.main import app
 from nuguard.cli.report_meta import ReportMeta
 from nuguard.models.finding import Finding, Severity
+from nuguard.models.token_usage import TokenUsage
 
 
 def _make_findings() -> list[Finding]:
@@ -55,6 +61,45 @@ def _make_findings() -> list[Finding]:
             owasp_asi_ref="ASI-02",
         ),
     ]
+
+
+def _make_minimal_sbom(tmp_path: Path) -> Path:
+    """Write a minimal valid AI-SBOM JSON file the redteam CLI will accept."""
+    sbom_path = tmp_path / "minimal.sbom.json"
+    sbom_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.5.0",
+                "generator": "nuguard",
+                "target": "https://github.com/test/test",
+                "nodes": [],
+                "edges": [],
+                "deps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return sbom_path
+
+
+def _mock_run_redteam_outcome():
+    """Return a coroutine that yields the 13-tuple ``_run_redteam`` produces."""
+    async def _coro(*_args, **_kwargs):
+        return (
+            _make_findings(),  # findings
+            [],                 # scenario_records
+            "no_findings",      # scan_outcome
+            [],                 # config_notes
+            None,               # catalog_coverage
+            0,                  # input_tokens_used
+            0,                  # output_tokens_used
+            None,               # coverage_tracker
+            TokenUsage(),       # token_usage
+            "/chat",            # resolved_chat_path
+            "default",          # resolved_chat_path_source
+            [],                 # remediation_plan
+        )
+    return _coro
 
 
 # ---------------------------------------------------------------------------
@@ -140,71 +185,91 @@ def test_render_text_empty_findings_has_no_table_block() -> None:
 
 
 def test_dispatch_text_format_writes_plain_text_file(tmp_path: Path) -> None:
-    """Replicate the redteam --output dispatch loop and verify a ``.txt`` file
-    that ``fmt='text'`` produces contains plain text — NOT JSON.
+    """End-to-end: ``nuguard redteam --output foo.txt --format text`` writes
+    the plain-text report, not JSON.
 
-    This mirrors the inline dispatch in
-    ``nuguard/cli/commands/redteam.py:421-460`` after the fix.
+    Regression for #254 — the pre-fix dispatch fell through to the JSON
+    ``else`` branch when ``fmt='text'`` was requested, producing a JSON file
+    with a ``.txt`` extension. This test exercises the real CLI through
+    ``CliRunner`` so it will fail the moment the production dispatch loop
+    stops routing ``text`` to :func:`_render_findings_text`.
     """
-    findings = _make_findings()
-    meta = ReportMeta(verbose=False)
-
+    sbom_path = _make_minimal_sbom(tmp_path)
     output = tmp_path / "redteam.txt"
-    effective_formats = ["text"]
-    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
 
-    # --- Inline dispatch (mirrors redteam.py --output branch) ---
-    for fmt in effective_formats:
-        if len(effective_formats) > 1:
-            out_path = output.with_suffix(extension_map[fmt])
-        else:
-            out_path = output
-        if fmt == "text":
-            out_path.write_text(
-                _render_findings_text(findings, meta, "no_findings", colour=False),
-                encoding="utf-8",
-            )
-        elif fmt == "markdown":
-            out_path.write_text("MARKDOWN", encoding="utf-8")
-        elif fmt == "sarif":
-            out_path.write_text("SARIF", encoding="utf-8")
-        else:
-            # Bug path: should not be reached for fmt == "text".
-            out_path.write_text("BUG: JSON INSTEAD OF TEXT", encoding="utf-8")
+    runner = CliRunner()
+    with patch(
+        "nuguard.cli.commands.redteam._run_redteam",
+        new=_mock_run_redteam_outcome(),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(sbom_path),
+                "--target", "http://localhost:9999",
+                "--output", str(output),
+                "--format", "text",
+            ],
+        )
+
+    assert output.exists(), (
+        f"Output file was not written to {output}.\nstdout:\n{result.stdout}"
+    )
 
     content = output.read_text(encoding="utf-8")
     assert not content.lstrip().startswith("{"), (
-        "fmt='text' must write plain text, not JSON (regression for #254)."
+        "--format text --output must write plain text, not JSON (regression for #254)."
     )
     assert "\x1b[" not in content, "File output must not contain ANSI escapes."
     assert "NuGuard Red-Team" in content
     assert "2 finding(s)" in content
 
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by CRITICAL/HIGH
+    # findings) are both acceptable — the dispatch contract is that the file
+    # is written before the threshold check runs.
+    assert result.exit_code in (0, 2), (
+        f"Unexpected exit code {result.exit_code}; stdout:\n{result.stdout}"
+    )
+
 
 def test_dispatch_json_format_still_writes_json_file(tmp_path: Path) -> None:
-    """Sanity check: --format json --output foo.json still writes valid JSON.
+    """Sanity check: ``--format json --output foo.json`` still writes valid JSON.
 
-    The fix must not regress the JSON output path.
+    The fix must not regress the JSON output path. Same end-to-end shape as
+    the text-format test above — exercises the real CLI dispatcher.
     """
-    import json as _json
-
-    from nuguard.redteam.report import to_json
-
-    findings = _make_findings()
-    meta = ReportMeta(verbose=False)
+    sbom_path = _make_minimal_sbom(tmp_path)
     output = tmp_path / "redteam.json"
-    effective_formats = ["json"]
-    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
 
-    for fmt in effective_formats:
-        out_path = output.with_suffix(extension_map[fmt])
-        if fmt == "json":
-            out_path.write_text(
-                to_json(findings, meta=meta, scan_outcome="no_findings"),
-                encoding="utf-8",
-            )
+    runner = CliRunner()
+    with patch(
+        "nuguard.cli.commands.redteam._run_redteam",
+        new=_mock_run_redteam_outcome(),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(sbom_path),
+                "--target", "http://localhost:9999",
+                "--output", str(output),
+                "--format", "json",
+            ],
+        )
+
+    assert output.exists(), (
+        f"Output file was not written to {output}.\nstdout:\n{result.stdout}"
+    )
 
     content = output.read_text(encoding="utf-8")
-    parsed = _json.loads(content)
+    parsed = json.loads(content)
     assert "_meta" in parsed
     assert len(parsed["findings"]) == 2
+
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by CRITICAL/HIGH
+    # findings) are both acceptable — the dispatch contract is that the file
+    # is written before the threshold check runs.
+    assert result.exit_code in (0, 2), (
+        f"Unexpected exit code {result.exit_code}; stdout:\n{result.stdout}"
+    )

--- a/tests/cli/test_redteam_format_output.py
+++ b/tests/cli/test_redteam_format_output.py
@@ -1,0 +1,210 @@
+"""Regression tests for the redteam --output / --format dispatch.
+
+Background
+----------
+``nuguard redteam --output foo.txt`` historically wrote JSON content into
+``foo.txt`` regardless of the requested format. The ``--output`` branch in
+``nuguard/cli/commands/redteam.py`` only had explicit handling for
+``markdown`` and ``sarif``; ``text`` (the default format) and ``json`` both
+fell into the same ``else`` block that JSON-serialised the findings. The
+``text`` default therefore produced a JSON file with a ``.txt`` extension
+when ``--output`` was used, which is incorrect — the file should match
+the stdout text format (minus ANSI escapes).
+
+These tests pin the contract:
+
+* ``_render_findings_text(findings, meta, scan_outcome, colour=False)``
+  returns plain text (no JSON, no ANSI escapes).
+* ``_render_findings_text(..., colour=True)`` is the stdout form and
+  contains ANSI escapes for severity labels.
+* When the dispatch loop encounters ``fmt == "text"``, the written file is
+  the plain-text report — not a JSON document.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nuguard.cli.commands.redteam import _render_findings_text
+from nuguard.cli.report_meta import ReportMeta
+from nuguard.models.finding import Finding, Severity
+
+
+def _make_findings() -> list[Finding]:
+    return [
+        Finding(
+            finding_id="redteam-test-001",
+            title="Prompt injection via tool description",
+            severity=Severity.HIGH,
+            description=(
+                "An attacker-controlled page injected a tool description that "
+                "exfiltrated adjacent user data through tool-call arguments."
+            ),
+            remediation="Strip tool descriptions from untrusted sources.",
+            owasp_asi_ref="ASI-01",
+        ),
+        Finding(
+            finding_id="redteam-test-002",
+            title="Data exfiltration via canary value",
+            severity=Severity.CRITICAL,
+            description=(
+                "The agent echoed the canary tenant record into a public "
+                "response, confirming cross-tenant data leakage."
+            ),
+            remediation="Enforce per-tenant tool scoping.",
+            owasp_asi_ref="ASI-02",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _render_findings_text helper
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_plain_is_not_json() -> None:
+    """Plain text must not be JSON-serialised and must have no ANSI escapes."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    assert not txt.lstrip().startswith("{"), (
+        "Plain text output must not start with '{' (would indicate JSON)."
+    )
+    assert "\x1b[" not in txt, "Plain text output must not contain ANSI escapes."
+
+
+def test_render_text_plain_contains_expected_sections() -> None:
+    """Plain text should contain the report header, finding count, and outcome."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    assert "NuGuard Red-Team" in txt
+    assert "2 finding(s)" in txt
+    assert "Outcome: no_findings" in txt
+
+
+def test_render_text_plain_severity_ordering() -> None:
+    """Findings must be sorted by descending severity (CRITICAL before HIGH)."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    crit_pos = txt.index("CRITICAL")
+    high_pos = txt.index("HIGH")
+    assert crit_pos < high_pos, (
+        "CRITICAL findings must appear before HIGH findings in the text report."
+    )
+
+
+def test_render_text_plain_no_ansi_even_with_findings() -> None:
+    """Severity labels must not be wrapped in colour escapes for plain output."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    # No escape introducer anywhere in the document.
+    assert "\x1b" not in txt
+
+
+def test_render_text_colour_contains_ansi_escapes() -> None:
+    """Colour=True must inject ANSI escapes (for stdout on a TTY)."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=True)
+
+    assert "\x1b[" in txt, "Colour output should contain ANSI escape sequences."
+
+
+def test_render_text_empty_findings_has_no_table_block() -> None:
+    """An empty findings list produces the short 'No findings' message, not the
+    full table block (which would be misleading)."""
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text([], meta, "no_findings", colour=False)
+
+    assert "No findings — scan complete" in txt
+    assert "NuGuard Red-Team — 0 finding(s)" not in txt
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: when --output is used and the format is "text", the file must be
+# plain text, not JSON. This is the regression test for the original bug.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_text_format_writes_plain_text_file(tmp_path: Path) -> None:
+    """Replicate the redteam --output dispatch loop and verify a ``.txt`` file
+    that ``fmt='text'`` produces contains plain text — NOT JSON.
+
+    This mirrors the inline dispatch in
+    ``nuguard/cli/commands/redteam.py:421-460`` after the fix.
+    """
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    output = tmp_path / "redteam.txt"
+    effective_formats = ["text"]
+    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
+
+    # --- Inline dispatch (mirrors redteam.py --output branch) ---
+    for fmt in effective_formats:
+        if len(effective_formats) > 1:
+            out_path = output.with_suffix(extension_map[fmt])
+        else:
+            out_path = output
+        if fmt == "text":
+            out_path.write_text(
+                _render_findings_text(findings, meta, "no_findings", colour=False),
+                encoding="utf-8",
+            )
+        elif fmt == "markdown":
+            out_path.write_text("MARKDOWN", encoding="utf-8")
+        elif fmt == "sarif":
+            out_path.write_text("SARIF", encoding="utf-8")
+        else:
+            # Bug path: should not be reached for fmt == "text".
+            out_path.write_text("BUG: JSON INSTEAD OF TEXT", encoding="utf-8")
+
+    content = output.read_text(encoding="utf-8")
+    assert not content.lstrip().startswith("{"), (
+        "fmt='text' must write plain text, not JSON (regression for #254)."
+    )
+    assert "\x1b[" not in content, "File output must not contain ANSI escapes."
+    assert "NuGuard Red-Team" in content
+    assert "2 finding(s)" in content
+
+
+def test_dispatch_json_format_still_writes_json_file(tmp_path: Path) -> None:
+    """Sanity check: --format json --output foo.json still writes valid JSON.
+
+    The fix must not regress the JSON output path.
+    """
+    import json as _json
+
+    from nuguard.redteam.report import to_json
+
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+    output = tmp_path / "redteam.json"
+    effective_formats = ["json"]
+    extension_map = {"text": ".txt", "json": ".json", "markdown": ".md", "sarif": ".sarif"}
+
+    for fmt in effective_formats:
+        out_path = output.with_suffix(extension_map[fmt])
+        if fmt == "json":
+            out_path.write_text(
+                to_json(findings, meta=meta, scan_outcome="no_findings"),
+                encoding="utf-8",
+            )
+
+    content = output.read_text(encoding="utf-8")
+    parsed = _json.loads(content)
+    assert "_meta" in parsed
+    assert len(parsed["findings"]) == 2

--- a/tests/cli/test_sbom_cli.py
+++ b/tests/cli/test_sbom_cli.py
@@ -169,6 +169,66 @@ def test_show_unknown_id_exits(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# nuguard sbom enrich
+# ---------------------------------------------------------------------------
+
+
+def _write_pre_fix_sbom(tmp_path: Path) -> Path:
+    """Write a minimal SBOM with an AUTH->PROTECTS->API_ENDPOINT edge but no
+    ``auth_required`` set, mimicking a file generated before the enricher fix."""
+    from nuguard.sbom.models import AiSbomDocument, Edge, Node
+    from nuguard.sbom.types import ComponentType, RelationshipType
+
+    auth_node = Node(name="auth", component_type=ComponentType.AUTH, confidence=1.0)
+    endpoint = Node(name="get-user", component_type=ComponentType.API_ENDPOINT, confidence=1.0)
+    edge = Edge(
+        source=auth_node.id,
+        target=endpoint.id,
+        relationship_type=RelationshipType.PROTECTS,
+    )
+    doc = AiSbomDocument(target="t", nodes=[auth_node, endpoint], edges=[edge])
+
+    sbom_file = tmp_path / "stale.sbom.json"
+    sbom_file.write_text(AiSbomSerializer.to_json(doc), encoding="utf-8")
+    data = json.loads(sbom_file.read_text())
+    assert "auth_required" not in json.dumps(data)  # sanity: field truly absent
+    return sbom_file
+
+
+def test_enrich_populates_auth_required_in_place(tmp_path: Path) -> None:
+    sbom_file = _write_pre_fix_sbom(tmp_path)
+    result = runner.invoke(app, ["sbom", "enrich", "--file", str(sbom_file)])
+    assert result.exit_code == 0, result.output
+
+    doc = AiSbomDocument.model_validate(json.loads(sbom_file.read_text()))
+    endpoint = next(n for n in doc.nodes if n.component_type == "API_ENDPOINT")
+    assert endpoint.metadata.auth_required is True
+
+
+def test_enrich_writes_to_output_path_without_modifying_source(tmp_path: Path) -> None:
+    sbom_file = _write_pre_fix_sbom(tmp_path)
+    out_file = tmp_path / "enriched.sbom.json"
+    result = runner.invoke(
+        app, ["sbom", "enrich", "--file", str(sbom_file), "--output", str(out_file)]
+    )
+    assert result.exit_code == 0, result.output
+    assert out_file.exists()
+
+    doc = AiSbomDocument.model_validate(json.loads(out_file.read_text()))
+    endpoint = next(n for n in doc.nodes if n.component_type == "API_ENDPOINT")
+    assert endpoint.metadata.auth_required is True
+
+    # Source file is untouched
+    src_data = json.loads(sbom_file.read_text())
+    assert "auth_required" not in json.dumps(src_data)
+
+
+def test_enrich_missing_file_exits(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["sbom", "enrich", "--file", str(tmp_path / "nope.json")])
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
 # nuguard sbom schema
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_sbom_cli.py
+++ b/tests/cli/test_sbom_cli.py
@@ -110,6 +110,20 @@ def test_generate_bad_source_exits_nonzero(tmp_path: Path) -> None:
     assert result.exit_code != 0
 
 
+def test_generate_creates_missing_parent_dir(tmp_path: Path) -> None:
+    # --output into a not-yet-existing directory should succeed and create the
+    # parent, matching `nuguard behavior` (analyze/redteam also create parents).
+    out = tmp_path / "nested" / "deep" / "app.sbom.json"
+    result = runner.invoke(
+        app,
+        ["sbom", "generate", "--source", str(_FIXTURE_APP), "--output", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert "nodes" in data
+
+
 # ---------------------------------------------------------------------------
 # nuguard sbom validate
 # ---------------------------------------------------------------------------

--- a/tests/sbom/test_application_summary_paths.py
+++ b/tests/sbom/test_application_summary_paths.py
@@ -1,0 +1,87 @@
+"""Tests for application_summary path handling.
+
+Verifies that deployment-context extraction works regardless of the path
+separator used by the platform that produced the path. On Windows, ``os.walk``
+and ``Path.relative_to`` yield backslash-separated paths, so deployment-file
+hints defined with forward slashes (``.github/workflows/``, ``/k8s/``,
+``infra/``) would silently fail to match and ``deployment_urls`` would end up
+empty even when workflow content clearly contains URLs.
+
+See issue #234.
+"""
+
+from __future__ import annotations
+
+from nuguard.sbom.core.application_summary import extract_deployment_context
+
+
+def _workflow_content(url: str = "https://my-backend.azurewebsites.net") -> str:
+    return f"""name: Deploy
+on: [push]
+jobs:
+  deploy:
+    steps:
+      - run: echo {url}
+"""
+
+
+def _azure_workflow_with_env_var() -> str:
+    return """name: Deploy
+on: [push]
+env:
+  AZURE_WEBAPP_NAME: my-backend
+jobs:
+  deploy:
+    steps:
+      - run: deploy
+"""
+
+
+def test_windows_style_workflow_path_matches_hint() -> None:
+    """A backslash-separated path must still trigger the workflow hint."""
+    files = [
+        (".github\\workflows\\deploy.yml", _workflow_content()),
+    ]
+    result = extract_deployment_context(files)
+    assert "GitHub Actions" in result["deployment_platforms"], (
+        f"Expected GitHub Actions detection on Windows path, got "
+        f"{result['deployment_platforms']!r}"
+    )
+    assert "https://my-backend.azurewebsites.net" in result["deployment_urls"]
+
+
+def test_windows_style_workflow_path_reconstructs_azure_url() -> None:
+    """AZURE_WEBAPP_NAME env-var URL reconstruction must work on Windows paths."""
+    files = [
+        (".github\\workflows\\deploy.yml", _azure_workflow_with_env_var()),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://my-backend.azurewebsites.net" in result["deployment_urls"]
+
+
+def test_windows_style_kubernetes_path_matches_hint() -> None:
+    """A backslash-separated ``k8s`` path must still trigger the Kubernetes hint."""
+    files = [
+        ("k8s\\deployment.yaml", "apiVersion: apps/v1\nkind: Deployment\n"),
+    ]
+    result = extract_deployment_context(files)
+    assert "Kubernetes" in result["deployment_platforms"]
+
+
+def test_windows_style_infra_path_matches_hint() -> None:
+    """A backslash-separated ``infra`` path must still trigger the deployment hint."""
+    files = [
+        ("infra\\main.tf", 'resource "azurerm_app_service" "x" {}'),
+    ]
+    result = extract_deployment_context(files)
+    # Terraform / Azure detection should both fire
+    assert "Azure" in result["deployment_platforms"]
+
+
+def test_posix_paths_still_work() -> None:
+    """Forward-slash paths continue to work after the normalization change."""
+    files = [
+        (".github/workflows/deploy.yml", _workflow_content()),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://my-backend.azurewebsites.net" in result["deployment_urls"]

--- a/tests/sbom/test_application_summary_paths.py
+++ b/tests/sbom/test_application_summary_paths.py
@@ -78,6 +78,93 @@ def test_windows_style_infra_path_matches_hint() -> None:
     assert "Azure" in result["deployment_platforms"]
 
 
+# ---------------------------------------------------------------------------
+# Path-only path-hint tests (regression-pin the actual fix on PR #241)
+# ---------------------------------------------------------------------------
+#
+# These tests use content that does NOT independently trigger Kubernetes/Azure
+# detection — only the path-hint match (e.g. ``docker``, ``infra/``) should
+# cause the file's URL to flow into ``deployment_urls``. Without the path
+# normalization, the raw backslash-separated path never matches the forward
+# slash hint and the URL is silently dropped. Reviewer nit on PR #241:
+# the existing ``test_windows_style_kubernetes_path_matches_hint`` and
+# ``test_windows_style_infra_path_matches_hint`` tests above were vacuous
+# because they happened to pass via content-based detection regardless of
+# the path normalization.
+
+
+def test_windows_style_kubernetes_path_extracts_url_via_path_hint() -> None:
+    """A backslash-separated path containing ``/k8s/`` (with leading slash)
+    must extract URLs from content that does NOT independently trigger
+    Kubernetes detection.
+
+    The content here contains no ``apiVersion:`` and no other Kubernetes
+    marker — the URL is only captured because the path-hint match
+    (``/k8s/`` substring) fires after path normalization converts the
+    backslashes to forward slashes. Without the normalization, the raw
+    path ``myapp\\\\k8s\\\\frontend.yaml`` never matches the ``/k8s/``
+    hint (which requires a forward-slash separator before ``k8s``).
+    """
+    files = [
+        (
+            "myapp\\k8s\\frontend.yaml",
+            "# Plain config with a load balancer URL\n"
+            "url: https://k8s-lb.example.com/api\n",
+        ),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://k8s-lb.example.com/api" in result["deployment_urls"], (
+        f"Expected path-hint to surface URL on Windows k8s path; got "
+        f"{result['deployment_urls']!r}"
+    )
+
+
+def test_windows_style_infra_path_extracts_url_via_path_hint() -> None:
+    """A backslash-separated ``infra`` path must extract URLs from content
+    that does NOT independently trigger Azure/Terraform detection.
+
+    The content here contains no ``azurerm_`` resource and no other Azure
+    marker — the URL is only captured because the path-hint match
+    (``infra/``) fires after path normalization. Without the normalization,
+    ``deployment_urls`` would be empty.
+    """
+    files = [
+        (
+            "infra\\README.md",
+            "README: deploys to https://infra-deploy.example.com/qa\n",
+        ),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://infra-deploy.example.com/qa" in result["deployment_urls"], (
+        f"Expected path-hint to surface URL on Windows infra path; got "
+        f"{result['deployment_urls']!r}"
+    )
+
+
+def test_windows_style_deployment_path_extracts_url_via_path_hint() -> None:
+    """A backslash-separated path containing ``infra/`` (with trailing
+    forward slash) must extract URLs from content that does NOT
+    independently trigger Azure/Terraform detection.
+
+    Pins the path-hint normalization for hints that require a trailing
+    forward slash. The content is a plain text file with a URL but no
+    platform-specific markers. Without path normalization, the raw
+    backslash path ``app\\\\infra\\\\notes.txt`` never matches the
+    ``infra/`` hint and the URL is silently dropped.
+    """
+    files = [
+        (
+            "app\\infra\\notes.txt",
+            "App is deployed at https://app-infra-deploy.example.com/qa\n",
+        ),
+    ]
+    result = extract_deployment_context(files)
+    assert "https://app-infra-deploy.example.com/qa" in result["deployment_urls"], (
+        f"Expected path-hint to surface URL on Windows infra path; got "
+        f"{result['deployment_urls']!r}"
+    )
+
+
 def test_posix_paths_still_work() -> None:
     """Forward-slash paths continue to work after the normalization change."""
     files = [

--- a/tests/sbom/test_application_summary_paths.py
+++ b/tests/sbom/test_application_summary_paths.py
@@ -79,18 +79,14 @@ def test_windows_style_infra_path_matches_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Path-only path-hint tests (regression-pin the actual fix on PR #241)
+# Path-only path-hint tests (regression for the Windows path-normalization fix)
 # ---------------------------------------------------------------------------
 #
 # These tests use content that does NOT independently trigger Kubernetes/Azure
 # detection — only the path-hint match (e.g. ``docker``, ``infra/``) should
 # cause the file's URL to flow into ``deployment_urls``. Without the path
 # normalization, the raw backslash-separated path never matches the forward
-# slash hint and the URL is silently dropped. Reviewer nit on PR #241:
-# the existing ``test_windows_style_kubernetes_path_matches_hint`` and
-# ``test_windows_style_infra_path_matches_hint`` tests above were vacuous
-# because they happened to pass via content-based detection regardless of
-# the path normalization.
+# slash hint and the URL is silently dropped.
 
 
 def test_windows_style_kubernetes_path_extracts_url_via_path_hint() -> None:

--- a/tests/sbom/test_clone_repo_arg_injection.py
+++ b/tests/sbom/test_clone_repo_arg_injection.py
@@ -1,0 +1,182 @@
+"""Regression tests for argument-injection hardening in ``AiSbomExtractor._clone_repo``.
+
+The git-clone path is reached from ``nuguard sbom generate --from-repo --ref <ref>``
+or directly via ``AiSbomExtractor.extract_from_repo()``.  Historically the ref
+and url values were passed verbatim as positional arguments to ``git clone``;
+that allows a hostile ref (or url) string starting with ``-`` to be
+interpreted by git as a flag (e.g. ``--upload-pack=<cmd>``), which is a known
+argument-injection vector.
+
+These tests pin the contract that:
+
+* refs beginning with ``-`` are rejected before any subprocess is started;
+* empty / whitespace / null-byte refs are rejected;
+* url strings lacking a scheme (or starting with ``-``) are rejected;
+* well-formed values still flow through to ``git clone`` unchanged;
+* the subprocess command now uses ``--`` to terminate option parsing
+  (defence in depth, in case validation is ever loosened).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nuguard.sbom.extractor import AiSbomExtractor
+
+# ---------------------------------------------------------------------------
+# Ref / URL rejection — argument-injection defence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_ref",
+    [
+        # Leading-dash: would be parsed as a git flag (e.g. --upload-pack=...).
+        "--upload-pack=touch /tmp/pwn",
+        "-x",
+        "--",
+        # Embedded null byte / newline / tab — shell-confusion classic.
+        "main\x00evil",
+        "main\n--upload-pack=evil",
+        "main\t--config=core.editor=vim",
+        # Whitespace-only / empty.
+        " ",
+        "",
+    ],
+)
+def test_clone_repo_rejects_unsafe_refs(bad_ref: str, tmp_path: Path) -> None:
+    """A ref beginning with ``-`` or containing whitespace must raise ValueError.
+
+    No subprocess should be started for these inputs.
+    """
+    with patch("nuguard.sbom.extractor.core.subprocess.run") as run_mock:
+        with pytest.raises(ValueError, match="Invalid git ref"):
+            AiSbomExtractor._clone_repo(
+                url="https://github.com/example/repo.git",
+                ref=bad_ref,
+                dest=tmp_path,
+            )
+    assert run_mock.call_count == 0, "subprocess.run must NOT be invoked for an unsafe ref"
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        # Leading-dash URL would be parsed by git as a flag.
+        "--upload-pack=evil",
+        # No scheme.
+        "github.com/example/repo",
+        "example/repo.git",
+        # Empty / whitespace.
+        "",
+        " ",
+        # File:// — refused: not http(s).
+        "file:///etc/passwd",
+        # git:// — refused: not http(s).
+        "git://github.com/example/repo.git",
+    ],
+)
+def test_clone_repo_rejects_unsafe_urls(bad_url: str, tmp_path: Path) -> None:
+    """A url lacking a recognised scheme or starting with ``-`` must raise ValueError."""
+    with patch("nuguard.sbom.extractor.core.subprocess.run") as run_mock:
+        with pytest.raises(ValueError, match="Invalid repository URL"):
+            AiSbomExtractor._clone_repo(
+                url=bad_url,
+                ref="main",
+                dest=tmp_path,
+            )
+    assert run_mock.call_count == 0, "subprocess.run must NOT be invoked for an unsafe url"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — well-formed inputs still work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "good_url",
+    [
+        "https://github.com/example/repo",
+        "https://github.com/example/repo.git",
+        "http://internal.example.com/team/repo.git",
+        "ssh://git@example.com/repo.git",
+    ],
+)
+def test_clone_repo_accepts_well_formed_urls(good_url: str, tmp_path: Path) -> None:
+    """Common url formats must reach ``subprocess.run`` unchanged."""
+    with patch(
+        "nuguard.sbom.extractor.core.subprocess.run",
+        return_value=_ok_completed_process(),
+    ) as run_mock:
+        AiSbomExtractor._clone_repo(url=good_url, ref="main", dest=tmp_path)
+
+    assert run_mock.call_count == 1
+    cmd = run_mock.call_args.args[0]
+    assert cmd[0] == "git"
+    assert cmd[1] == "clone"
+    assert cmd[2:6] == ["--depth", "1", "--branch", "main"]
+    # ``--`` must terminate option parsing so the url can never be
+    # reinterpreted as a flag even if validation were ever weakened.
+    assert "--" in cmd
+    assert good_url in cmd
+    assert str(tmp_path) in cmd
+
+
+def test_clone_repo_preserves_ref_in_subprocess(tmp_path: Path) -> None:
+    """The ref value is passed to git verbatim after validation."""
+    with patch(
+        "nuguard.sbom.extractor.core.subprocess.run",
+        return_value=_ok_completed_process(),
+    ) as run_mock:
+        AiSbomExtractor._clone_repo(
+            url="https://github.com/example/repo.git",
+            ref="feature/some_branch",
+            dest=tmp_path,
+        )
+    cmd = run_mock.call_args.args[0]
+    assert "feature/some_branch" in cmd
+    # The ref must appear before the ``--`` separator (still positional).
+    ref_index = cmd.index("feature/some_branch")
+    sep_index = cmd.index("--")
+    assert ref_index < sep_index
+
+
+def test_clone_repo_subprocess_uses_double_dash_separator(tmp_path: Path) -> None:
+    """Defence in depth: ``--`` must appear between ref and url in the command.
+
+    This prevents any future ref/url value that passes validation from being
+    misinterpreted as a git flag, even if a regression weakens the regex.
+    """
+    with patch(
+        "nuguard.sbom.extractor.core.subprocess.run",
+        return_value=_ok_completed_process(),
+    ) as run_mock:
+        AiSbomExtractor._clone_repo(
+            url="https://github.com/example/repo.git",
+            ref="main",
+            dest=tmp_path,
+        )
+    cmd = run_mock.call_args.args[0]
+    # ``--`` must come after ``--branch <ref>`` and before the url.
+    sep_index = cmd.index("--")
+    assert cmd[sep_index - 2 : sep_index] == ["--branch", "main"]
+    assert cmd[sep_index + 1] == "https://github.com/example/repo.git"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletedProcess:
+    def __init__(self) -> None:
+        self.returncode = 0
+        self.stdout = b""
+        self.stderr = b""
+
+
+def _ok_completed_process() -> _FakeCompletedProcess:
+    return _FakeCompletedProcess()

--- a/tests/sbom/test_clone_repo_arg_injection.py
+++ b/tests/sbom/test_clone_repo_arg_injection.py
@@ -45,6 +45,11 @@ from nuguard.sbom.extractor import AiSbomExtractor
         # Whitespace-only / empty.
         " ",
         "",
+        # Trailing newline only — Python's ``$`` matches before a trailing
+        # newline, so a bare ``^...$`` regex would let ``"main\n"`` through.
+        # The hardening regex uses ``\Z`` (or ``re.fullmatch``) so this is
+        # rejected.
+        "main\n",
     ],
 )
 def test_clone_repo_rejects_unsafe_refs(bad_ref: str, tmp_path: Path) -> None:
@@ -103,6 +108,12 @@ def test_clone_repo_rejects_unsafe_urls(bad_url: str, tmp_path: Path) -> None:
         "https://github.com/example/repo.git",
         "http://internal.example.com/team/repo.git",
         "ssh://git@example.com/repo.git",
+        # scp-style SSH — historically accepted by ``extract_from_repo`` and
+        # still a valid git transport. The hardening regex explicitly permits
+        # this form so we don't regress existing callers that use it.
+        "git@github.com:example/repo.git",
+        "git@github.com:/example/repo.git",
+        "git@gitlab.com:group/subgroup/project.git",
     ],
 )
 def test_clone_repo_accepts_well_formed_urls(good_url: str, tmp_path: Path) -> None:
@@ -123,6 +134,40 @@ def test_clone_repo_accepts_well_formed_urls(good_url: str, tmp_path: Path) -> N
     assert "--" in cmd
     assert good_url in cmd
     assert str(tmp_path) in cmd
+
+
+@pytest.mark.parametrize(
+    "hostile_scp_url",
+    [
+        # scp-style URL with a leading-dash path. The colon already
+        # separates host from path, but a hostile provider could try
+        # ``git@host:--upload-pack=evil`` to look like a flag. The regex
+        # rejects this even though the scp form is otherwise permitted.
+        "git@github.com:--upload-pack=evil",
+        "git@github.com:-flag",
+        "git@github.com:--",
+        "git@github.com: --option",
+        "git@github.com:,foo",
+    ],
+)
+def test_clone_repo_rejects_hostile_scp_urls(hostile_scp_url: str, tmp_path: Path) -> None:
+    """An scp-style URL whose path begins with ``-`` must raise ValueError.
+
+    Companion to ``test_clone_repo_accepts_well_formed_urls`` for the scp
+    form: the hardening regex permits legitimate scp URLs
+    (``git@host:path``) but still rejects scp URLs whose path portion
+    starts with ``-`` so a hostile provider cannot smuggle a flag through.
+    """
+    with patch("nuguard.sbom.extractor.core.subprocess.run") as run_mock:
+        with pytest.raises(ValueError, match="Invalid repository URL"):
+            AiSbomExtractor._clone_repo(
+                url=hostile_scp_url,
+                ref="main",
+                dest=tmp_path,
+            )
+    assert run_mock.call_count == 0, (
+        "subprocess.run must NOT be invoked for a hostile scp URL"
+    )
 
 
 def test_clone_repo_preserves_ref_in_subprocess(tmp_path: Path) -> None:

--- a/tests/sbom/test_extractor_core.py
+++ b/tests/sbom/test_extractor_core.py
@@ -355,3 +355,91 @@ def test_deployment_generic_adapter_separates_distinct_technologies(tmp_path) ->
     assert "docker" in deployment_names
     assert "vercel" in deployment_names
     assert "generic" not in deployment_names
+
+
+def test_api_endpoint_generic_adapter_separates_distinct_routes(tmp_path) -> None:
+    """A file with several distinct routes not recognized by any framework
+    AST adapter must produce one API_ENDPOINT node per route, not a single
+    'Generic' bucket node that hides which paths exist and merges unrelated
+    evidence (regression: a doc-comment mentioning 'POST /api/chat' was
+    getting merged into the same node as an unrelated '@router.get(' hit)."""
+    source_dir = tmp_path / "sample-app"
+    source_dir.mkdir()
+    (source_dir / "routes.js").write_text(
+        "app.get('/health', handler);\n"
+        "app.post('/webhooks/register', handler);\n",
+        encoding="utf-8",
+    )
+
+    config = AiSbomConfig(include_extensions={".js"}, enable_llm=False, max_files=20)
+    doc = AiSbomExtractor().extract_from_path(source_dir, config)
+
+    endpoint_nodes = [n for n in doc.nodes if n.component_type == ComponentType.API_ENDPOINT]
+    paths = {n.metadata.endpoint for n in endpoint_nodes}
+    assert paths == {"/health", "/webhooks/register"}
+    assert "generic" not in {n.name.lower() for n in endpoint_nodes}
+
+
+def test_api_endpoint_generic_and_fastapi_adapter_merge_same_route(tmp_path) -> None:
+    """The same route detected by both the FastAPI AST adapter (which infers
+    request_body_schema) and the generic regex fallback (evidence-only) must
+    collapse into a single node, keeping the AST-derived schema."""
+    source_dir = tmp_path / "sample-app"
+    source_dir.mkdir()
+    (source_dir / "main.py").write_text(
+        "from fastapi import FastAPI\n"
+        "from pydantic import BaseModel\n\n"
+        "app = FastAPI()\n\n"
+        "class ChatRequest(BaseModel):\n"
+        "    message: str\n\n"
+        "@app.post('/api/chat')\n"
+        "async def chat(body: ChatRequest):\n"
+        "    return {'reply': 'hi'}\n",
+        encoding="utf-8",
+    )
+
+    config = AiSbomConfig(include_extensions={".py"}, enable_llm=False, max_files=20)
+    doc = AiSbomExtractor().extract_from_path(source_dir, config)
+
+    endpoint_nodes = [
+        n
+        for n in doc.nodes
+        if n.component_type == ComponentType.API_ENDPOINT and n.metadata.endpoint == "/api/chat"
+    ]
+    assert len(endpoint_nodes) == 1
+    assert endpoint_nodes[0].metadata.request_body_schema == {"message": "str"}
+
+
+def test_summary_api_endpoints_all_have_matching_nodes(tmp_path) -> None:
+    """Every path nuguard reports in summary.api_endpoints must be backed by
+    an API_ENDPOINT node — otherwise downstream consumers of the node graph
+    (analyze, redteam scenario generation) silently miss routes the summary
+    claims exist."""
+    source_dir = tmp_path / "sample-app"
+    source_dir.mkdir()
+    (source_dir / "main.py").write_text(
+        "from fastapi import FastAPI\n\n"
+        "app = FastAPI()\n\n"
+        "@app.get('/api/health')\n"
+        "async def health():\n"
+        "    return {'status': 'ok'}\n",
+        encoding="utf-8",
+    )
+    (source_dir / "auth_routes.py").write_text(
+        "from fastapi import APIRouter\n\n"
+        "router = APIRouter()\n\n"
+        "@router.post('/api/auth/login')\n"
+        "async def login():\n"
+        "    return {'token': 'x'}\n",
+        encoding="utf-8",
+    )
+
+    config = AiSbomConfig(include_extensions={".py"}, enable_llm=False, max_files=20)
+    doc = AiSbomExtractor().extract_from_path(source_dir, config)
+
+    node_paths = {
+        n.metadata.endpoint for n in doc.nodes if n.component_type == ComponentType.API_ENDPOINT
+    }
+    assert doc.summary is not None
+    for path in doc.summary.api_endpoints:
+        assert path in node_paths, f"{path} in summary.api_endpoints has no matching node"

--- a/tests/sbom/test_llm_client_enrichment.py
+++ b/tests/sbom/test_llm_client_enrichment.py
@@ -1,0 +1,88 @@
+"""Tests for nuguard.sbom.llm_client enrichment helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nuguard.sbom.llm_client import _DESCRIPTION_BATCH_SIZE, enrich_node_descriptions
+from nuguard.sbom.models import ComponentType, Node, NodeMetadata
+
+
+class _FakeLLMClient:
+    """Records prompts and returns a canned structured JSON response per call."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.prompts: list[str] = []
+
+    async def complete(self, prompt: str, system: str) -> str:
+        self.call_count += 1
+        self.prompts.append(prompt)
+        start = prompt.find("[")
+        end = prompt.rfind("]") + 1
+        items = json.loads(prompt[start:end])
+        return json.dumps({item["id"]: f"Description for {item['name']}" for item in items})
+
+
+def _make_tool_node(name: str) -> Node:
+    return Node(
+        name=name,
+        component_type=ComponentType.TOOL,
+        confidence=0.8,
+        metadata=NodeMetadata(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrich_node_descriptions_batches_instead_of_one_call_per_node() -> None:
+    nodes = [_make_tool_node(f"Tool {i}") for i in range(60)]
+    client = _FakeLLMClient()
+
+    await enrich_node_descriptions(nodes, client)
+
+    # 60 nodes at batch size _DESCRIPTION_BATCH_SIZE should take a handful of
+    # calls, never one call per node.
+    expected_batches = -(-60 // _DESCRIPTION_BATCH_SIZE)  # ceil division
+    assert client.call_count == expected_batches
+    assert client.call_count < len(nodes)
+    for node in nodes:
+        assert node.metadata.description == f"Description for {node.name}"
+
+
+@pytest.mark.asyncio
+async def test_enrich_node_descriptions_skips_nodes_with_existing_description() -> None:
+    described = _make_tool_node("Already Described")
+    described.metadata.description = "This tool already has a sufficiently long description."
+    undescribed = _make_tool_node("Needs Description")
+    client = _FakeLLMClient()
+
+    await enrich_node_descriptions([described, undescribed], client)
+
+    assert client.call_count == 1
+    assert described.metadata.description == "This tool already has a sufficiently long description."
+    assert undescribed.metadata.description == "Description for Needs Description"
+
+
+@pytest.mark.asyncio
+async def test_enrich_node_descriptions_ignores_non_agent_tool_nodes() -> None:
+    other = Node(
+        name="Some Model",
+        component_type=ComponentType.MODEL,
+        confidence=0.8,
+        metadata=NodeMetadata(),
+    )
+    client = _FakeLLMClient()
+
+    await enrich_node_descriptions([other], client)
+
+    assert client.call_count == 0
+    assert other.metadata.description in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_enrich_node_descriptions_no_targets_makes_no_calls() -> None:
+    client = _FakeLLMClient()
+    await enrich_node_descriptions([], client)
+    assert client.call_count == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -342,6 +342,35 @@ class TestSharedTargetBlock:
         """)
         assert flat["target_endpoint"] == "/api/redteam"
 
+    def test_redteam_endpoint_alias_overrides_shared_endpoint(self) -> None:
+        """The shared ``target:`` block accepts both ``endpoint:`` and
+        ``target_endpoint:`` as aliases for the same field. The redteam
+        override block must accept the same alias so users who write
+        ``redteam.endpoint:`` (the canonical form documented in
+        nuguard.yaml.example line 47) actually see their override take
+        effect. Previously the alias was silently ignored."""
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              endpoint: /api/chat
+            redteam:
+              endpoint: /api/redteam
+        """)
+        assert flat["target_endpoint"] == "/api/redteam"
+
+    def test_behavior_endpoint_alias_overrides_shared_endpoint(self) -> None:
+        """Same contract for the behavior override block: ``behavior.endpoint:``
+        must override the shared ``target.endpoint:`` value, mirroring the
+        alias-pair behavior the shared block already provides."""
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              endpoint: /api/chat
+            behavior:
+              endpoint: /api/behavior
+        """)
+        assert flat["behavior_config"]["target_endpoint"] == "/api/behavior"
+
     def test_shared_chat_payload_key_propagates(self) -> None:
         flat = _flatten("""
             target:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -371,6 +371,67 @@ class TestSharedTargetBlock:
         """)
         assert flat["behavior_config"]["target_endpoint"] == "/api/behavior"
 
+    def test_redteam_endpoint_wins_over_target_endpoint_when_both_set(self) -> None:
+        """Precedence mirrors the shared ``target:`` block: ``endpoint`` wins
+        over ``target_endpoint`` when both keys are set in the same block.
+
+        Reviewer nit on PR #257: the previous override block used the
+        inverted order (``target_endpoint`` wins), which was inconsistent
+        with the shared block. When a user explicitly sets both keys,
+        ``endpoint`` (the canonical form documented in nuguard.yaml.example)
+        must take precedence.
+        """
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              endpoint: /api/chat
+            redteam:
+              endpoint: /api/redteam-canonical
+              target_endpoint: /api/redteam-alias
+        """)
+        assert flat["target_endpoint"] == "/api/redteam-canonical"
+
+    def test_behavior_endpoint_wins_over_target_endpoint_when_both_set(self) -> None:
+        """Same precedence contract for the behavior override block: when
+        both ``behavior.endpoint`` and ``behavior.target_endpoint`` are set,
+        ``endpoint`` (canonical) wins. Mirrors the shared ``target:`` block.
+        """
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              endpoint: /api/chat
+            behavior:
+              endpoint: /api/behavior-canonical
+              target_endpoint: /api/behavior-alias
+        """)
+        assert flat["behavior_config"]["target_endpoint"] == "/api/behavior-canonical"
+
+    def test_redteam_target_endpoint_used_when_endpoint_absent(self) -> None:
+        """The long-form ``target_endpoint:`` still works as an alias when
+        ``endpoint:`` is absent — we only flipped the precedence when both
+        are present, not the alias resolution itself.
+        """
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+            redteam:
+              target_endpoint: /api/redteam-long
+        """)
+        assert flat["target_endpoint"] == "/api/redteam-long"
+
+    def test_behavior_target_endpoint_used_when_endpoint_absent(self) -> None:
+        """Long-form ``behavior.target_endpoint:`` still wins the shared
+        ``target.endpoint:`` value when ``behavior.endpoint:`` is absent.
+        """
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              endpoint: /api/chat
+            behavior:
+              target_endpoint: /api/behavior-long
+        """)
+        assert flat["behavior_config"]["target_endpoint"] == "/api/behavior-long"
+
     def test_shared_chat_payload_key_propagates(self) -> None:
         flat = _flatten("""
             target:

--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ wheels = [
 
 [[package]]
 name = "nuguard"
-version = "0.8.8"
+version = "0.8.9"
 source = { editable = "." }
 dependencies = [
     { name = "cyclonedx-bom" },

--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ wheels = [
 
 [[package]]
 name = "nuguard"
-version = "0.8.9"
+version = "0.8.10"
 source = { editable = "." }
 dependencies = [
     { name = "cyclonedx-bom" },


### PR DESCRIPTION
This pull request introduces version 0.8.10 of NuGuard, adding a new high-severity structural rule (NGA-021) for detecting IDOR-prone API endpoints without authorization checks, updating documentation and tests accordingly, and ensuring SBOM topology enrichment is always run for compatibility. It also includes minor workflow and CLI improvements and marks a deprecated CLI subcommand as hidden.

**Security rule enhancements:**

* Added new rule NGA-021: Detects API endpoints with user/tenant-scoped path parameters (IDOR surface) that lack authorization or guardrail protection, with corresponding logic, metadata, and comprehensive tests. [[1]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R25-R27) [[2]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1501-R1541) [[3]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1565) [[4]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1690-R1695) [[5]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1878-R1883) [[6]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dR39) [[7]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dR949-R1029) [[8]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dL572-R609)
* Updated NGA-006 to also trigger when `auth_required` is explicitly set to `False`, with new tests for this case. [[1]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R642) [[2]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dR511-R540)

**SBOM and enrichment improvements:**

* Ensured that SBOM topology enrichment is always (re-)run before analysis or behavioral validation to support legacy SBOMs that may lack enrichment. [[1]](diffhunk://#diff-96f1441412ca8271bc34c4351a40bc3dc02bdf724b613ed130b744893d749643R192-R195) [[2]](diffhunk://#diff-28c2a02a6dce24e61e1c55a5123ae7c1f33f6a701d59b53f107aa7a2c1b22d0bR205-R209)

**Documentation and versioning:**

* Updated all version numbers and documentation references from 0.8.8 to 0.8.10, and revised help text to reflect 21 NGA rules instead of 18. [[1]](diffhunk://#diff-037fda53525563fb89230704794a06db1150204ca28ce80697a637121c3ed3f9L4-R4) [[2]](diffhunk://#diff-3e0472dd4c66bdfb357315f1cd94143bd45cd98f56f6242acb1214852c7d2d99L3-R3) [[3]](diffhunk://#diff-94fae5d8ff3f60da82a6c956edac23d2177b136bc2d04e41a3aece5fe5ffe3e2L9-R17) [[4]](diffhunk://#diff-e214773068dff0c46c847729a9684734cd08ca2574113d5a2c8b48f1818d9933L3-R3) [[5]](diffhunk://#diff-74678538ffe765c025e9042091e6803e4121efaa7598958e22c43852061844c0L3-R3) [[6]](diffhunk://#diff-96f1441412ca8271bc34c4351a40bc3dc02bdf724b613ed130b744893d749643L113-R113) [[7]](diffhunk://#diff-96f1441412ca8271bc34c4351a40bc3dc02bdf724b613ed130b744893d749643L644-R648) [[8]](diffhunk://#diff-1c5030eda176ab38ef251a9b427e4b646bbf97d373cffcf15adce0c7635f4e09L304-R304)

**Workflow and CLI improvements:**

* Improved the GitHub workflow for requiring linked issues by parsing PR bodies for closing keywords, ensuring checks work for all branches.
* Marked the `policy show` CLI subcommand as hidden and deprecated, providing a clearer message for users and automation scripts.
This pull request introduces version 0.8.10 of NuGuard, adding a new high-severity structural rule (NGA-021) for detecting IDOR-prone API endpoints without authorization checks, updating documentation and tests accordingly, and ensuring SBOM topology enrichment is always run for compatibility. It also includes minor workflow and CLI improvements and marks a deprecated CLI subcommand as hidden.

**Security rule enhancements:**

* Added new rule NGA-021: Detects API endpoints with user/tenant-scoped path parameters (IDOR surface) that lack authorization or guardrail protection, with corresponding logic, metadata, and comprehensive tests. [[1]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R25-R27) [[2]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1501-R1541) [[3]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1565) [[4]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1690-R1695) [[5]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R1878-R1883) [[6]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dR39) [[7]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dR949-R1029) [[8]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dL572-R609)
* Updated NGA-006 to also trigger when `auth_required` is explicitly set to `False`, with new tests for this case. [[1]](diffhunk://#diff-9a9c8e7923a0c26ffa74874dafc9b00e76be3efd3a2c105a1bcb738b0942ade2R642) [[2]](diffhunk://#diff-0e9e25d535855cc269adf4d87d16197af70eb5c514b93a6f19f8b87cd8f55d5dR511-R540)

**SBOM and enrichment improvements:**

* Ensured that SBOM topology enrichment is always (re-)run before analysis or behavioral validation to support legacy SBOMs that may lack enrichment. [[1]](diffhunk://#diff-96f1441412ca8271bc34c4351a40bc3dc02bdf724b613ed130b744893d749643R192-R195) [[2]](diffhunk://#diff-28c2a02a6dce24e61e1c55a5123ae7c1f33f6a701d59b53f107aa7a2c1b22d0bR205-R209)

**Documentation and versioning:**

* Updated all version numbers and documentation references from 0.8.8 to 0.8.10, and revised help text to reflect 21 NGA rules instead of 18. [[1]](diffhunk://#diff-037fda53525563fb89230704794a06db1150204ca28ce80697a637121c3ed3f9L4-R4) [[2]](diffhunk://#diff-3e0472dd4c66bdfb357315f1cd94143bd45cd98f56f6242acb1214852c7d2d99L3-R3) [[3]](diffhunk://#diff-94fae5d8ff3f60da82a6c956edac23d2177b136bc2d04e41a3aece5fe5ffe3e2L9-R17) [[4]](diffhunk://#diff-e214773068dff0c46c847729a9684734cd08ca2574113d5a2c8b48f1818d9933L3-R3) [[5]](diffhunk://#diff-74678538ffe765c025e9042091e6803e4121efaa7598958e22c43852061844c0L3-R3) [[6]](diffhunk://#diff-96f1441412ca8271bc34c4351a40bc3dc02bdf724b613ed130b744893d749643L113-R113) [[7]](diffhunk://#diff-96f1441412ca8271bc34c4351a40bc3dc02bdf724b613ed130b744893d749643L644-R648) [[8]](diffhunk://#diff-1c5030eda176ab38ef251a9b427e4b646bbf97d373cffcf15adce0c7635f4e09L304-R304)

**Workflow and CLI improvements:**

* Improved the GitHub workflow for requiring linked issues by parsing PR bodies for closing keywords, ensuring checks work for all branches.
* Marked the `policy show` CLI subcommand as hidden and deprecated, providing a clearer message for users and automation scripts.