### PR TITLE
fix(cli): resolve remaining PR #271 conflict (mkdir before redteam output write)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev --extra mcp
 
+      # Semgrep is an optional runtime scanner dependency, but Go rule-behaviour
+      # tests need the executable. Pin the version used for local validation so
+      # CI does not silently drift onto an incompatible Semgrep release.
+      - name: Install Semgrep for rule-behaviour tests
+        run: uv pip install "semgrep==1.172.0"
+
       - name: Run package unit tests
         run: uv run pytest nuguard/ -q
 

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -25,6 +25,36 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // GitHub only populates closingIssuesReferences (below) when the PR targets the
+            // repo's default branch — that field mirrors the auto-close-on-merge relationship,
+            // which GitHub disables for non-default-branch PRs. So a develop-targeted PR with
+            // a correct "Closes #123" in its body still reports totalCount: 0. Parse the body
+            // for closing keywords ourselves first, so the check works regardless of base
+            // branch; keep the GraphQL query as a fallback for issues linked manually via the
+            // PR's Development panel (no keyword in the body) on default-branch PRs.
+            const CLOSING_KEYWORDS = "close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved";
+            const KEYWORD_RE = new RegExp(`\\b(?:${CLOSING_KEYWORDS})\\s+#(\\d+)`, "gi");
+
+            const body = context.payload.pull_request.body || "";
+            const referenced = new Set();
+            let match;
+            while ((match = KEYWORD_RE.exec(body)) !== null) {
+              referenced.add(parseInt(match[1], 10));
+            }
+
+            for (const num of referenced) {
+              try {
+                await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                return; // found a real issue referenced with a closing keyword — done
+              } catch (e) {
+                // Not a real issue (or was deleted) — keep checking any other referenced numbers.
+              }
+            }
+
             const query = `
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -173,7 +173,9 @@ rules:
       nuguard_rule: NGA-008
 
   # -------------------------------------------------------------------------
-  # Go AI/LLM security rules (issue #180)
+  # Go AI/LLM security rules (issues #180 / #223)
+  # #223 adds qualified official non-streaming SDK sinks; TLS / credential
+  # option flows remain unchanged (WithHTTPClient follow-up).
   # -------------------------------------------------------------------------
 
   - id: nuguard-go-llm-prompt-injection-sprintf
@@ -184,6 +186,8 @@ rules:
     # Trusted literals/constants/config fields are not USER sources, so
     # trusted fmt.Sprintf -> LLM is not reported. Direct string-param -> LLM
     # (no sprintf) keeps only USER and therefore does not match.
+    # Issue #223: qualified official sinks (never bare New); Bedrock uses
+    # Converse/InvokeModel with optional trailing optFns (...).
     pattern-sources:
       - label: USER
         patterns:
@@ -216,6 +220,24 @@ rules:
           - metavariable-regex:
               metavariable: $METHOD
               regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Responses.New($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Messages.New($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Converse($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
     message: >
       Potential prompt injection: untrusted string input is interpolated into an
       LLM prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
@@ -406,6 +428,726 @@ rules:
               $CTX, $_ = context.WithDeadline($CTX, ...)
               ...
               $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: $CLIENT.Chat.Completions.New(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Responses.New(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Messages.New(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Converse(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.InvokeModel(context.Background(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Models.GenerateContent(context.Background(), $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: $CLIENT.Chat.Completions.New(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Responses.New(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Messages.New(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Converse(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.InvokeModel(context.TODO(), $REQ, ...)
+      - patterns:
+          - pattern: $CLIENT.Models.GenerateContent(context.TODO(), $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Responses.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Messages.New($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Converse($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.InvokeModel($CTX, $REQ, ...)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
     message: >
       AI/LLM request uses an unbounded root context (context.Background or
       context.TODO) with no timeout or deadline. Unbounded LLM calls can hang

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -178,19 +178,42 @@ rules:
 
   - id: nuguard-go-llm-prompt-injection-sprintf
     mode: taint
+    # Issue #180 scope: untrusted string input must flow through fmt.Sprintf
+    # before reaching an LLM sink. USER-labeled sources alone are not enough;
+    # sinks require the FORMATTED label produced only by sprintf propagators.
+    # Trusted literals/constants/config fields are not USER sources, so
+    # trusted fmt.Sprintf -> LLM is not reported. Direct string-param -> LLM
+    # (no sprintf) keeps only USER and therefore does not match.
     pattern-sources:
-      - patterns:
-          - pattern: fmt.Sprintf($FMT, ..., $INPUT, ...)
-          - pattern-not: fmt.Sprintf($FMT)
+      - label: USER
+        patterns:
+          - pattern: |
+              func $FN(..., $INPUT string, ...) {
+                ...
+              }
+          - focus-metavariable: $INPUT
+    pattern-propagators:
+      - pattern: $TO = fmt.Sprintf(..., $FROM, ...)
+        from: $FROM
+        to: $TO
+        label: FORMATTED
+        requires: USER
+      - pattern: fmt.Sprintf(..., $FROM, ...)
+        from: $FROM
+        to: $FROM
+        label: FORMATTED
+        requires: USER
+        by-side-effect: false
     pattern-sinks:
-      - patterns:
+      - requires: FORMATTED
+        patterns:
           - pattern: $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
               regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
     message: >
-      Potential prompt injection: dynamic input is interpolated into an LLM
-      prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
+      Potential prompt injection: untrusted string input is interpolated into an
+      LLM prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
       sanitize untrusted input before including it in prompts, or use a
       parameterised template approach.
     languages: [go]
@@ -214,21 +237,18 @@ rules:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.AuthToken = os.Getenv(...)
-          - pattern-not: $CFG.AuthToken = os.LookupEnv(...)
       - patterns:
           - pattern: $CFG.APIKey = $KEY
           - metavariable-regex:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.APIKey = os.Getenv(...)
-          - pattern-not: $CFG.APIKey = os.LookupEnv(...)
       - patterns:
           - pattern: $CFG.ApiKey = $KEY
           - metavariable-regex:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.ApiKey = os.Getenv(...)
-          - pattern-not: $CFG.ApiKey = os.LookupEnv(...)
     message: >
       Hardcoded AI service API key or auth token detected. Store secrets in
       environment variables or a secrets manager. Never commit API keys to
@@ -306,6 +326,9 @@ rules:
       owasp: "LLM04: Model Denial of Service"
 
   - id: nuguard-go-llm-insecure-tls
+    # Match both value-form constructors (e.g. go-openai NewClientWithConfig(cfg))
+    # and pointer-deref forms (NewClientWithConfig(*cfg)) used by some providers.
+    # Passing a pointer config variable without dereference is covered by $CFG.
     pattern-either:
       - patterns:
           - pattern: |
@@ -323,7 +346,51 @@ rules:
                 ...
                 $CFG.HTTPClient = $HTTP
                 ...
+                $CLIENT := $NEW(..., $CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $TRANSPORT := &http.Transport{
+                  TLSClientConfig: &tls.Config{
+                    InsecureSkipVerify: true,
+                  },
+                }
+                ...
+                $HTTP := &http.Client{
+                  Transport: $TRANSPORT,
+                }
+                ...
+                $CFG.HTTPClient = $HTTP
+                ...
                 $CLIENT := $NEW(..., *$CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $CFG.HTTPClient = &http.Client{
+                  Transport: &http.Transport{
+                    TLSClientConfig: &tls.Config{
+                      InsecureSkipVerify: true,
+                    },
+                  },
+                }
+                ...
+                $CLIENT := $NEW(..., $CFG, ...)
                 ...
                 $CLIENT.$METHOD($CTX, $REQ)
                 ...

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -198,6 +198,11 @@ rules:
         to: $TO
         label: FORMATTED
         requires: USER
+      - pattern: $TO := fmt.Sprintf(..., $FROM, ...)
+        from: $FROM
+        to: $TO
+        label: FORMATTED
+        requires: USER
       - pattern: fmt.Sprintf(..., $FROM, ...)
         from: $FROM
         to: $FROM
@@ -290,7 +295,19 @@ rules:
           - pattern-not: |
               $CTX := context.Background()
               ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
               $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
               ...
               $CLIENT.$METHOD($CTX, $REQ)
       - patterns:
@@ -310,7 +327,83 @@ rules:
           - pattern-not: |
               $CTX := context.TODO()
               ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
               $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: |
+              $CTX = context.Background()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.Background()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: |
+              $CTX = context.TODO()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX = context.TODO()
+              ...
+              $CTX, $_ = context.WithDeadline($CTX, ...)
               ...
               $CLIENT.$METHOD($CTX, $REQ)
     message: >
@@ -418,15 +511,6 @@ rules:
           - metavariable-regex:
               metavariable: $METHOD
               regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
-    pattern-not:
-      - pattern: |
-          $CFG.HTTPClient = &http.Client{
-            Transport: &http.Transport{
-              TLSClientConfig: &tls.Config{
-                InsecureSkipVerify: false,
-              },
-            },
-          }
     message: >
       HTTP client TLS configuration disables certificate verification
       (InsecureSkipVerify: true) on an HTTP client assigned to a config that is

--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -1,7 +1,7 @@
 rules:
   # -------------------------------------------------------------------------
   # NuGuard AI Security Semgrep Rules
-  # Detects common AI/LLM application security anti-patterns in Python code.
+  # Detects common AI/LLM application security anti-patterns in Python and Go.
   # -------------------------------------------------------------------------
 
   - id: nuguard-llm-prompt-injection-fstring
@@ -57,12 +57,13 @@ rules:
       nuguard_rule: NGA-003
 
   - id: nuguard-openai-key-in-code
-    pattern: |
-      openai.api_key = $LITERAL
-    pattern-not: |
-      openai.api_key = os.environ[...]
-    pattern-not: |
-      openai.api_key = os.getenv(...)
+    patterns:
+      - pattern: |
+          openai.api_key = $LITERAL
+      - pattern-not: |
+          openai.api_key = os.environ[...]
+      - pattern-not: |
+          openai.api_key = os.getenv(...)
     message: >
       OpenAI API key set to a literal value rather than an environment variable.
       Use `os.environ["OPENAI_API_KEY"]` or a secrets manager.
@@ -170,3 +171,204 @@ rules:
       technology: [ml, pytorch, scikit-learn]
       owasp: "A08: Software and Data Integrity Failures"
       nuguard_rule: NGA-008
+
+  # -------------------------------------------------------------------------
+  # Go AI/LLM security rules (issue #180)
+  # -------------------------------------------------------------------------
+
+  - id: nuguard-go-llm-prompt-injection-sprintf
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: fmt.Sprintf($FMT, ..., $INPUT, ...)
+          - pattern-not: fmt.Sprintf($FMT)
+    pattern-sinks:
+      - patterns:
+          - pattern: $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+    message: >
+      Potential prompt injection: dynamic input is interpolated into an LLM
+      prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
+      sanitize untrusted input before including it in prompts, or use a
+      parameterised template approach.
+    languages: [go]
+    severity: WARNING
+    metadata:
+      category: security
+      technology: [go, llm]
+      owasp: "LLM01: Prompt Injection"
+      nuguard_rule: NGA-002
+
+  - id: nuguard-go-hardcoded-api-key
+    pattern-either:
+      - patterns:
+          - pattern: openai.DefaultConfig($KEY)
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+      - patterns:
+          - pattern: $CFG.AuthToken = $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+          - pattern-not: $CFG.AuthToken = os.Getenv(...)
+          - pattern-not: $CFG.AuthToken = os.LookupEnv(...)
+      - patterns:
+          - pattern: $CFG.APIKey = $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+          - pattern-not: $CFG.APIKey = os.Getenv(...)
+          - pattern-not: $CFG.APIKey = os.LookupEnv(...)
+      - patterns:
+          - pattern: $CFG.ApiKey = $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
+          - pattern-not: $CFG.ApiKey = os.Getenv(...)
+          - pattern-not: $CFG.ApiKey = os.LookupEnv(...)
+    message: >
+      Hardcoded AI service API key or auth token detected. Store secrets in
+      environment variables or a secrets manager. Never commit API keys to
+      source control.
+    languages: [go]
+    severity: ERROR
+    metadata:
+      category: security
+      technology: [go, llm]
+      owasp: "A02: Cryptographic Failures"
+      nuguard_rule: NGA-003
+
+  - id: nuguard-go-llm-missing-context-timeout
+    pattern-either:
+      - patterns:
+          - pattern: $CLIENT.$METHOD(context.Background(), $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: $CLIENT.$METHOD(context.TODO(), $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              $CTX := context.Background()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.Background()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+      - patterns:
+          - pattern: |
+              $CTX := context.TODO()
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithTimeout($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+          - pattern-not: |
+              $CTX := context.TODO()
+              ...
+              $CTX, $_ := context.WithDeadline($CTX, ...)
+              ...
+              $CLIENT.$METHOD($CTX, $REQ)
+    message: >
+      AI/LLM request uses an unbounded root context (context.Background or
+      context.TODO) with no timeout or deadline. Unbounded LLM calls can hang
+      indefinitely and enable denial-of-service. Wrap the context with
+      context.WithTimeout or context.WithDeadline before calling the LLM API.
+    languages: [go]
+    severity: WARNING
+    metadata:
+      category: security
+      technology: [go, llm]
+      owasp: "LLM04: Model Denial of Service"
+
+  - id: nuguard-go-llm-insecure-tls
+    pattern-either:
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $TRANSPORT := &http.Transport{
+                  TLSClientConfig: &tls.Config{
+                    InsecureSkipVerify: true,
+                  },
+                }
+                ...
+                $HTTP := &http.Client{
+                  Transport: $TRANSPORT,
+                }
+                ...
+                $CFG.HTTPClient = $HTTP
+                ...
+                $CLIENT := $NEW(..., *$CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $CFG.HTTPClient = &http.Client{
+                  Transport: &http.Transport{
+                    TLSClientConfig: &tls.Config{
+                      InsecureSkipVerify: true,
+                    },
+                  },
+                }
+                ...
+                $CLIENT := $NEW(..., *$CFG, ...)
+                ...
+                $CLIENT.$METHOD($CTX, $REQ)
+                ...
+              }
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+    pattern-not:
+      - pattern: |
+          $CFG.HTTPClient = &http.Client{
+            Transport: &http.Transport{
+              TLSClientConfig: &tls.Config{
+                InsecureSkipVerify: false,
+              },
+            },
+          }
+    message: >
+      HTTP client TLS configuration disables certificate verification
+      (InsecureSkipVerify: true) on an HTTP client assigned to a config that is
+      then used to construct the AI/LLM client for an API call. This enables
+      man-in-the-middle attacks against LLM API traffic. Use the default TLS
+      settings or pin trusted certificates.
+    languages: [go]
+    severity: ERROR
+    metadata:
+      category: security
+      technology: [go, llm, tls]
+      owasp: "A02: Cryptographic Failures"

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
@@ -1,0 +1,33 @@
+# Go provider Semgrep sample attribution
+
+Minimal, independently written regression fixtures for NuGuard's bundled Go
+AI-security Semgrep rules. They are inspired by / based on the API and
+configuration patterns documented in the linked provider sources. They are
+**not** full applications.
+
+No upstream application or source file is vendored wholesale. Linked upstream
+projects and docs retain their own applicable licenses.
+
+Official first-party SDK call shapes that do not match today's sink allowlist
+(for example `Chat.Completions.New`, Bedrock `Converse`, Anthropic
+`Messages.New`, or multi-arg `Models.GenerateContent`) are intentionally **not**
+exercised here. That work is tracked separately in issue **#223**
+("Extend Go AI security rules for official provider SDK patterns").
+
+Thin local compatibility wrappers exist only to exercise today's NuGuard sink
+allowlist (`CreateChatCompletion`, `CreateMessage`, `GenerateContent`,
+`SendMessage`, …). Official SDK call-shape support remains #223.
+
+| Provider | Patterns documented in | Fixture notes |
+|----------|------------------------|---------------|
+| OpenAI | [openai-go](https://github.com/openai/openai-go); community [go-openai](https://github.com/sashabaranov/go-openai) | Independently written sample using `CreateChatCompletion` / `DefaultConfig` shapes compatible with current rules. Official `Chat.Completions.New` coverage is #223. |
+| Azure | Azure OpenAI + [go-openai Azure config](https://github.com/sashabaranov/go-openai#azure-openai-chatgpt) docs | Independently written sample using Azure-style `DefaultAzureConfig` / `NewClientWithConfig` with an insecure TLS HTTP client. Official Azure/`openai-go` sinks are #223. |
+| AWS | [AWS SDK for Go v2 Bedrock Runtime examples](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/go_bedrock-runtime_code_examples.html) | Independently written sample; Bedrock Runtime import for flavour; LLM sink is a local `SendMessage(ctx, req)` wrapper because `Converse` / `InvokeModel` are #223. |
+| GCP | [google.golang.org/genai](https://pkg.go.dev/google.golang.org/genai) / Gemini Go docs | Independently written sample using `APIKey` + a two-arg local `GenerateContent(ctx, req)` wrapper; official multi-arg `Models.GenerateContent` is #223. |
+| Claude | [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) docs | Independently written sample using `AuthToken` + a local `CreateMessage(ctx, req)` wrapper; official `Messages.New` is #223. |
+
+LangGraph is intentionally omitted from this pack (no official LangGraph Go SDK;
+handled separately from this follow-up).
+
+All credentials in these fixtures are synthetic placeholders (`sk-…`, `AIza…`)
+and must never be treated as real secrets.

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/ATTRIBUTION.md
@@ -8,23 +8,29 @@ configuration patterns documented in the linked provider sources. They are
 No upstream application or source file is vendored wholesale. Linked upstream
 projects and docs retain their own applicable licenses.
 
-Official first-party SDK call shapes that do not match today's sink allowlist
-(for example `Chat.Completions.New`, Bedrock `Converse`, Anthropic
-`Messages.New`, or multi-arg `Models.GenerateContent`) are intentionally **not**
-exercised here. That work is tracked separately in issue **#223**
-("Extend Go AI security rules for official provider SDK patterns").
+Each provider directory includes:
 
-Thin local compatibility wrappers exist only to exercise today's NuGuard sink
-allowlist (`CreateChatCompletion`, `CreateMessage`, `GenerateContent`,
-`SendMessage`, …). Official SDK call-shape support remains #223.
+- `vulnerable.go` — community / provider-neutral compatibility shapes that
+  exercise today's baseline sink allowlist (`CreateChatCompletion`,
+  `CreateMessage`, local two-arg `GenerateContent`, `SendMessage`, …), from
+  PR #224. Azure TLS coverage remains on this community `CFG.HTTPClient` path.
+- `official_vulnerable.go` — independently written structural samples of the
+  official non-streaming SDK call shapes added in issue **#223**
+  (`Chat.Completions.New`, `Responses.New`, Bedrock `Converse` /
+  `InvokeModel` including optional trailing optFns, Anthropic `Messages.New`,
+  multi-arg `Models.GenerateContent`). Azure is covered via OpenAI-compatible
+  nested New call shapes only (not official TLS).
+
+Streaming APIs, credential-option patterns (`option.WithAPIKey`, …), and
+official `option.WithHTTPClient` TLS flows remain out of scope.
 
 | Provider | Patterns documented in | Fixture notes |
 |----------|------------------------|---------------|
-| OpenAI | [openai-go](https://github.com/openai/openai-go); community [go-openai](https://github.com/sashabaranov/go-openai) | Independently written sample using `CreateChatCompletion` / `DefaultConfig` shapes compatible with current rules. Official `Chat.Completions.New` coverage is #223. |
-| Azure | Azure OpenAI + [go-openai Azure config](https://github.com/sashabaranov/go-openai#azure-openai-chatgpt) docs | Independently written sample using Azure-style `DefaultAzureConfig` / `NewClientWithConfig` with an insecure TLS HTTP client. Official Azure/`openai-go` sinks are #223. |
-| AWS | [AWS SDK for Go v2 Bedrock Runtime examples](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/go_bedrock-runtime_code_examples.html) | Independently written sample; Bedrock Runtime import for flavour; LLM sink is a local `SendMessage(ctx, req)` wrapper because `Converse` / `InvokeModel` are #223. |
-| GCP | [google.golang.org/genai](https://pkg.go.dev/google.golang.org/genai) / Gemini Go docs | Independently written sample using `APIKey` + a two-arg local `GenerateContent(ctx, req)` wrapper; official multi-arg `Models.GenerateContent` is #223. |
-| Claude | [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) docs | Independently written sample using `AuthToken` + a local `CreateMessage(ctx, req)` wrapper; official `Messages.New` is #223. |
+| OpenAI | [openai-go](https://github.com/openai/openai-go); community [go-openai](https://github.com/sashabaranov/go-openai) | `vulnerable.go`: `CreateChatCompletion` / `DefaultConfig`. `official_vulnerable.go`: `Chat.Completions.New` / `Responses.New`. |
+| Azure | Azure OpenAI + [go-openai Azure config](https://github.com/sashabaranov/go-openai#azure-openai-chatgpt) docs | `vulnerable.go`: `DefaultAzureConfig` + insecure TLS + `CreateChatCompletion`. `official_vulnerable.go`: OpenAI-compatible `Chat.Completions.New` / `Responses.New` (no official TLS). |
+| AWS | [AWS SDK for Go v2 Bedrock Runtime examples](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/go_bedrock-runtime_code_examples.html) | `vulnerable.go`: local `SendMessage` wrapper. `official_vulnerable.go`: `Converse` / `InvokeModel` with trailing optFns. |
+| GCP | [google.golang.org/genai](https://pkg.go.dev/google.golang.org/genai) / Gemini Go docs | `vulnerable.go`: two-arg local `GenerateContent`. `official_vulnerable.go`: multi-arg `Models.GenerateContent`. |
+| Claude | [anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go) docs | `vulnerable.go`: local `CreateMessage`. `official_vulnerable.go`: `Messages.New`. |
 
 LangGraph is intentionally omitted from this pack (no official LangGraph Go SDK;
 handled separately from this follow-up).

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/aws/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/aws/official_vulnerable.go
@@ -1,0 +1,31 @@
+// NuGuard minimal official Bedrock Runtime call-shape fixture (issue #223).
+// Independently written structural sample — not vendored upstream source.
+// Includes a trailing optFn argument to exercise variadic sink matching.
+// See ../ATTRIBUTION.md.
+package aws_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type bedrockOfficialClient struct{}
+
+func (bedrockOfficialClient) Converse(ctx context.Context, req any, _ ...any) {}
+
+func (bedrockOfficialClient) InvokeModel(ctx context.Context, req any, _ ...any) {}
+
+// OfficialConverseWithUserPromptAndOptFn exercises Client.Converse with optFns.
+func OfficialConverseWithUserPromptAndOptFn(userInput string) {
+	client := bedrockOfficialClient{}
+	prompt := fmt.Sprintf("Summarize ticket: %s", userInput)
+	optFn := func() {}
+	client.Converse(context.Background(), prompt, optFn)
+}
+
+// OfficialInvokeModelMissingTimeoutWithOptFn exercises Client.InvokeModel with optFns.
+func OfficialInvokeModelMissingTimeoutWithOptFn() {
+	client := bedrockOfficialClient{}
+	optFn := func() {}
+	client.InvokeModel(context.Background(), "hello from aws official sample", optFn)
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/aws/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/aws/vulnerable.go
@@ -1,0 +1,44 @@
+// NuGuard minimal, independently written regression fixture (AWS-flavoured).
+// Inspired by AWS Bedrock Runtime Go v2 API patterns — not a runnable app and
+// not vendored upstream source. Bedrock Runtime import is for flavour only;
+// local SendMessage(ctx, req) wrapper exercises today's sink allowlist.
+// Converse/InvokeModel support is #223. See ../ATTRIBUTION.md.
+package aws_sample
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+)
+
+// bedrockChatRequest is a minimal stand-in for a chat request body.
+type bedrockChatRequest struct {
+	Prompt string
+}
+
+// bedrockCompatClient wraps Bedrock Runtime with a rule-compatible sink method.
+// Official Client.Converse / InvokeModel matching is issue #223.
+type bedrockCompatClient struct {
+	runtime *bedrockruntime.Client
+}
+
+func newBedrockCompatClient(runtime *bedrockruntime.Client) *bedrockCompatClient {
+	return &bedrockCompatClient{runtime: runtime}
+}
+
+// SendMessage is a compatibility sink matching the current Go Semgrep allowlist.
+func (c *bedrockCompatClient) SendMessage(ctx context.Context, req bedrockChatRequest) {
+	_ = c.runtime
+	_ = ctx
+	_ = req
+}
+
+// AskWithUserPrompt formats untrusted input and sends it via the compatibility
+// sink using an unbounded root context.
+func AskWithUserPrompt(userInput string) {
+	// runtime is nil in this offline fixture; Semgrep only needs the call graph.
+	client := newBedrockCompatClient(nil)
+	prompt := fmt.Sprintf("Summarize ticket: %s", userInput)
+	client.SendMessage(context.Background(), bedrockChatRequest{Prompt: prompt})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/azure/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/azure/official_vulnerable.go
@@ -1,0 +1,41 @@
+// NuGuard minimal Azure OpenAI-compatible official call-shape fixture (#223).
+// Independently written structural sample — not vendored upstream source.
+// Exercises Chat.Completions.New / Responses.New only. Official
+// option.WithHTTPClient TLS coverage is intentionally out of scope.
+// See ../ATTRIBUTION.md.
+package azure_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type azureChatCompletions struct{}
+
+func (azureChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+type azureChatService struct {
+	Completions azureChatCompletions
+}
+
+type azureResponsesService struct{}
+
+func (azureResponsesService) New(ctx context.Context, req any, _ ...any) {}
+
+type azureOfficialClient struct {
+	Chat      azureChatService
+	Responses azureResponsesService
+}
+
+// OfficialChatCompletionsWithUserPrompt exercises Chat.Completions.New.
+func OfficialChatCompletionsWithUserPrompt(userInput string) {
+	client := azureOfficialClient{}
+	prompt := fmt.Sprintf("Answer the customer: %s", userInput)
+	client.Chat.Completions.New(context.Background(), prompt)
+}
+
+// OfficialResponsesMissingTimeout exercises Responses.New on an unbounded context.
+func OfficialResponsesMissingTimeout() {
+	client := azureOfficialClient{}
+	client.Responses.New(context.Background(), "hello from azure official sample")
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/azure/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/azure/vulnerable.go
@@ -1,0 +1,37 @@
+// NuGuard minimal, independently written regression fixture (Azure-flavoured).
+// Inspired by Azure OpenAI / go-openai Azure config patterns — not a runnable
+// app and not vendored upstream source. Uses DefaultAzureConfig +
+// CreateChatCompletion shapes for today's sinks; official Azure/openai-go
+// call shapes are #223. See ../ATTRIBUTION.md.
+package azure_sample
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// ChatWithInsecureTLS builds an Azure OpenAI client that disables TLS
+// verification and issues a chat completion on an unbounded context.
+func ChatWithInsecureTLS() {
+	cfg := openai.DefaultAzureConfig(
+		"SYNTHETIC_AZURE_OPENAI_KEY",
+		"https://example.openai.azure.com/",
+	)
+	cfg.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // intentional insecure fixture
+			},
+		},
+	}
+	client := openai.NewClientWithConfig(cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello from azure sample"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/claude/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/claude/official_vulnerable.go
@@ -1,0 +1,24 @@
+// NuGuard minimal official anthropic-sdk-go call-shape fixture (issue #223).
+// Independently written structural sample — not vendored upstream source.
+// See ../ATTRIBUTION.md.
+package claude_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type claudeMessagesService struct{}
+
+func (claudeMessagesService) New(ctx context.Context, req any, _ ...any) {}
+
+type claudeOfficialClient struct {
+	Messages claudeMessagesService
+}
+
+// OfficialMessagesWithUserPrompt exercises Messages.New.
+func OfficialMessagesWithUserPrompt(userInput string) {
+	client := claudeOfficialClient{}
+	prompt := fmt.Sprintf("Discuss: %s", userInput)
+	client.Messages.New(context.Background(), prompt)
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/claude/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/claude/vulnerable.go
@@ -1,0 +1,45 @@
+// NuGuard minimal, independently written regression fixture (Claude-flavoured).
+// Inspired by anthropic-sdk-go API patterns — not a runnable app and not
+// vendored upstream source. Local CreateMessage(ctx, req) wrapper exercises
+// today's sink allowlist; official Messages.New is #223.
+// See ../ATTRIBUTION.md.
+package claude_sample
+
+import (
+	"context"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// claudeMessageRequest is a minimal stand-in for a Messages API request.
+type claudeMessageRequest struct {
+	Prompt string
+}
+
+// claudeCompatClient provides a rule-compatible CreateMessage sink.
+type claudeCompatClient struct {
+	apiKey string
+}
+
+func newClaudeCompatClient(apiKey string) *claudeCompatClient {
+	return &claudeCompatClient{apiKey: apiKey}
+}
+
+// CreateMessage is a compatibility sink matching the current Go Semgrep allowlist.
+func (c *claudeCompatClient) CreateMessage(ctx context.Context, req claudeMessageRequest) {
+	_ = c.apiKey
+	_ = ctx
+	_ = req
+	_ = anthropic.ModelClaudeOpus4_6
+}
+
+// ChatWithHardcodedToken uses a synthetic Anthropic auth token and an
+// unbounded context for a create-message call.
+func ChatWithHardcodedToken() {
+	cfg := struct{ AuthToken string }{}
+	cfg.AuthToken = "sk-SYNTHETIC_CLAUDE_PROVIDER_KEY"
+	client := newClaudeCompatClient(cfg.AuthToken)
+	client.CreateMessage(context.Background(), claudeMessageRequest{
+		Prompt: "hello from claude sample",
+	})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/official_vulnerable.go
@@ -1,0 +1,25 @@
+// NuGuard minimal official google.golang.org/genai call-shape fixture (#223).
+// Independently written structural sample — not vendored upstream source.
+// See ../ATTRIBUTION.md.
+package gcp_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type geminiModelsService struct{}
+
+func (geminiModelsService) GenerateContent(ctx context.Context, model string, contents any, config any, _ ...any) {
+}
+
+type geminiOfficialClient struct {
+	Models geminiModelsService
+}
+
+// OfficialGenerateContentWithUserPrompt exercises Models.GenerateContent.
+func OfficialGenerateContentWithUserPrompt(userInput string) {
+	client := geminiOfficialClient{}
+	prompt := fmt.Sprintf("Summarize: %s", userInput)
+	client.Models.GenerateContent(context.Background(), "gemini-2.0-flash", prompt, nil)
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/gcp/vulnerable.go
@@ -1,0 +1,44 @@
+// NuGuard minimal, independently written regression fixture (GCP-flavoured).
+// Inspired by google.golang.org/genai / Gemini Go API patterns — not a runnable
+// app and not vendored upstream source. Local two-arg GenerateContent(ctx, req)
+// wrapper exercises today's sink allowlist; official multi-arg
+// Models.GenerateContent is #223. See ../ATTRIBUTION.md.
+package gcp_sample
+
+import (
+	"context"
+
+	"google.golang.org/genai"
+)
+
+// geminiRequest is a minimal stand-in for a generate-content request.
+type geminiRequest struct {
+	Prompt string
+}
+
+// geminiCompatClient provides a rule-compatible GenerateContent sink.
+type geminiCompatClient struct {
+	cfg *genai.ClientConfig
+}
+
+func newGeminiCompatClient(cfg *genai.ClientConfig) *geminiCompatClient {
+	return &geminiCompatClient{cfg: cfg}
+}
+
+// GenerateContent is a compatibility sink matching the current Go Semgrep allowlist.
+func (c *geminiCompatClient) GenerateContent(ctx context.Context, req geminiRequest) {
+	_ = c.cfg
+	_ = ctx
+	_ = req
+}
+
+// GenerateWithHardcodedKey uses a synthetic Gemini API key and an unbounded
+// context for a generate-content call.
+func GenerateWithHardcodedKey() {
+	cfg := &genai.ClientConfig{}
+	cfg.APIKey = "AIzaSYNTHETIC_GCP_PROVIDER_KEY"
+	client := newGeminiCompatClient(cfg)
+	client.GenerateContent(context.Background(), geminiRequest{
+		Prompt: "hello from gcp sample",
+	})
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/openai/official_vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/openai/official_vulnerable.go
@@ -1,0 +1,39 @@
+// NuGuard minimal official openai-go call-shape fixture (issue #223).
+// Independently written structural sample — not vendored upstream source.
+// See ../ATTRIBUTION.md.
+package openai_sample
+
+import (
+	"context"
+	"fmt"
+)
+
+type openaiChatCompletions struct{}
+
+func (openaiChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+type openaiChatService struct {
+	Completions openaiChatCompletions
+}
+
+type openaiResponsesService struct{}
+
+func (openaiResponsesService) New(ctx context.Context, req any, _ ...any) {}
+
+type openaiOfficialClient struct {
+	Chat      openaiChatService
+	Responses openaiResponsesService
+}
+
+// OfficialChatCompletionsWithUserPrompt exercises Chat.Completions.New.
+func OfficialChatCompletionsWithUserPrompt(userInput string) {
+	client := openaiOfficialClient{}
+	prompt := fmt.Sprintf("Answer the customer: %s", userInput)
+	client.Chat.Completions.New(context.Background(), prompt)
+}
+
+// OfficialResponsesMissingTimeout exercises Responses.New on an unbounded context.
+func OfficialResponsesMissingTimeout() {
+	client := openaiOfficialClient{}
+	client.Responses.New(context.Background(), "hello from openai official sample")
+}

--- a/nuguard/analysis/tests/fixtures/go_provider_samples/openai/vulnerable.go
+++ b/nuguard/analysis/tests/fixtures/go_provider_samples/openai/vulnerable.go
@@ -1,0 +1,27 @@
+// NuGuard minimal, independently written regression fixture (OpenAI-flavoured).
+// Inspired by go-openai / OpenAI Go API patterns — not a runnable app and not
+// vendored upstream source. Uses CreateChatCompletion / DefaultConfig shapes
+// that match today's sinks; official openai-go Chat.Completions.New is #223.
+// See ../ATTRIBUTION.md.
+package openai_sample
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// ChatWithUserPrompt interpolates untrusted input into a prompt and calls the
+// chat-completion API with an unbounded context and a hardcoded API key.
+func ChatWithUserPrompt(userInput string) {
+	cfg := openai.DefaultConfig("sk-SYNTHETIC_OPENAI_PROVIDER_KEY")
+	client := openai.NewClientWithConfig(cfg)
+	prompt := fmt.Sprintf("Answer the customer: %s", userInput)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
@@ -12,24 +12,34 @@ func (s secretStore) Get(name string) string { return "from-store" }
 
 func HardcodedKeyFromEnv() {
 	cfg := openai.DefaultConfig(os.Getenv("AI_API_TOKEN"))
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = openai.NewClientWithConfig(cfg)
 }
 
 func HardcodedKeyFromLookupEnv() {
-	cfg := openai.DefaultConfig("")
-	cfg.AuthToken = os.LookupEnv("AI_API_TOKEN")
-	_ = openai.NewClientWithConfig(*cfg)
+	token, ok := os.LookupEnv("AI_API_TOKEN")
+	if !ok {
+		return
+	}
+	cfg := providerConfig{}
+	cfg.AuthToken = token
+	_ = cfg
 }
 
 func HardcodedKeyFromSecretStore() {
 	store := secretStore{}
-	cfg := openai.DefaultConfig("")
+	cfg := providerConfig{}
 	cfg.APIKey = store.Get("openai-key")
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = cfg
+}
+
+func HardcodedKeyApiKeyFromEnv() {
+	cfg := providerConfig{}
+	cfg.ApiKey = os.Getenv("AI_API_TOKEN")
+	_ = cfg
 }
 
 func HarmlessStringAssignment() {
 	cfg := openai.DefaultConfig("")
 	cfg.BaseURL = "https://api.example.com/v1"
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = openai.NewClientWithConfig(cfg)
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_negative.go
@@ -1,0 +1,35 @@
+package semgrepfixtures
+
+import (
+	"os"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type secretStore struct{}
+
+func (s secretStore) Get(name string) string { return "from-store" }
+
+func HardcodedKeyFromEnv() {
+	cfg := openai.DefaultConfig(os.Getenv("AI_API_TOKEN"))
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedKeyFromLookupEnv() {
+	cfg := openai.DefaultConfig("")
+	cfg.AuthToken = os.LookupEnv("AI_API_TOKEN")
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedKeyFromSecretStore() {
+	store := secretStore{}
+	cfg := openai.DefaultConfig("")
+	cfg.APIKey = store.Get("openai-key")
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HarmlessStringAssignment() {
+	cfg := openai.DefaultConfig("")
+	cfg.BaseURL = "https://api.example.com/v1"
+	_ = openai.NewClientWithConfig(*cfg)
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
@@ -1,0 +1,22 @@
+package semgrepfixtures
+
+import (
+	"github.com/sashabaranov/go-openai"
+)
+
+func HardcodedOpenAIDefaultConfig() {
+	cfg := openai.DefaultConfig("sk-SYNTHETIC_TEST_KEY_001")
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedAuthTokenAssignment() {
+	cfg := openai.DefaultConfig("")
+	cfg.AuthToken = "sk-SYNTHETIC_TEST_KEY_002"
+	_ = openai.NewClientWithConfig(*cfg)
+}
+
+func HardcodedAPIKeyField() {
+	cfg := openai.DefaultConfig("")
+	cfg.APIKey = "AIzaSYNTHETIC_TEST_KEY_003"
+	_ = openai.NewClientWithConfig(*cfg)
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/hardcoded_key_positive.go
@@ -4,19 +4,33 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+// providerConfig is a minimal local type that preserves provider-neutral
+// credential field names without pretending go-openai.ClientConfig exposes them.
+type providerConfig struct {
+	AuthToken string
+	APIKey    string
+	ApiKey    string
+}
+
 func HardcodedOpenAIDefaultConfig() {
 	cfg := openai.DefaultConfig("sk-SYNTHETIC_TEST_KEY_001")
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = openai.NewClientWithConfig(cfg)
 }
 
 func HardcodedAuthTokenAssignment() {
-	cfg := openai.DefaultConfig("")
+	cfg := providerConfig{}
 	cfg.AuthToken = "sk-SYNTHETIC_TEST_KEY_002"
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = cfg
 }
 
 func HardcodedAPIKeyField() {
-	cfg := openai.DefaultConfig("")
+	cfg := providerConfig{}
 	cfg.APIKey = "AIzaSYNTHETIC_TEST_KEY_003"
-	_ = openai.NewClientWithConfig(*cfg)
+	_ = cfg
+}
+
+func HardcodedApiKeyField() {
+	cfg := providerConfig{}
+	cfg.ApiKey = "sk-SYNTHETIC_TEST_KEY_004"
+	_ = cfg
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
@@ -57,5 +57,5 @@ func UnrelatedHTTPClientField(cfg genericHTTPConfig) {
 	}
 	httpClient := &http.Client{Transport: transport}
 	cfg.HTTPClient = httpClient
-	_ = cfg.HTTPClient.Get("https://example.com")
+	_, _ = cfg.HTTPClient.Get("https://example.com")
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_negative.go
@@ -1,0 +1,61 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type internalConfig struct {
+	HTTPClient *http.Client
+}
+
+func UnrelatedClientsSameFunction(ctx context.Context, llmClient *openai.Client, request openai.ChatCompletionRequest) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	unrelatedHTTP := &http.Client{Transport: transport}
+	internalConfig := internalConfig{}
+	internalConfig.HTTPClient = unrelatedHTTP
+
+	llmClient.CreateChatCompletion(ctx, request)
+}
+
+func SecureTLSExplicitFalse() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: false,
+		},
+	}
+	_ = &http.Client{Transport: transport}
+}
+
+func DefaultSecureTransport() {
+	_ = &http.Client{}
+}
+
+func UnrelatedTLSNoLLMContext() {
+	cfg := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	_ = cfg
+}
+
+type genericHTTPConfig struct {
+	HTTPClient *http.Client
+}
+
+func UnrelatedHTTPClientField(cfg genericHTTPConfig) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	cfg.HTTPClient = httpClient
+	_ = cfg.HTTPClient.Get("https://example.com")
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
@@ -1,0 +1,45 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func InsecureTLSWithLLMClient() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	cfg := openai.DefaultConfig("test-token")
+	cfg.HTTPClient = httpClient
+	client := openai.NewClientWithConfig(*cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func InsecureTLSNestedClientLiteral() {
+	cfg := openai.DefaultConfig("test-token")
+	cfg.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	client := openai.NewClientWithConfig(*cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/insecure_tls_positive.go
@@ -8,6 +8,22 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+// providerHTTPConfig is a minimal local config type used to exercise the
+// pointer-dereference constructor form (*cfg) in a compile-valid way without
+// pretending go-openai's ClientConfig is itself a pointer API.
+type providerHTTPConfig struct {
+	HTTPClient *http.Client
+}
+
+type providerLLMClient struct{}
+
+func newProviderLLMClient(cfg providerHTTPConfig) *providerLLMClient {
+	return &providerLLMClient{}
+}
+
+func (c *providerLLMClient) CreateChatCompletion(ctx context.Context, req openai.ChatCompletionRequest) {
+}
+
 func InsecureTLSWithLLMClient() {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -17,7 +33,7 @@ func InsecureTLSWithLLMClient() {
 	httpClient := &http.Client{Transport: transport}
 	cfg := openai.DefaultConfig("test-token")
 	cfg.HTTPClient = httpClient
-	client := openai.NewClientWithConfig(*cfg)
+	client := openai.NewClientWithConfig(cfg)
 	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
@@ -35,7 +51,25 @@ func InsecureTLSNestedClientLiteral() {
 			},
 		},
 	}
-	client := openai.NewClientWithConfig(*cfg)
+	client := openai.NewClientWithConfig(cfg)
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func InsecureTLSPointerDerefConfig() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	cfg := &providerHTTPConfig{}
+	cfg.HTTPClient = httpClient
+	client := newProviderLLMClient(*cfg)
 	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
@@ -1,0 +1,49 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func BoundedContextWithTimeout() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextWithDeadline() {
+	deadline := time.Now().Add(30 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func NonLLMBackgroundContext(db *sql.DB) {
+	ctx := context.Background()
+	_ = db.QueryContext(ctx, "SELECT 1")
+}
+
+func LLMWithParameterContext(ctx context.Context) {
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
@@ -33,6 +33,184 @@ func BoundedContextWithDeadline() {
 	})
 }
 
+func BoundedContextBackgroundAssignWithTimeout() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	ctx = context.Background()
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextBackgroundAssignWithDeadline() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.Background()
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextTODOAssignWithTimeout() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	ctx = context.TODO()
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextTODOAssignWithDeadline() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.TODO()
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclBackgroundAssignTimeout() {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclTODOAssignTimeout() {
+	ctx := context.TODO()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclBackgroundAssignDeadline() {
+	deadline := time.Now().Add(30 * time.Second)
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextShortDeclTODOAssignDeadline() {
+	deadline := time.Now().Add(30 * time.Second)
+	ctx := context.TODO()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignBackgroundShortDeclTimeout() {
+	var ctx context.Context
+	ctx = context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignTODOShortDeclTimeout() {
+	var ctx context.Context
+	ctx = context.TODO()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignBackgroundShortDeclDeadline() {
+	var ctx context.Context
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.Background()
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func BoundedContextAssignTODOShortDeclDeadline() {
+	var ctx context.Context
+	deadline := time.Now().Add(30 * time.Second)
+	ctx = context.TODO()
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
 func NonLLMBackgroundContext(db *sql.DB) {
 	ctx := context.Background()
 	_, _ = db.QueryContext(ctx, "SELECT 1")

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_negative.go
@@ -35,7 +35,7 @@ func BoundedContextWithDeadline() {
 
 func NonLLMBackgroundContext(db *sql.DB) {
 	ctx := context.Background()
-	_ = db.QueryContext(ctx, "SELECT 1")
+	_, _ = db.QueryContext(ctx, "SELECT 1")
 }
 
 func LLMWithParameterContext(ctx context.Context) {

--- a/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/missing_timeout_positive.go
@@ -1,0 +1,28 @@
+package semgrepfixtures
+
+import (
+	"context"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func MissingTimeoutAssignmentThenCall() {
+	ctx := context.Background()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}
+
+func MissingTimeoutInlineBackground() {
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_negative.go
@@ -1,0 +1,23 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+)
+
+// Bare .New(ctx, ...) must not become an LLM sink (issue #223).
+
+type arbitraryStore struct{}
+
+func (arbitraryStore) New(ctx context.Context, name string, _ ...any) {}
+
+func BareNewNotLLMSink(userInput string) {
+	store := arbitraryStore{}
+	name := fmt.Sprintf("order-%s", userInput)
+	store.New(context.Background(), name)
+}
+
+func BareNewMissingTimeoutNotLLM() {
+	store := arbitraryStore{}
+	store.New(context.Background(), "widget")
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_positive.go
@@ -1,0 +1,91 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+)
+
+// Minimal structural stand-ins for official SDK call shapes (issue #223).
+// Not runnable and not vendored upstream source.
+
+type officialChatCompletions struct{}
+
+func (officialChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+type officialChatService struct {
+	Completions officialChatCompletions
+}
+
+type officialResponsesService struct{}
+
+func (officialResponsesService) New(ctx context.Context, req any, _ ...any) {}
+
+type officialMessagesService struct{}
+
+func (officialMessagesService) New(ctx context.Context, req any, _ ...any) {}
+
+type officialModelsService struct{}
+
+func (officialModelsService) GenerateContent(ctx context.Context, model string, contents any, config any, _ ...any) {
+}
+
+type officialOpenAIClient struct {
+	Chat      officialChatService
+	Responses officialResponsesService
+}
+
+type officialAnthropicClient struct {
+	Messages officialMessagesService
+}
+
+type officialBedrockClient struct{}
+
+func (officialBedrockClient) Converse(ctx context.Context, req any, _ ...any) {}
+
+func (officialBedrockClient) InvokeModel(ctx context.Context, req any, _ ...any) {}
+
+type officialGeminiClient struct {
+	Models officialModelsService
+}
+
+func OfficialOpenAIChatCompletionsPromptInjection(userInput string) {
+	client := officialOpenAIClient{}
+	prompt := fmt.Sprintf("Answer: %s", userInput)
+	client.Chat.Completions.New(context.Background(), prompt)
+}
+
+func OfficialOpenAIResponsesMissingTimeout() {
+	client := officialOpenAIClient{}
+	client.Responses.New(context.Background(), "hello")
+}
+
+func OfficialAnthropicMessagesPromptInjection(userInput string) {
+	client := officialAnthropicClient{}
+	prompt := fmt.Sprintf("Discuss: %s", userInput)
+	client.Messages.New(context.Background(), prompt)
+}
+
+func OfficialBedrockConverseMissingTimeout() {
+	client := officialBedrockClient{}
+	client.Converse(context.Background(), "hello")
+}
+
+// OfficialBedrockInvokeModelWithOptFn proves variadic optFns matching (#223).
+func OfficialBedrockInvokeModelWithOptFn() {
+	client := officialBedrockClient{}
+	optFn := func() {}
+	client.InvokeModel(context.Background(), "hello", optFn)
+}
+
+func OfficialBedrockConversePromptInjectionWithOptFn(userInput string) {
+	client := officialBedrockClient{}
+	prompt := fmt.Sprintf("Summarize ticket: %s", userInput)
+	optFn := func() {}
+	client.Converse(context.Background(), prompt, optFn)
+}
+
+func OfficialGeminiGenerateContentPromptInjection(userInput string) {
+	client := officialGeminiClient{}
+	prompt := fmt.Sprintf("Summarize: %s", userInput)
+	client.Models.GenerateContent(context.Background(), "gemini-2.0-flash", prompt, nil)
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+type appConfig struct {
+	Model string
+}
+
+// Case 4: user/dynamic input -> fmt.Sprintf, but no LLM sink.
 func OrdinarySprintfNoLLM(orderID string) {
 	message := fmt.Sprintf("order %s", orderID)
 	log.Println(message)
@@ -23,6 +28,48 @@ func StaticLLMPrompt() {
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+// Case 2: trusted literal/constant -> fmt.Sprintf -> LLM.
+func TrustedFormattedPromptReachesLLM() {
+	model := "internal-model"
+	prompt := fmt.Sprintf("Use model %s", model)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+// Case 3: trusted application-configuration value -> fmt.Sprintf -> LLM.
+func TrustedAppConfigFormattedPromptReachesLLM(cfg appConfig) {
+	prompt := fmt.Sprintf("Use model %s", cfg.Model)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+// Case 5: string parameter -> LLM directly, with no fmt.Sprintf.
+func DirectStringParamToLLM(userInput string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: userInput},
 		},
 	})
 }

--- a/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_negative.go
@@ -1,0 +1,28 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func OrdinarySprintfNoLLM(orderID string) {
+	message := fmt.Sprintf("order %s", orderID)
+	log.Println(message)
+}
+
+func StaticLLMPrompt() {
+	prompt := "fixed prompt"
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/prompt_injection_positive.go
@@ -1,0 +1,29 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func PromptInjectionAssignmentThenCall(userInput string) {
+	prompt := fmt.Sprintf("Answer this user: %s", userInput)
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+}
+
+func PromptInjectionInlineCall(userInput string) {
+	client := openai.NewClient("test-token")
+	client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: fmt.Sprintf("Summarize: %s", userInput)},
+		},
+	})
+}

--- a/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
+++ b/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
@@ -5,14 +5,17 @@ GCP / OpenAI / Claude flavoured fixtures under
 ``fixtures/go_provider_samples/``.
 
 This is intentionally *not* a direct ``semgrep`` CLI invocation (see
-``test_semgrep_go_rules.py`` for rule-behaviour line tests). Official
-first-party SDK sink shapes are tracked in issue #223 and are out of scope.
+``test_semgrep_go_rules.py`` for rule-behaviour line tests). Each provider
+directory covers community/compat shapes (``vulnerable.go``, PR #224) and
+official non-streaming SDK call shapes (``official_vulnerable.go``, #223).
 
-Semgrep's default ``.semgrepignore`` skips paths under ``tests/``, and the
-plugin scans directories (not explicit file args). Fixtures are therefore
-materialized into a temporary directory before
-``SemgrepScannerPlugin.run`` so discovery matches production source trees
-that are not nested under a ``tests/`` path segment.
+``SemgrepScannerPlugin`` adds ``--exclude tests/`` by default when
+``semgrep_exclude_tests`` is true, and the plugin scans directories (not
+explicit file args). Fixtures under this test tree are therefore materialized
+into a temporary source-like directory before ``SemgrepScannerPlugin.run`` so
+discovery matches production source trees that are not nested under a
+``tests/`` path segment. E2E cases pass ``semgrep_exclude_tests=False`` on the
+materialized temp dir as belt-and-suspenders.
 """
 
 from __future__ import annotations
@@ -20,6 +23,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from collections import defaultdict
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
@@ -41,6 +45,7 @@ _GO_RULE_IDS = frozenset(
 )
 
 # Expected rule-ID sets per provider (normalized Semgrep check_id suffixes).
+# These #224 community/compat expectations remain the regression baseline.
 _EXPECTED_BY_PROVIDER: dict[str, frozenset[str]] = {
     "openai": frozenset(
         {
@@ -75,6 +80,44 @@ _EXPECTED_BY_PROVIDER: dict[str, frozenset[str]] = {
     ),
 }
 
+# Official (#223) fixtures must themselves produce at least these rule IDs.
+# Kept distinct from #224 so community findings cannot satisfy official coverage.
+_EXPECTED_OFFICIAL_BY_PROVIDER: dict[str, frozenset[str]] = {
+    "openai": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "azure": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "aws": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "gcp": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "claude": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+}
+
+_OFFICIAL_FIXTURE_NAME = "official_vulnerable.go"
+_COMMUNITY_FIXTURE_NAME = "vulnerable.go"
+
 
 def _semgrep_binary() -> str | None:
     return shutil.which("semgrep")
@@ -96,6 +139,17 @@ def _normalize_rule_id(check_id: str) -> str:
     return str(check_id).rsplit(".", 1)[-1]
 
 
+def _finding_filename(finding: Mapping[str, object]) -> str:
+    """Best-effort filename from SemgrepScannerPlugin finding ``affected`` paths."""
+    affected = finding.get("affected") or []
+    if not isinstance(affected, list) or not affected:
+        return ""
+    location = str(affected[0])
+    # location is typically "<path>:<line>"
+    path_part = location.rsplit(":", 1)[0]
+    return Path(path_part).name
+
+
 @contextmanager
 def _materialize_provider(provider: str) -> Iterator[Path]:
     """Copy one provider fixture into a temp dir suitable for Semgrep directory scans."""
@@ -113,8 +167,8 @@ def _materialize_provider(provider: str) -> Iterator[Path]:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
 
-def _scan_provider(provider: str) -> frozenset[str]:
-    """Run SemgrepScannerPlugin on one provider fixture (via temp materialization)."""
+def _scan_provider(provider: str) -> Mapping[str, frozenset[str]]:
+    """Run SemgrepScannerPlugin; return rule IDs keyed by fixture filename."""
     with _materialize_provider(provider) as source_dir:
         result = SemgrepScannerPlugin().run(
             {"nodes": []},
@@ -129,32 +183,45 @@ def _scan_provider(provider: str) -> frozenset[str]:
         )
         assert result.plugin == "semgrep"
 
-        fired: set[str] = set()
+        by_file: dict[str, set[str]] = defaultdict(set)
         for finding in result.findings:
             rule_id = _normalize_rule_id(str(finding.get("rule_id", "")))
-            if rule_id:
-                fired.add(rule_id)
-        return frozenset(fired)
+            if not rule_id:
+                continue
+            filename = _finding_filename(finding)
+            if filename:
+                by_file[filename].add(rule_id)
+        return MappingProxyType({name: frozenset(ids) for name, ids in by_file.items()})
 
 
 @pytest.fixture(scope="module")
-def provider_semgrep_findings() -> Mapping[str, frozenset[str]]:
-    """Scan each provider once; share immutable results across this module's tests."""
+def provider_semgrep_findings_by_file() -> Mapping[str, Mapping[str, frozenset[str]]]:
+    """Scan each provider once; share immutable per-file results across tests."""
     _require_semgrep()
     findings = {
-        provider: _scan_provider(provider) for provider in sorted(_EXPECTED_BY_PROVIDER)
+        provider: _scan_provider(provider)
+        for provider in sorted(_EXPECTED_BY_PROVIDER)
     }
     return MappingProxyType(findings)
+
+
+def _provider_union(
+    by_file: Mapping[str, frozenset[str]],
+) -> frozenset[str]:
+    fired: set[str] = set()
+    for rule_ids in by_file.values():
+        fired |= set(rule_ids)
+    return frozenset(fired)
 
 
 @pytest.mark.parametrize("provider", sorted(_EXPECTED_BY_PROVIDER))
 def test_provider_fixture_emits_expected_go_rules(
     provider: str,
-    provider_semgrep_findings: Mapping[str, frozenset[str]],
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
 ) -> None:
     """Each provider sample must surface its expected Go AI-security rule IDs."""
     expected = _EXPECTED_BY_PROVIDER[provider]
-    fired = provider_semgrep_findings[provider]
+    fired = _provider_union(provider_semgrep_findings_by_file[provider])
     missing = expected - fired
     assert not missing, (
         f"{provider}: missing expected Go rule IDs {sorted(missing)}; "
@@ -162,13 +229,45 @@ def test_provider_fixture_emits_expected_go_rules(
     )
 
 
+@pytest.mark.parametrize("provider", sorted(_EXPECTED_BY_PROVIDER))
+def test_community_vulnerable_fixture_still_fires(
+    provider: str,
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
+) -> None:
+    """#224 regression: community ``vulnerable.go`` must satisfy expected rule IDs."""
+    expected = _EXPECTED_BY_PROVIDER[provider]
+    by_file = provider_semgrep_findings_by_file[provider]
+    fired = by_file.get(_COMMUNITY_FIXTURE_NAME, frozenset())
+    missing = expected - fired
+    assert not missing, (
+        f"{provider}: {_COMMUNITY_FIXTURE_NAME} missing expected Go rule IDs "
+        f"{sorted(missing)}; fired={sorted(fired)}"
+    )
+
+
+@pytest.mark.parametrize("provider", sorted(_EXPECTED_OFFICIAL_BY_PROVIDER))
+def test_official_vulnerable_fixture_emits_expected_go_rules(
+    provider: str,
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
+) -> None:
+    """#223: official_vulnerable.go must itself fire expected rule IDs."""
+    expected = _EXPECTED_OFFICIAL_BY_PROVIDER[provider]
+    by_file = provider_semgrep_findings_by_file[provider]
+    fired = by_file.get(_OFFICIAL_FIXTURE_NAME, frozenset())
+    missing = expected - fired
+    assert not missing, (
+        f"{provider}: official fixture missing rule IDs {sorted(missing)}; "
+        f"fired={sorted(fired)}; files={sorted(by_file)}"
+    )
+
+
 def test_provider_pack_covers_all_go_rules(
-    provider_semgrep_findings: Mapping[str, frozenset[str]],
+    provider_semgrep_findings_by_file: Mapping[str, Mapping[str, frozenset[str]]],
 ) -> None:
     """Collectively, the provider pack must exercise all four Go rule IDs."""
     fired: set[str] = set()
-    for rule_ids in provider_semgrep_findings.values():
-        fired |= rule_ids
+    for by_file in provider_semgrep_findings_by_file.values():
+        fired |= set(_provider_union(by_file))
 
     missing = _GO_RULE_IDS - fired
     assert not missing, (

--- a/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
+++ b/nuguard/analysis/tests/test_go_provider_semgrep_e2e.py
@@ -1,0 +1,178 @@
+"""Provider-style Go Semgrep E2E via SemgrepScannerPlugin.
+
+Exercises the NuGuard Semgrep integration path against minimal Azure / AWS /
+GCP / OpenAI / Claude flavoured fixtures under
+``fixtures/go_provider_samples/``.
+
+This is intentionally *not* a direct ``semgrep`` CLI invocation (see
+``test_semgrep_go_rules.py`` for rule-behaviour line tests). Official
+first-party SDK sink shapes are tracked in issue #223 and are out of scope.
+
+Semgrep's default ``.semgrepignore`` skips paths under ``tests/``, and the
+plugin scans directories (not explicit file args). Fixtures are therefore
+materialized into a temporary directory before
+``SemgrepScannerPlugin.run`` so discovery matches production source trees
+that are not nested under a ``tests/`` path segment.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from nuguard.analysis.plugins.semgrep_scanner import SemgrepScannerPlugin
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "go_provider_samples"
+
+_GO_RULE_IDS = frozenset(
+    {
+        "nuguard-go-llm-prompt-injection-sprintf",
+        "nuguard-go-hardcoded-api-key",
+        "nuguard-go-llm-missing-context-timeout",
+        "nuguard-go-llm-insecure-tls",
+    }
+)
+
+# Expected rule-ID sets per provider (normalized Semgrep check_id suffixes).
+_EXPECTED_BY_PROVIDER: dict[str, frozenset[str]] = {
+    "openai": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-hardcoded-api-key",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "azure": frozenset(
+        {
+            "nuguard-go-llm-insecure-tls",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "aws": frozenset(
+        {
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "gcp": frozenset(
+        {
+            "nuguard-go-hardcoded-api-key",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+    "claude": frozenset(
+        {
+            "nuguard-go-hardcoded-api-key",
+            "nuguard-go-llm-missing-context-timeout",
+        }
+    ),
+}
+
+
+def _semgrep_binary() -> str | None:
+    return shutil.which("semgrep")
+
+
+def _require_semgrep() -> None:
+    if _semgrep_binary() is not None:
+        return
+    if os.environ.get("CI"):
+        pytest.fail(
+            "semgrep is required in CI for Go provider Semgrep E2E tests; "
+            "install semgrep before running pytest"
+        )
+    pytest.skip("semgrep not installed — Go provider Semgrep E2E skipped")
+
+
+def _normalize_rule_id(check_id: str) -> str:
+    """Strip Semgrep config-path prefixes from a check_id."""
+    return str(check_id).rsplit(".", 1)[-1]
+
+
+@contextmanager
+def _materialize_provider(provider: str) -> Iterator[Path]:
+    """Copy one provider fixture into a temp dir suitable for Semgrep directory scans."""
+    source = _FIXTURES / provider
+    assert source.is_dir(), f"missing provider fixture directory: {source}"
+    go_files = sorted(source.glob("*.go"))
+    assert go_files, f"no Go fixtures in {source}"
+
+    temp_dir = Path(tempfile.mkdtemp(prefix=f"nuguard-go-provider-{provider}-"))
+    try:
+        for path in go_files:
+            shutil.copy2(path, temp_dir / path.name)
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _scan_provider(provider: str) -> frozenset[str]:
+    """Run SemgrepScannerPlugin on one provider fixture (via temp materialization)."""
+    with _materialize_provider(provider) as source_dir:
+        result = SemgrepScannerPlugin().run(
+            {"nodes": []},
+            {
+                "source_path": str(source_dir),
+                "semgrep_exclude_tests": False,
+                "semgrep_timeout": 120.0,
+            },
+        )
+        assert result.status != "skipped", (
+            f"SemgrepScannerPlugin skipped scan of {provider}: {result.message}"
+        )
+        assert result.plugin == "semgrep"
+
+        fired: set[str] = set()
+        for finding in result.findings:
+            rule_id = _normalize_rule_id(str(finding.get("rule_id", "")))
+            if rule_id:
+                fired.add(rule_id)
+        return frozenset(fired)
+
+
+@pytest.fixture(scope="module")
+def provider_semgrep_findings() -> Mapping[str, frozenset[str]]:
+    """Scan each provider once; share immutable results across this module's tests."""
+    _require_semgrep()
+    findings = {
+        provider: _scan_provider(provider) for provider in sorted(_EXPECTED_BY_PROVIDER)
+    }
+    return MappingProxyType(findings)
+
+
+@pytest.mark.parametrize("provider", sorted(_EXPECTED_BY_PROVIDER))
+def test_provider_fixture_emits_expected_go_rules(
+    provider: str,
+    provider_semgrep_findings: Mapping[str, frozenset[str]],
+) -> None:
+    """Each provider sample must surface its expected Go AI-security rule IDs."""
+    expected = _EXPECTED_BY_PROVIDER[provider]
+    fired = provider_semgrep_findings[provider]
+    missing = expected - fired
+    assert not missing, (
+        f"{provider}: missing expected Go rule IDs {sorted(missing)}; "
+        f"fired={sorted(fired)}"
+    )
+
+
+def test_provider_pack_covers_all_go_rules(
+    provider_semgrep_findings: Mapping[str, frozenset[str]],
+) -> None:
+    """Collectively, the provider pack must exercise all four Go rule IDs."""
+    fired: set[str] = set()
+    for rule_ids in provider_semgrep_findings.values():
+        fired |= rule_ids
+
+    missing = _GO_RULE_IDS - fired
+    assert not missing, (
+        f"provider pack missing Go rule coverage {sorted(missing)}; "
+        f"fired={sorted(fired)}"
+    )
+    assert fired & _GO_RULE_IDS == _GO_RULE_IDS

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -1,0 +1,204 @@
+"""Semgrep Go AI-security rule tests for bundled ai-security.yaml.
+
+Runs the four Go rules against annotated fixture files. Skips when semgrep is
+not installed on PATH (same behaviour as SemgrepScannerPlugin).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+_RULES = Path(__file__).parent.parent / "plugins" / "semgrep_rules" / "ai-security.yaml"
+_FIXTURES = Path(__file__).parent / "fixtures" / "semgrep_go"
+
+_GO_RULE_IDS = frozenset(
+    {
+        "nuguard-go-llm-prompt-injection-sprintf",
+        "nuguard-go-hardcoded-api-key",
+        "nuguard-go-llm-missing-context-timeout",
+        "nuguard-go-llm-insecure-tls",
+    }
+)
+
+
+def _semgrep_binary() -> str | None:
+    return shutil.which("semgrep")
+
+
+def _run_semgrep_on_fixtures() -> dict[str, list[dict[str, object]]]:
+    """Run bundled rules on all Go fixture files; return findings keyed by filename."""
+    binary = _semgrep_binary()
+    if binary is None:
+        pytest.skip("semgrep not installed — Go rule tests skipped")
+
+    files = sorted(_FIXTURES.glob("*.go"))
+    if not files:
+        pytest.fail(f"no Go fixtures found in {_FIXTURES}")
+
+    cmd = [
+        binary,
+        "--quiet",
+        "--json",
+        "--config",
+        str(_RULES),
+        *[str(f) for f in files],
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode not in (0, 1):
+        pytest.fail(f"semgrep exited {result.returncode}: {result.stderr.strip()}")
+
+    data = json.loads(result.stdout)
+    by_file: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in data.get("results") or []:
+        path = str(row.get("path", ""))
+        filename = Path(path).name
+        check_id = str(row.get("check_id", ""))
+        rule_id = check_id.rsplit(".", 1)[-1]
+        start = row.get("start") or {}
+        by_file[filename].append(
+            {
+                "rule_id": rule_id,
+                "line": start.get("line"),
+            }
+        )
+    return by_file
+
+
+@pytest.fixture(scope="module")
+def semgrep_findings() -> dict[str, list[dict[str, object]]]:
+    return _run_semgrep_on_fixtures()
+
+
+def _rule_lines(
+    findings: dict[str, list[dict[str, object]]],
+    filename: str,
+    rule_id: str,
+) -> list[int]:
+    rows = findings.get(filename, [])
+    lines: list[int] = []
+    for row in rows:
+        if row["rule_id"] != rule_id:
+            continue
+        line = row.get("line")
+        if isinstance(line, int):
+            lines.append(line)
+    return sorted(lines)
+
+
+def _assert_no_rule(
+    findings: dict[str, list[dict[str, object]]],
+    filename: str,
+    rule_id: str,
+) -> None:
+    hits = _rule_lines(findings, filename, rule_id)
+    assert hits == [], f"unexpected {rule_id} on {filename}: lines {hits}"
+
+
+class TestGoPromptInjectionSprintf:
+    def test_positive_assignment_and_inline(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "prompt_injection_positive.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+        assert lines == [13, 23]
+
+    def test_negative_ordinary_sprintf(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+    def test_negative_static_prompt(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+
+class TestGoHardcodedApiKey:
+    def test_positive_literals(self, semgrep_findings: dict[str, list[dict[str, object]]]) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "hardcoded_key_positive.go",
+            "nuguard-go-hardcoded-api-key",
+        )
+        assert lines == [8, 14, 20]
+
+    def test_negative_env_and_store(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "hardcoded_key_negative.go",
+            "nuguard-go-hardcoded-api-key",
+        )
+
+
+class TestGoMissingContextTimeout:
+    def test_positive_background_context(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "missing_timeout_positive.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+        assert lines == [10, 22]
+
+    def test_negative_bounded_and_non_llm(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "missing_timeout_negative.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+
+
+class TestGoInsecureTls:
+    def test_positive_llm_client_transport(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "insecure_tls_positive.go",
+            "nuguard-go-llm-insecure-tls",
+        )
+        assert lines == [11, 29]
+
+    def test_negative_secure_and_unrelated(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "insecure_tls_negative.go",
+            "nuguard-go-llm-insecure-tls",
+        )
+
+
+class TestGoRuleInventory:
+    def test_only_expected_go_rules_fire_on_fixtures(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        fired: set[str] = set()
+        for rows in semgrep_findings.values():
+            for row in rows:
+                rule_id = str(row["rule_id"])
+                if rule_id in _GO_RULE_IDS:
+                    fired.add(rule_id)
+        assert fired == _GO_RULE_IDS

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -221,6 +221,38 @@ class TestGoInsecureTls:
         )
 
 
+class TestGoOfficialSdkSinks:
+    """Issue #223: qualified official SDK sinks (never bare New)."""
+
+    def test_official_positive_prompt_injection(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "official_sdk_positive.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+        # Chat.Completions.New, Messages.New, Converse(...optFn), GenerateContent
+        assert lines == [54, 65, 84, 90]
+
+    def test_official_positive_missing_timeout(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "official_sdk_positive.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+        # Includes Bedrock InvokeModel/Converse calls that pass a trailing optFn.
+        assert lines == [54, 59, 65, 70, 77, 84, 90]
+
+    def test_bare_new_is_not_llm_sink(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        for rule_id in _GO_RULE_IDS:
+            _assert_no_rule(semgrep_findings, "official_sdk_negative.go", rule_id)
+
+
 class TestGoRuleInventory:
     def test_only_expected_go_rules_fire_on_fixtures(
         self, semgrep_findings: dict[str, list[dict[str, object]]]

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -1,12 +1,14 @@
 """Semgrep Go AI-security rule tests for bundled ai-security.yaml.
 
 Runs the four Go rules against annotated fixture files. Skips when semgrep is
-not installed on PATH (same behaviour as SemgrepScannerPlugin).
+not installed on PATH (same behaviour as SemgrepScannerPlugin). In CI, missing
+semgrep is a hard failure so rule-behaviour regressions cannot silently skip.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from collections import defaultdict
@@ -35,6 +37,11 @@ def _run_semgrep_on_fixtures() -> dict[str, list[dict[str, object]]]:
     """Run bundled rules on all Go fixture files; return findings keyed by filename."""
     binary = _semgrep_binary()
     if binary is None:
+        if os.environ.get("CI"):
+            pytest.fail(
+                "semgrep is required in CI for Go rule-behaviour tests; "
+                "install semgrep before running pytest"
+            )
         pytest.skip("semgrep not installed — Go rule tests skipped")
 
     files = sorted(_FIXTURES.glob("*.go"))
@@ -101,9 +108,10 @@ def _assert_no_rule(
 
 
 class TestGoPromptInjectionSprintf:
-    def test_positive_assignment_and_inline(
+    def test_case1_untrusted_through_sprintf_to_llm(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
     ) -> None:
+        """user/external/dynamic input -> fmt.Sprintf -> LLM = MATCH."""
         lines = _rule_lines(
             semgrep_findings,
             "prompt_injection_positive.go",
@@ -111,18 +119,40 @@ class TestGoPromptInjectionSprintf:
         )
         assert lines == [13, 23]
 
-    def test_negative_ordinary_sprintf(
+    def test_case2_trusted_literal_sprintf_to_llm(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
     ) -> None:
+        """trusted literal/constant -> fmt.Sprintf -> LLM = NO MATCH."""
         _assert_no_rule(
             semgrep_findings,
             "prompt_injection_negative.go",
             "nuguard-go-llm-prompt-injection-sprintf",
         )
 
-    def test_negative_static_prompt(
+    def test_case3_trusted_app_config_sprintf_to_llm(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
     ) -> None:
+        """trusted application-configuration value -> fmt.Sprintf -> LLM = NO MATCH."""
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+    def test_case4_sprintf_without_llm_sink(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        """user/dynamic input -> fmt.Sprintf but no LLM sink = NO MATCH."""
+        _assert_no_rule(
+            semgrep_findings,
+            "prompt_injection_negative.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+
+    def test_case5_direct_string_param_to_llm_without_sprintf(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        """string parameter -> LLM directly, with no fmt.Sprintf = NO MATCH."""
         _assert_no_rule(
             semgrep_findings,
             "prompt_injection_negative.go",
@@ -137,7 +167,7 @@ class TestGoHardcodedApiKey:
             "hardcoded_key_positive.go",
             "nuguard-go-hardcoded-api-key",
         )
-        assert lines == [8, 14, 20]
+        assert lines == [16, 22, 28, 34]
 
     def test_negative_env_and_store(
         self, semgrep_findings: dict[str, list[dict[str, object]]]
@@ -179,7 +209,7 @@ class TestGoInsecureTls:
             "insecure_tls_positive.go",
             "nuguard-go-llm-insecure-tls",
         )
-        assert lines == [11, 29]
+        assert lines == [27, 45, 63]
 
     def test_negative_secure_and_unrelated(
         self, semgrep_findings: dict[str, list[dict[str, object]]]

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -228,7 +228,5 @@ class TestGoRuleInventory:
         fired: set[str] = set()
         for rows in semgrep_findings.values():
             for row in rows:
-                rule_id = str(row["rule_id"])
-                if rule_id in _GO_RULE_IDS:
-                    fired.add(rule_id)
+                fired.add(str(row["rule_id"]))
         assert fired == _GO_RULE_IDS

--- a/nuguard/cli/commands/analyze.py
+++ b/nuguard/cli/commands/analyze.py
@@ -304,6 +304,7 @@ def analyze(
                 extension_map=extension_map,
             )
             report_text = _render(fmt)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(report_text, encoding="utf-8")
             typer.echo(f"report written to {out_path}")
     else:

--- a/nuguard/cli/commands/behavior.py
+++ b/nuguard/cli/commands/behavior.py
@@ -27,6 +27,14 @@ def behavior_command(
     config: Optional[Path] = typer.Option(
         None, "--config", "-c", help="Path to nuguard.yaml"
     ),
+    sbom: Optional[str] = typer.Option(
+        None,
+        "--sbom",
+        help=(
+            "Path to AI-SBOM JSON file to seed behavior analysis with. "
+            "Falls back to 'sbom:' in nuguard.yaml when --config is set."
+        ),
+    ),
     mode: str = typer.Option(
         "static+dynamic",
         "--mode",
@@ -196,7 +204,7 @@ async def _run_behavior(
     # 4. Load AI-SBOM and auto-enrich if confidence is low
     sbom = None
     sbom_path_obj: Path | None = None
-    raw_sbom_path = cfg.sbom_path
+    raw_sbom_path = sbom or cfg.sbom_path
     if raw_sbom_path:
         sbom_path_obj = Path(raw_sbom_path)
         try:

--- a/nuguard/cli/commands/behavior.py
+++ b/nuguard/cli/commands/behavior.py
@@ -32,7 +32,8 @@ def behavior_command(
         "--sbom",
         help=(
             "Path to AI-SBOM JSON file to seed behavior analysis with. "
-            "Falls back to 'sbom:' in nuguard.yaml when --config is set."
+            "Falls back to 'sbom:' in nuguard.yaml (located via --config or "
+            "the current working directory)."
         ),
     ),
     mode: str = typer.Option(

--- a/nuguard/cli/commands/behavior.py
+++ b/nuguard/cli/commands/behavior.py
@@ -135,6 +135,7 @@ def behavior_command(
     asyncio.run(
         _run_behavior(
             config_path=config,
+            sbom_override=sbom,
             mode=effective_mode,
             target_override=target,
             policy_path=policy,
@@ -153,6 +154,7 @@ def behavior_command(
 
 async def _run_behavior(
     config_path: Optional[Path],
+    sbom_override: Optional[str],
     mode: str,
     target_override: Optional[str],
     policy_path: Optional[Path],
@@ -202,9 +204,12 @@ async def _run_behavior(
         raise typer.Exit(code=1)
 
     # 4. Load AI-SBOM and auto-enrich if confidence is low
+    # Precedence: --sbom CLI override > cfg.sbom_path config fallback.
+    # The local ``sbom`` below is the parsed SBOM doc; do not reuse the name
+    # for the path so the CLI override param can be threaded through cleanly.
     sbom = None
     sbom_path_obj: Path | None = None
-    raw_sbom_path = sbom or cfg.sbom_path
+    raw_sbom_path = sbom_override or cfg.sbom_path
     if raw_sbom_path:
         sbom_path_obj = Path(raw_sbom_path)
         try:

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -680,6 +680,14 @@ async def _run_redteam(
             log_prefix="redteam",
         )
 
+        # enrich_sbom_for_run() may return a cached artifact loaded from disk
+        # or a freshly rebuilt SBOM, neither of which is guaranteed to have
+        # gone through topology enrichment. Re-run it here — it's idempotent
+        # — so scenario generation always sees the derived risk attributes.
+        from nuguard.sbom.enricher import enrich as _enrich_topology_post
+
+        _enrich_topology_post(sbom_doc)
+
     # Load policy + compiled controls
     cognitive_policy: CognitivePolicy | None = None
     policy_controls: list | None = None

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -421,6 +421,7 @@ def redteam(
                 all_formats=effective_formats,
                 extension_map=extension_map,
             )
+            out_path.parent.mkdir(parents=True, exist_ok=True)
             if fmt == "markdown":
                 out_path.write_text(
                     _findings_to_markdown(

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -686,7 +686,7 @@ async def _run_redteam(
         # — so scenario generation always sees the derived risk attributes.
         from nuguard.sbom.enricher import enrich as _enrich_topology_post
 
-        _enrich_topology_post(sbom_doc)
+        _enrich_topology_post(sbom_doc)  # type: ignore[arg-type]
 
     # Load policy + compiled controls
     cognitive_policy: CognitivePolicy | None = None

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -252,6 +252,11 @@ def redteam(
         typer.echo(f"Error loading SBOM: {exc}", err=True)
         raise typer.Exit(code=1)
 
+    # Re-run topology enrichment in case the SBOM file predates it (idempotent).
+    from nuguard.sbom.enricher import enrich as _enrich_topology  # noqa: PLC0415
+
+    _enrich_topology(sbom_doc)
+
     # Resolve target URL — explicit > SBOM discovery
     if not target_url:
         target_url = _resolve_target_url(sbom_doc, launch=launch)
@@ -422,7 +427,14 @@ def redteam(
                 extension_map=extension_map,
             )
             out_path.parent.mkdir(parents=True, exist_ok=True)
-            if fmt == "markdown":
+            if fmt == "text":
+                # Plain-text report — no ANSI escapes in a file. Identical
+                # content to what ``nuguard redteam`` emits to stdout.
+                out_path.write_text(
+                    _render_findings_text(findings, meta, scan_outcome, colour=False),
+                    encoding="utf-8",
+                )
+            elif fmt == "markdown":
                 out_path.write_text(
                     _findings_to_markdown(
                         findings,
@@ -975,6 +987,85 @@ async def _run_orchestrator(  # noqa: C901
     )
 
 
+_SEV_COLOUR: dict[str, str] = {
+    "critical": "red",
+    "high": "red",
+    "medium": "yellow",
+    "low": "blue",
+    "info": "white",
+}
+
+
+def _render_findings_text(
+    findings: list,
+    meta: "ReportMeta",
+    scan_outcome: str = "no_findings",
+    *,
+    colour: bool = False,
+) -> str:
+    """Render findings as a plain-text report.
+
+    Returns a multi-line string suitable for writing to a file or echoing to a
+    terminal. When ``colour`` is ``True``, the severity label is wrapped in
+    ANSI escapes via :func:`typer.style` (used for stdout). When ``False``
+    (default), the output is plain text with no escape sequences — suitable
+    for on-disk reports that downstream tools may parse.
+
+    Args:
+        findings: List of :class:`~nuguard.models.finding.Finding` objects.
+        meta: Report metadata header.
+        scan_outcome: One-line scan outcome string ("no_findings", etc.).
+        colour: If ``True``, wrap severity labels with ANSI colour codes.
+
+    Returns:
+        Plain-text report as a single string.
+    """
+    from nuguard.models.finding import Severity as _Severity
+
+    if not findings:
+        lines = [
+            meta.to_text_line(),
+            f"Outcome: {scan_outcome}",
+            "No findings — scan complete",
+        ]
+        return "\n".join(lines) + "\n"
+
+    _ORDER = [
+        _Severity.CRITICAL,
+        _Severity.HIGH,
+        _Severity.MEDIUM,
+        _Severity.LOW,
+        _Severity.INFO,
+    ]
+
+    out: list[str] = []
+    out.append("")
+    out.append("─" * 60)
+    out.append(f"  NuGuard Red-Team — {len(findings)} finding(s)")
+    out.append(f"  {meta.to_text_line()}")
+    out.append(f"  Outcome: {scan_outcome}")
+    out.append("─" * 60)
+    for f in sorted(findings, key=lambda x: _ORDER.index(x.severity)):
+        sev_key = f.severity.value if hasattr(f.severity, "value") else str(f.severity)
+        sev_text = sev_key.upper()
+        if colour:
+            colour_name = _SEV_COLOUR.get(sev_key, "white")
+            sev_label = typer.style(sev_text, fg=colour_name, bold=True)
+        else:
+            sev_label = sev_text
+        out.append("")
+        out.append(f"[{sev_label}] {f.title}")
+        out.append(f"  {f.description[:200]}")
+        if f.remediation:
+            out.append(f"  Fix: {f.remediation[:150]}")
+        if f.owasp_asi_ref:
+            out.append(f"  Ref: {f.owasp_asi_ref}")
+    out.append("")
+    out.append("─" * 60)
+    out.append("")
+    return "\n".join(out)
+
+
 def _print_findings(
     findings: list,
     format: str,
@@ -988,8 +1079,6 @@ def _print_findings(
     coverage_tracker: object | None = None,
 ) -> None:
     """Print findings to stdout in the requested format."""
-    from nuguard.models.finding import Severity
-
     if meta is None:
         meta = ReportMeta()
 
@@ -1024,35 +1113,9 @@ def _print_findings(
         )
         return
 
-    if not findings:
-        typer.echo(meta.to_text_line())
-        typer.echo(f"Outcome: {scan_outcome}")
-        typer.echo("No findings — scan complete")
-        return
-
-    _SEV_COLOUR = {
-        Severity.CRITICAL: "red",
-        Severity.HIGH: "red",
-        Severity.MEDIUM: "yellow",
-        Severity.LOW: "blue",
-        Severity.INFO: "white",
-    }
-
-    typer.echo(f"\n{'─' * 60}")
-    typer.echo(f"  NuGuard Red-Team — {len(findings)} finding(s)")
-    typer.echo(f"  {meta.to_text_line()}")
-    typer.echo(f"  Outcome: {scan_outcome}")
-    typer.echo(f"{'─' * 60}")
-    for f in sorted(findings, key=lambda x: list(Severity).index(x.severity)):
-        colour = _SEV_COLOUR.get(f.severity, "white")
-        sev_label = typer.style(f.severity.upper(), fg=colour, bold=True)
-        typer.echo(f"\n[{sev_label}] {f.title}")
-        typer.echo(f"  {f.description[:200]}")
-        if f.remediation:
-            typer.echo(f"  Fix: {f.remediation[:150]}")
-        if f.owasp_asi_ref:
-            typer.echo(f"  Ref: {f.owasp_asi_ref}")
-    typer.echo(f"\n{'─' * 60}\n")
+    # Default and explicit "text" path — emit the plain-text report (with
+    # ANSI colour escapes when stdout is a TTY).
+    typer.echo(_render_findings_text(findings, meta, scan_outcome, colour=True))
 
 
 def _scenario_coverage_table(scenario_records: list) -> list[str]:

--- a/nuguard/sbom/adapters/csharp/__init__.py
+++ b/nuguard/sbom/adapters/csharp/__init__.py
@@ -1,5 +1,17 @@
-"""Shared infrastructure for C# framework adapters."""
+"""C# framework adapters."""
 
 from ._csharp_base import CSharpFrameworkAdapter
+from .aspnet_core import CSharpAspNetCoreAdapter
+from .llm_clients import CSharpLLMClientsAdapter
+from .mlnet import CSharpMLNetAdapter
+from .semantic_kernel import (
+    CSharpSemanticKernelAdapter,
+)
 
-__all__ = ["CSharpFrameworkAdapter"]
+__all__ = [
+    "CSharpAspNetCoreAdapter",
+    "CSharpFrameworkAdapter",
+    "CSharpLLMClientsAdapter",
+    "CSharpMLNetAdapter",
+    "CSharpSemanticKernelAdapter",
+]

--- a/nuguard/sbom/adapters/csharp/__init__.py
+++ b/nuguard/sbom/adapters/csharp/__init__.py
@@ -1,0 +1,5 @@
+"""Shared infrastructure for C# framework adapters."""
+
+from ._csharp_base import CSharpFrameworkAdapter
+
+__all__ = ["CSharpFrameworkAdapter"]

--- a/nuguard/sbom/adapters/csharp/_csharp_base.py
+++ b/nuguard/sbom/adapters/csharp/_csharp_base.py
@@ -1,0 +1,184 @@
+"""Shared base class for C# framework adapters."""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from typing import Any
+
+from ...core.csharp_parser import CSharpParseResult, parse_csharp
+from ...types import ComponentType
+from ..base import ComponentDetection, FrameworkAdapter
+
+
+class CSharpFrameworkAdapter(
+    FrameworkAdapter,
+    ABC,
+):
+    """Base class for adapters that consume C# parse results.
+
+    Subclasses declare namespace prefixes in ``handles_namespaces`` or in the
+    inherited ``handles_imports`` alias and implement :meth:`extract`.
+    """
+
+    handles_namespaces: list[str] = []
+
+    def _namespace_prefixes(self) -> list[str]:
+        return self.handles_namespaces or self.handles_imports
+
+    @staticmethod
+    def _normalize_namespace(
+        namespace: str,
+    ) -> str:
+        return namespace.strip().removeprefix("global::").rstrip(".")
+
+    def can_handle(
+        self,
+        imports_present: set[str],
+    ) -> bool:
+        """Return whether an imported namespace matches this adapter."""
+        prefixes = [
+            self._normalize_namespace(prefix)
+            for prefix in self._namespace_prefixes()
+            if prefix.strip()
+        ]
+
+        for imported in imports_present:
+            namespace = self._normalize_namespace(imported)
+
+            for prefix in prefixes:
+                if namespace == prefix or namespace.startswith(prefix + "."):
+                    return True
+
+        return False
+
+    def _detect(
+        self,
+        result: CSharpParseResult,
+    ) -> bool:
+        """Return whether the parse result imports a handled namespace."""
+        return self.can_handle({directive.namespace for directive in result.using_directives})
+
+    @staticmethod
+    def _parse_result(
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> CSharpParseResult:
+        """Return a typed result, parsing content when necessary."""
+        if isinstance(
+            parse_result,
+            CSharpParseResult,
+        ):
+            return parse_result
+
+        return parse_csharp(
+            content,
+            file_path,
+        )
+
+    @abstractmethod
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        """Extract component detections from one C# source file."""
+        raise NotImplementedError
+
+    def _fw_node(
+        self,
+        file_path: str,
+        line: int = 0,
+    ) -> ComponentDetection:
+        """Emit a C# framework-presence node."""
+        return ComponentDetection(
+            component_type=ComponentType.FRAMEWORK,
+            canonical_name=f"framework:{self.name}",
+            display_name=f"framework:{self.name}",
+            adapter_name=self.name,
+            priority=self.priority,
+            confidence=0.95,
+            metadata={
+                "framework": self.name,
+                "language": "csharp",
+            },
+            file_path=file_path,
+            line=line,
+            snippet=f"using {self.name}",
+            evidence_kind="ast_import",
+        )
+
+    @staticmethod
+    def _clean(value: Any) -> str:
+        """Strip common C# string delimiters and placeholders."""
+        if value is None:
+            return ""
+
+        text = str(value).strip()
+
+        if text.startswith("$("):
+            return ""
+
+        text = re.sub(
+            r"^(?:\$@|@\$|\$+|@)",
+            "",
+            text,
+        )
+
+        if text.startswith('"""') and text.endswith('"""'):
+            text = text[3:-3]
+        else:
+            text = text.strip("'\" ")
+
+        if text.startswith("$(") or text in {
+            "<complex>",
+            "<lambda>",
+            "<dict>",
+            "<list>",
+        }:
+            return ""
+
+        return text
+
+    @staticmethod
+    def _assignment_name(
+        source: str,
+        line: int,
+    ) -> str | None:
+        """Return the assignment target on a one-based source line."""
+        lines = source.splitlines()
+
+        if line < 1 or line > len(lines):
+            return None
+
+        match = re.search(
+            r"(?:\b(?:const|var|"
+            r"[A-Za-z_]\w*"
+            r"(?:[.<>,?\[\] ]+[A-Za-z_]\w*)?)\s+)?"
+            r"(?P<name>@?[A-Za-z_]\w*)\s*=",
+            lines[line - 1],
+        )
+
+        return match.group("name").removeprefix("@") if match else None
+
+    @staticmethod
+    def _template_vars(
+        text: str,
+    ) -> list[str]:
+        """Extract unique expressions from interpolation braces."""
+        variables: list[str] = []
+        seen: set[str] = set()
+
+        for match in re.finditer(
+            r"(?<!\{)\{\s*([^{}]+?)\s*\}(?!\})",
+            text,
+        ):
+            expression = match.group(1).split(":", 1)[0].strip()
+
+            if expression and expression not in seen:
+                seen.add(expression)
+                variables.append(expression)
+
+        return variables

--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -125,7 +125,7 @@ def find_calls(
         prefix = masked[max(0, match.start() - 12) : match.start()]
         is_constructor = bool(re.search(r"\bnew\s*$", prefix))
         assigned_to = _assignment_target(
-            source,
+            masked,
             match.start(),
         )
         end = close_paren + 1
@@ -268,11 +268,55 @@ def split_top_level(value: str) -> list[str]:
 def string_constants(
     result: CSharpParseResult,
 ) -> dict[str, str]:
-    """Build a variable-to-string map from parsed literal results."""
+    """Return unambiguous C# ``const`` string declarations.
+
+    Mutable variables are deliberately excluded because a file-wide
+    name-to-value dictionary cannot safely model reassignment or scope.
+    Duplicate constant names with different values are also omitted.
+    """
+    source = result.source
+
+    if not source:
+        return {}
+
+    masked = mask_non_code(source)
+    values: dict[str, set[str]] = {}
+
+    for token in _TOKEN_RE.finditer(source):
+        if token.lastgroup not in {
+            "raw",
+            "verbatim",
+            "regular",
+        }:
+            continue
+
+        start = token.start()
+        boundary = max(
+            masked.rfind(";", 0, start),
+            masked.rfind("{", 0, start),
+            masked.rfind("}", 0, start),
+        )
+        prefix = masked[boundary + 1 : start]
+        declaration = re.search(
+            rf"\bconst\s+(?:string|var)\s+"
+            rf"(?P<name>{_IDENTIFIER})"
+            rf"\s*=\s*$",
+            prefix,
+        )
+
+        if declaration is None:
+            continue
+
+        value = _decode_string(token.group(0))
+
+        if value is None:
+            continue
+
+        name = declaration.group("name").removeprefix("@")
+        values.setdefault(name, set()).add(value)
+
     return {
-        literal.assigned_to: literal.value
-        for literal in result.string_literals
-        if literal.assigned_to and literal.value
+        name: next(iter(candidates)) for name, candidates in values.items() if len(candidates) == 1
     }
 
 
@@ -446,7 +490,8 @@ def _assignment_target(
 ) -> str | None:
     boundary = max(
         source.rfind(";", 0, position),
-        source.rfind("\n", 0, position),
+        source.rfind("{", 0, position),
+        source.rfind("}", 0, position),
     )
     prefix = source[boundary + 1 : position]
     match = re.search(

--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -1,0 +1,554 @@
+"""Small source helpers shared by C# framework adapters."""
+
+from __future__ import annotations
+
+import re
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import Iterable
+
+from ...core.csharp_parser import CSharpMethodDeclaration, CSharpParseResult
+
+_IDENTIFIER = r"@?[A-Za-z_]\w*"
+_TOKEN_RE = re.compile(
+    r"(?P<line_comment>//[^\n]*)"
+    r"|(?P<block_comment>/\*.*?\*/)"
+    r'|(?P<raw>\$*""".*?""")'
+    r'|(?P<verbatim>(?:\$@|@\$|@)"(?:""|[^"])*")'
+    r'|(?P<regular>\$?"(?:\\.|[^"\\\r\n])*")'
+    r"|(?P<char>'(?:\\.|[^'\\\r\n])')",
+    re.DOTALL,
+)
+_GENERIC = r"(?:\s*<[^<>{}();\n]+>)?"
+_CALL_RE = re.compile(
+    rf"(?P<callee>(?:global::)?{_IDENTIFIER}{_GENERIC}"
+    rf"(?:\s*\.\s*{_IDENTIFIER}{_GENERIC})*)\s*\("
+)
+_CONTROL_NAMES = {
+    "if",
+    "for",
+    "foreach",
+    "while",
+    "switch",
+    "catch",
+    "using",
+    "lock",
+    "return",
+    "throw",
+    "typeof",
+    "nameof",
+    "sizeof",
+    "default",
+    "checked",
+    "unchecked",
+}
+
+
+@dataclass(frozen=True)
+class CSharpCall:
+    """One best-effort C# call or constructor expression."""
+
+    callee: str
+    name: str
+    receiver: str | None
+    generic_arguments: tuple[str, ...]
+    arguments_text: str
+    named_arguments: dict[str, str]
+    positional_arguments: tuple[str, ...]
+    assigned_to: str | None
+    is_constructor: bool
+    line: int
+    start: int
+    end: int
+    snippet: str
+
+
+def mask_non_code(source: str) -> str:
+    """Mask comments, strings, and character literals without shifting offsets."""
+    masked = list(source)
+
+    for match in _TOKEN_RE.finditer(source):
+        for index in range(match.start(), match.end()):
+            if masked[index] not in {"\n", "\r"}:
+                masked[index] = " "
+
+    return "".join(masked)
+
+
+def line_number(source: str, position: int) -> int:
+    offsets = [match.start() for match in re.finditer(r"\n", source)]
+    return bisect_right(offsets, position) + 1
+
+
+def find_calls(
+    source: str,
+    names: set[str] | None = None,
+) -> list[CSharpCall]:
+    """Return call expressions whose simple name is in *names*, if supplied."""
+    masked = mask_non_code(source)
+    calls: list[CSharpCall] = []
+
+    for match in _CALL_RE.finditer(masked):
+        callee = re.sub(
+            r"\s+",
+            "",
+            match.group("callee"),
+        )
+        simple_parts = _split_callee(callee)
+
+        if not simple_parts:
+            continue
+
+        name, generic_arguments = _split_generic(simple_parts[-1])
+        name = name.removeprefix("@")
+
+        if name in _CONTROL_NAMES:
+            continue
+
+        if names is not None and name not in names:
+            continue
+
+        open_paren = match.end() - 1
+        close_paren = _matching(
+            masked,
+            open_paren,
+            "(",
+            ")",
+        )
+
+        if close_paren is None:
+            continue
+
+        args_text = source[open_paren + 1 : close_paren]
+        named, positional = parse_arguments(args_text)
+        receiver = ".".join(simple_parts[:-1]) or None
+        prefix = masked[max(0, match.start() - 12) : match.start()]
+        is_constructor = bool(re.search(r"\bnew\s*$", prefix))
+        assigned_to = _assignment_target(
+            source,
+            match.start(),
+        )
+        end = close_paren + 1
+        snippet = " ".join(source[match.start() : end].strip().split())[:240]
+
+        calls.append(
+            CSharpCall(
+                callee=callee,
+                name=name,
+                receiver=receiver,
+                generic_arguments=generic_arguments,
+                arguments_text=args_text,
+                named_arguments=named,
+                positional_arguments=tuple(positional),
+                assigned_to=assigned_to,
+                is_constructor=is_constructor,
+                line=line_number(
+                    source,
+                    match.start(),
+                ),
+                start=match.start(),
+                end=end,
+                snippet=snippet,
+            )
+        )
+
+    return calls
+
+
+def parse_arguments(
+    value: str,
+) -> tuple[dict[str, str], list[str]]:
+    """Split C# call arguments into named and positional expressions."""
+    named: dict[str, str] = {}
+    positional: list[str] = []
+
+    for part in split_top_level(value):
+        item = part.strip()
+
+        if not item:
+            continue
+
+        name, expression = _named_argument(item)
+
+        if name is None:
+            positional.append(item)
+        else:
+            named[name] = expression
+
+    return named, positional
+
+
+def split_top_level(value: str) -> list[str]:
+    """Split comma-delimited C# text while respecting nesting and strings."""
+    parts: list[str] = []
+    start = 0
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+        "<": 0,
+    }
+    closing = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+        ">": "<",
+    }
+    index = 0
+    quote: str | None = None
+    verbatim = False
+    raw = False
+
+    while index < len(value):
+        if raw:
+            if value.startswith('"""', index):
+                raw = False
+                index += 3
+                continue
+
+            index += 1
+            continue
+
+        char = value[index]
+
+        if quote:
+            if verbatim:
+                if char == '"' and index + 1 < len(value) and value[index + 1] == '"':
+                    index += 2
+                    continue
+
+                if char == '"':
+                    quote = None
+                    verbatim = False
+            else:
+                if char == "\\":
+                    index += 2
+                    continue
+
+                if char == quote:
+                    quote = None
+
+            index += 1
+            continue
+
+        if value.startswith('"""', index):
+            raw = True
+            index += 3
+            continue
+
+        if char == '"':
+            quote = char
+            verbatim = index > 0 and value[index - 1] == "@"
+            index += 1
+            continue
+
+        if char == "'":
+            quote = char
+            index += 1
+            continue
+
+        if char in depths:
+            depths[char] += 1
+        elif char in closing:
+            opener = closing[char]
+            depths[opener] = max(
+                depths[opener] - 1,
+                0,
+            )
+        elif char == "," and not any(depths.values()):
+            parts.append(value[start:index])
+            start = index + 1
+
+        index += 1
+
+    parts.append(value[start:])
+    return parts
+
+
+def string_constants(
+    result: CSharpParseResult,
+) -> dict[str, str]:
+    """Build a variable-to-string map from parsed literal results."""
+    return {
+        literal.assigned_to: literal.value
+        for literal in result.string_literals
+        if literal.assigned_to and literal.value
+    }
+
+
+def resolve_expression(
+    expression: str | None,
+    constants: dict[str, str],
+) -> str:
+    """Resolve a simple C# string, constant, enum member, or nameof value."""
+    if not expression:
+        return ""
+
+    value = expression.strip()
+
+    while value.startswith("(") and value.endswith(")") and _balanced_outer(value):
+        value = value[1:-1].strip()
+
+    named = re.fullmatch(
+        r"nameof\s*\(\s*([^)]+)\s*\)",
+        value,
+    )
+
+    if named:
+        return named.group(1).split(".")[-1].strip()
+
+    uri = re.fullmatch(
+        r"new\s+Uri\s*\((.*)\)",
+        value,
+        re.DOTALL,
+    )
+
+    if uri:
+        return resolve_expression(
+            uri.group(1),
+            constants,
+        )
+
+    decoded = _decode_string(value)
+
+    if decoded is not None:
+        return decoded
+
+    identifier = value.removeprefix("global::").removeprefix("@").strip()
+
+    if identifier in constants:
+        return constants[identifier]
+
+    if re.fullmatch(
+        r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+",
+        identifier,
+    ):
+        return identifier
+
+    return ""
+
+
+def method_source(
+    source: str,
+    method: CSharpMethodDeclaration,
+) -> str:
+    """Return the source range covered by a parsed method declaration."""
+    lines = source.splitlines()
+    start = max(method.line - 1, 0)
+    end = min(
+        max(method.line_end, method.line),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
+def statement_tail(
+    source: str,
+    end: int,
+) -> str:
+    """Return the remainder of the current statement after a call."""
+    stop = source.find(";", end)
+
+    if stop < 0:
+        stop = min(
+            len(source),
+            end + 300,
+        )
+
+    return source[end:stop]
+
+
+def first_argument(
+    call: CSharpCall,
+    names: Iterable[str],
+    constants: dict[str, str],
+    position: int | None = 0,
+) -> str:
+    """Resolve the first named argument or optional positional argument."""
+    for name in names:
+        if name in call.named_arguments:
+            resolved = resolve_expression(
+                call.named_arguments[name],
+                constants,
+            )
+
+            if resolved:
+                return resolved
+
+    if position is not None and len(call.positional_arguments) > position:
+        return resolve_expression(
+            call.positional_arguments[position],
+            constants,
+        )
+
+    return ""
+
+
+def _split_callee(callee: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+
+    for index, char in enumerate(callee):
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth = max(depth - 1, 0)
+        elif char == "." and depth == 0:
+            parts.append(callee[start:index])
+            start = index + 1
+
+    parts.append(callee[start:])
+    return [part for part in parts if part]
+
+
+def _split_generic(
+    value: str,
+) -> tuple[str, tuple[str, ...]]:
+    match = re.fullmatch(
+        r"(?P<name>@?[A-Za-z_]\w*)"
+        r"\s*<(?P<args>.+)>",
+        value,
+    )
+
+    if not match:
+        return value, ()
+
+    return (
+        match.group("name"),
+        tuple(item.strip() for item in split_top_level(match.group("args")) if item.strip()),
+    )
+
+
+def _matching(
+    source: str,
+    start: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    depth = 0
+
+    for index in range(start, len(source)):
+        if source[index] == opening:
+            depth += 1
+        elif source[index] == closing:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _assignment_target(
+    source: str,
+    position: int,
+) -> str | None:
+    boundary = max(
+        source.rfind(";", 0, position),
+        source.rfind("\n", 0, position),
+    )
+    prefix = source[boundary + 1 : position]
+    match = re.search(
+        rf"(?P<name>{_IDENTIFIER})"
+        r"\s*=\s*(?:new\s+)?$",
+        prefix,
+    )
+
+    return match.group("name").removeprefix("@") if match else None
+
+
+def _named_argument(
+    value: str,
+) -> tuple[str | None, str]:
+    depth = 0
+
+    for index, char in enumerate(value):
+        if char in "([{<":
+            depth += 1
+        elif char in ")]}>":
+            depth = max(depth - 1, 0)
+        elif char == ":" and depth == 0:
+            name = value[:index].strip()
+
+            if re.fullmatch(_IDENTIFIER, name):
+                return (
+                    name.removeprefix("@"),
+                    value[index + 1 :].strip(),
+                )
+
+    return None, value
+
+
+def _decode_string(value: str) -> str | None:
+    raw_match = re.fullmatch(
+        r'\$*(?:@)?"""(.*)"""',
+        value,
+        re.DOTALL,
+    )
+
+    if raw_match:
+        return raw_match.group(1)
+
+    prefix_match = re.fullmatch(
+        r"(?P<prefix>\$@|@\$|\$|@)?"
+        r'"(?P<body>.*)"',
+        value,
+        re.DOTALL,
+    )
+
+    if not prefix_match:
+        return None
+
+    prefix = prefix_match.group("prefix") or ""
+    body = prefix_match.group("body")
+
+    if "@" in prefix:
+        return body.replace('""', '"')
+
+    replacements = {
+        r"\n": "\n",
+        r"\r": "\r",
+        r"\t": "\t",
+        r"\"": '"',
+        r"\\": "\\",
+    }
+
+    return re.sub(
+        r"\\(?:n|r|t|\"|\\)",
+        lambda match: replacements.get(
+            match.group(0),
+            match.group(0),
+        ),
+        body,
+    )
+
+
+def _balanced_outer(value: str) -> bool:
+    depth = 0
+
+    for index, char in enumerate(value):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+
+            if depth == 0 and index != len(value) - 1:
+                return False
+
+    return depth == 0
+
+
+__all__ = [
+    "CSharpCall",
+    "find_calls",
+    "first_argument",
+    "line_number",
+    "mask_non_code",
+    "method_source",
+    "parse_arguments",
+    "resolve_expression",
+    "split_top_level",
+    "statement_tail",
+    "string_constants",
+]

--- a/nuguard/sbom/adapters/csharp/aspnet_core.py
+++ b/nuguard/sbom/adapters/csharp/aspnet_core.py
@@ -1,0 +1,914 @@
+"""C# adapter for AI-facing ASP.NET Core routes."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import (
+    find_calls,
+    method_source,
+    parse_arguments,
+    resolve_expression,
+    statement_tail,
+    string_constants,
+)
+
+_HTTP_ATTRIBUTES = {
+    "HttpGet": "GET",
+    "HttpPost": "POST",
+    "HttpPut": "PUT",
+    "HttpDelete": "DELETE",
+    "HttpPatch": "PATCH",
+}
+_MAP_METHODS = {
+    "MapGet": "GET",
+    "MapPost": "POST",
+    "MapPut": "PUT",
+    "MapDelete": "DELETE",
+    "MapPatch": "PATCH",
+}
+_PROMPT_FIELDS = {
+    "message",
+    "messages",
+    "prompt",
+    "query",
+    "question",
+    "input",
+    "text",
+    "userinput",
+    "user_input",
+}
+_RESPONSE_FIELDS = {
+    "answer",
+    "content",
+    "message",
+    "output",
+    "response",
+    "result",
+    "text",
+}
+_PRIMITIVE_TYPES = {
+    "bool",
+    "byte",
+    "char",
+    "DateTime",
+    "DateTimeOffset",
+    "decimal",
+    "double",
+    "float",
+    "Guid",
+    "int",
+    "long",
+    "short",
+    "string",
+    "uint",
+    "ulong",
+    "ushort",
+}
+_INFRASTRUCTURE_TYPES = {
+    "CancellationToken",
+    "ClaimsPrincipal",
+    "HttpContext",
+    "HttpRequest",
+    "HttpResponse",
+    "IFormFile",
+    "IHeaderDictionary",
+    "IServiceProvider",
+}
+_AI_ROUTE_RE = re.compile(
+    r"(?:^|[/_-])"
+    r"(?:ai|ask|assistant|chat|complete|"
+    r"completion|generate|inference|model|"
+    r"predict|prompt)"
+    r"(?:$|[/_-])",
+    re.IGNORECASE,
+)
+_AI_CODE_RE = re.compile(
+    r"\b(?:AnthropicClient|AzureOpenAIClient|"
+    r"ChatClient|CompleteChat(?:Async)?|"
+    r"GetChatClient|Kernel\.(?:CreateBuilder|Invoke)|"
+    r"InvokePrompt(?:Async)?|"
+    r"Messages\.(?:Create|CreateAsync)|"
+    r"MLContext|PredictionEngine|"
+    r"OpenAIClient|ResponsesClient)\b"
+)
+_AI_NAMESPACE_PREFIXES = (
+    "Anthropic",
+    "Azure.AI.OpenAI",
+    "Microsoft.ML",
+    "Microsoft.SemanticKernel",
+    "OpenAI",
+)
+_PROPERTY_RE = re.compile(
+    r"(?m)^\s*public\s+"
+    r"(?P<type>[A-Za-z_][\w.<>,?\[\]]*)\s+"
+    r"(?P<name>[A-Za-z_]\w*)\s*"
+    r"\{\s*(?:get|init|set)\s*;"
+)
+
+
+class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
+    """Detect AI-facing controllers and Minimal API endpoints."""
+
+    name = "csharp_aspnet_core"
+    priority = 50
+    handles_namespaces = ["Microsoft.AspNetCore"]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result) and "WebApplication.CreateBuilder" not in content:
+            return []
+
+        constants = string_constants(result)
+        root = "framework:aspnet_core"
+        import_line = next(
+            (
+                item.line
+                for item in result.using_directives
+                if item.namespace.startswith("Microsoft.AspNetCore")
+            ),
+            0,
+        )
+        detections: list[ComponentDetection] = [
+            ComponentDetection(
+                component_type=(ComponentType.FRAMEWORK),
+                canonical_name=root,
+                display_name="ASP.NET Core",
+                adapter_name=self.name,
+                priority=self.priority,
+                confidence=0.97,
+                metadata={
+                    "framework": "aspnet_core",
+                    "language": "csharp",
+                },
+                file_path=file_path,
+                line=import_line,
+                snippet=("using Microsoft.AspNetCore"),
+                evidence_kind="ast_import",
+            )
+        ]
+
+        ai_imported = any(
+            any(
+                (item.namespace == prefix or item.namespace.startswith(prefix + "."))
+                for prefix in _AI_NAMESPACE_PREFIXES
+            )
+            for item in result.using_directives
+        )
+
+        detections.extend(
+            self._controller_endpoints(
+                content,
+                file_path,
+                result,
+                constants,
+                ai_imported,
+                root,
+            )
+        )
+        detections.extend(
+            self._minimal_endpoints(
+                content,
+                file_path,
+                result,
+                constants,
+                ai_imported,
+                root,
+            )
+        )
+
+        return _dedupe(detections)
+
+    def _controller_endpoints(
+        self,
+        content: str,
+        file_path: str,
+        result: Any,
+        constants: dict[str, str],
+        ai_imported: bool,
+        root: str,
+    ) -> list[ComponentDetection]:
+        detections: list[ComponentDetection] = []
+        controllers = {
+            item.name: (
+                item,
+                _declaration_attributes(
+                    item.attributes,
+                    item.signature,
+                ),
+            )
+            for item in result.type_declarations
+            if (
+                any(_base_type(base) == "ControllerBase" for base in item.base_types)
+                or _has_attribute(
+                    _declaration_attributes(
+                        item.attributes,
+                        item.signature,
+                    ),
+                    "ApiController",
+                )
+            )
+        }
+
+        for method in result.method_declarations:
+            controller_entry = controllers.get(method.containing_type or "")
+
+            if controller_entry is None:
+                continue
+
+            (
+                controller,
+                controller_attributes,
+            ) = controller_entry
+            method_attributes = _declaration_attributes(
+                method.attributes,
+                method.signature,
+            )
+            http_attribute = _http_attribute(
+                method_attributes,
+                constants,
+            )
+
+            if http_attribute is None:
+                continue
+
+            http_method, action_route = http_attribute
+            base_route = _route_attribute(
+                controller_attributes,
+                constants,
+            )
+            route = _combine_routes(
+                base_route,
+                action_route,
+                controller.name,
+                method.name,
+            )
+            body = method_source(
+                content,
+                method,
+            )
+
+            if not _is_ai_endpoint(
+                route,
+                method.name,
+                body,
+                ai_imported,
+            ):
+                continue
+
+            auth_required = (
+                _has_attribute(
+                    controller_attributes,
+                    "Authorize",
+                )
+                or _has_attribute(
+                    method_attributes,
+                    "Authorize",
+                )
+            ) and not _has_attribute(
+                method_attributes,
+                "AllowAnonymous",
+            )
+
+            params = [
+                parsed
+                for value in method.parameters
+                if (parsed := _parse_parameter(value)) is not None
+            ]
+            (
+                request_type,
+                request_name,
+            ) = _request_parameter(params)
+            request_schema = _schema_for_type(
+                content,
+                result,
+                request_type,
+            )
+            chat_key = _chat_key(
+                request_schema,
+                body,
+                request_name,
+            )
+            response_type = _unwrap_return_type(method.return_type or "")
+            response_schema = _schema_for_type(
+                content,
+                result,
+                response_type,
+            )
+            response_key = _response_key(response_schema)
+
+            detections.append(
+                _endpoint_node(
+                    adapter=self,
+                    root=root,
+                    file_path=file_path,
+                    line=method.line,
+                    http_method=http_method,
+                    route=route,
+                    display_name=method.name,
+                    snippet=method.signature,
+                    evidence_kind=("ast_attribute"),
+                    auth_required=(auth_required),
+                    request_schema=(request_schema),
+                    response_schema=(response_schema),
+                    chat_key=chat_key,
+                    response_key=response_key,
+                )
+            )
+
+        return detections
+
+    def _minimal_endpoints(
+        self,
+        content: str,
+        file_path: str,
+        result: Any,
+        constants: dict[str, str],
+        ai_imported: bool,
+        root: str,
+    ) -> list[ComponentDetection]:
+        detections: list[ComponentDetection] = []
+
+        for call in find_calls(
+            content,
+            set(_MAP_METHODS),
+        ):
+            if not call.positional_arguments:
+                continue
+
+            route = resolve_expression(
+                call.positional_arguments[0],
+                constants,
+            )
+
+            if not route:
+                continue
+
+            handler = call.positional_arguments[-1] if len(call.positional_arguments) > 1 else ""
+
+            if not _is_ai_endpoint(
+                route,
+                call.name,
+                handler,
+                ai_imported,
+            ):
+                continue
+
+            params = [
+                parsed
+                for value in _lambda_parameters(handler)
+                if (parsed := _parse_parameter(value)) is not None
+            ]
+            (
+                request_type,
+                request_name,
+            ) = _request_parameter(params)
+            request_schema = _schema_for_type(
+                content,
+                result,
+                request_type,
+            )
+            chat_key = _chat_key(
+                request_schema,
+                handler,
+                request_name,
+            )
+            auth_required = "RequireAuthorization" in statement_tail(
+                content,
+                call.end,
+            )
+            normalized_route = _normalize_route(route)
+            method = _MAP_METHODS[call.name]
+
+            detections.append(
+                _endpoint_node(
+                    adapter=self,
+                    root=root,
+                    file_path=file_path,
+                    line=call.line,
+                    http_method=method,
+                    route=normalized_route,
+                    display_name=(f"{method} {normalized_route}"),
+                    snippet=call.snippet,
+                    evidence_kind="ast_call",
+                    auth_required=(auth_required),
+                    request_schema=(request_schema),
+                    response_schema={},
+                    chat_key=chat_key,
+                    response_key=None,
+                )
+            )
+
+        return detections
+
+
+def _endpoint_node(
+    adapter: CSharpAspNetCoreAdapter,
+    root: str,
+    file_path: str,
+    line: int,
+    http_method: str,
+    route: str,
+    display_name: str,
+    snippet: str,
+    evidence_kind: str,
+    auth_required: bool,
+    request_schema: dict[str, str],
+    response_schema: dict[str, str],
+    chat_key: str | None,
+    response_key: str | None,
+) -> ComponentDetection:
+    canonical = canonicalize_text(f"aspnet:endpoint:{http_method}:{route}")
+    metadata: dict[str, Any] = {
+        "framework": "aspnet_core",
+        "method": http_method,
+        "endpoint": route,
+        "auth_required": auth_required,
+        "language": "csharp",
+    }
+
+    if request_schema:
+        metadata["request_body_schema"] = request_schema
+
+    if response_schema:
+        metadata["response_body_schema"] = response_schema
+
+    if chat_key:
+        metadata["chat_payload_key"] = chat_key
+        metadata["chat_payload_list"] = False
+
+    if response_key:
+        metadata["response_text_key"] = response_key
+
+    return ComponentDetection(
+        component_type=(ComponentType.API_ENDPOINT),
+        canonical_name=canonical,
+        display_name=display_name,
+        adapter_name=adapter.name,
+        priority=adapter.priority,
+        confidence=0.92,
+        metadata=metadata,
+        file_path=file_path,
+        line=line,
+        snippet=snippet,
+        evidence_kind=evidence_kind,
+        relationships=[
+            RelationshipHint(
+                source_canonical=root,
+                source_type=(ComponentType.FRAMEWORK),
+                target_canonical=canonical,
+                target_type=(ComponentType.API_ENDPOINT),
+                relationship_type="CALLS",
+            )
+        ],
+    )
+
+
+def _declaration_attributes(
+    parsed: tuple[str, ...],
+    signature: str,
+) -> tuple[str, ...]:
+    """Recover attributes containing brackets inside route strings."""
+    recovered: list[str] = []
+    index = 0
+
+    while index < len(signature):
+        start = signature.find(
+            "[",
+            index,
+        )
+
+        if start < 0:
+            break
+
+        depth = 1
+        quote: str | None = None
+        escaped = False
+        cursor = start + 1
+
+        while cursor < len(signature):
+            char = signature[cursor]
+
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif char == "\\" and quote == '"':
+                    escaped = True
+                elif char == quote:
+                    quote = None
+            elif char in {'"', "'"}:
+                quote = char
+            elif char == "[":
+                depth += 1
+            elif char == "]":
+                depth -= 1
+
+                if depth == 0:
+                    recovered.append(signature[start + 1 : cursor].strip())
+                    cursor += 1
+                    break
+
+            cursor += 1
+
+        if depth != 0:
+            break
+
+        index = cursor
+
+    return tuple(recovered) if recovered else parsed
+
+
+def _http_attribute(
+    attributes: tuple[str, ...],
+    constants: dict[str, str],
+) -> tuple[str, str] | None:
+    for attribute in attributes:
+        name, positional = _attribute_parts(
+            attribute,
+            constants,
+        )
+
+        if name in _HTTP_ATTRIBUTES:
+            return (
+                _HTTP_ATTRIBUTES[name],
+                positional[0] if positional else "",
+            )
+
+    return None
+
+
+def _route_attribute(
+    attributes: tuple[str, ...],
+    constants: dict[str, str],
+) -> str:
+    for attribute in attributes:
+        name, positional = _attribute_parts(
+            attribute,
+            constants,
+        )
+
+        if name == "Route" and positional:
+            return positional[0]
+
+    return ""
+
+
+def _attribute_parts(
+    attribute: str,
+    constants: dict[str, str],
+) -> tuple[str, list[str]]:
+    value = attribute.strip()
+
+    if "(" not in value:
+        return (
+            value.split(".")[-1].removesuffix("Attribute"),
+            [],
+        )
+
+    name, raw = value.split(
+        "(",
+        1,
+    )
+    raw = raw.rsplit(
+        ")",
+        1,
+    )[0]
+    _, positional = parse_arguments(raw)
+
+    return (
+        name.split(".")[-1].removesuffix("Attribute"),
+        [
+            resolved
+            for item in positional
+            if (
+                resolved := resolve_expression(
+                    item,
+                    constants,
+                )
+            )
+        ],
+    )
+
+
+def _has_attribute(
+    attributes: tuple[str, ...],
+    expected: str,
+) -> bool:
+    return any(
+        (
+            attribute.split(
+                "(",
+                1,
+            )[0]
+            .split(".")[-1]
+            .removesuffix("Attribute")
+            == expected
+        )
+        for attribute in attributes
+    )
+
+
+def _combine_routes(
+    base: str,
+    action: str,
+    controller_name: str,
+    action_name: str,
+) -> str:
+    controller = controller_name.removesuffix("Controller")
+    combined = "/".join(part.strip("/") for part in (base, action) if part.strip("/"))
+    combined = re.sub(
+        r"\[controller\]",
+        controller,
+        combined,
+        flags=re.IGNORECASE,
+    )
+    combined = re.sub(
+        r"\[action\]",
+        action_name,
+        combined,
+        flags=re.IGNORECASE,
+    )
+    return _normalize_route(combined)
+
+
+def _normalize_route(route: str) -> str:
+    clean = re.sub(
+        r"/{2,}",
+        "/",
+        "/" + route.strip(),
+    )
+    return clean if clean else "/"
+
+
+def _is_ai_endpoint(
+    route: str,
+    name: str,
+    body: str,
+    ai_imported: bool,
+) -> bool:
+    route_and_name = f"{route}/{name}"
+
+    if _AI_ROUTE_RE.search(route_and_name):
+        return True
+
+    if _AI_CODE_RE.search(body):
+        return True
+
+    return ai_imported and bool(
+        re.search(
+            r"\b(?:client|kernel|"
+            r"model|prompt)\b",
+            body,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _lambda_parameters(
+    handler: str,
+) -> list[str]:
+    match = re.search(
+        r"(?:async\s*)?"
+        r"\((?P<params>[^()]*)\)"
+        r"\s*=>",
+        handler,
+        re.DOTALL,
+    )
+
+    if match:
+        _, positional = parse_arguments(match.group("params"))
+        return positional
+
+    single = re.search(
+        r"(?:async\s+)?"
+        r"(?P<param>[A-Za-z_]\w*)"
+        r"\s*=>",
+        handler,
+    )
+
+    return [single.group("param")] if single else []
+
+
+def _parse_parameter(
+    value: str,
+) -> tuple[str, str, bool] | None:
+    clean = (
+        re.sub(
+            r"\[[^\]]+\]\s*",
+            "",
+            value,
+        )
+        .split(
+            "=",
+            1,
+        )[0]
+        .strip()
+    )
+    clean = re.sub(
+        r"\b(?:in|out|params|ref|"
+        r"scoped|this)\s+",
+        "",
+        clean,
+    )
+    match = re.search(
+        r"(?P<type>"
+        r"[A-Za-z_][\w.<>,?\[\]]*)"
+        r"\s+"
+        r"(?P<name>@?[A-Za-z_]\w*)$",
+        clean,
+    )
+
+    if not match:
+        return None
+
+    return (
+        match.group("type"),
+        match.group("name").removeprefix("@"),
+        "FromBody" in value,
+    )
+
+
+def _request_parameter(
+    parameters: list[tuple[str, str, bool]],
+) -> tuple[str, str | None]:
+    ordered = sorted(
+        parameters,
+        key=lambda item: not item[2],
+    )
+
+    for type_name, name, _ in ordered:
+        base = _base_type(type_name)
+
+        if base in _PRIMITIVE_TYPES or base in _INFRASTRUCTURE_TYPES:
+            continue
+
+        if base.startswith("I") and len(base) > 1 and base[1].isupper():
+            continue
+
+        return base, name
+
+    return "", None
+
+
+def _schema_for_type(
+    content: str,
+    result: Any,
+    type_name: str,
+) -> dict[str, str]:
+    if not type_name:
+        return {}
+
+    declaration = next(
+        (item for item in result.type_declarations if item.name == _base_type(type_name)),
+        None,
+    )
+
+    if declaration is None:
+        return {}
+
+    schema: dict[str, str] = {}
+    record_match = re.search(
+        r"\((?P<params>[^()]*)\)",
+        declaration.signature,
+        re.DOTALL,
+    )
+
+    if record_match:
+        _, values = parse_arguments(record_match.group("params"))
+
+        for value in values:
+            parameter = _parse_parameter(value)
+
+            if parameter is not None:
+                (
+                    field_type,
+                    field_name,
+                    _,
+                ) = parameter
+                schema[field_name] = field_type
+
+    lines = content.splitlines()
+    start = max(
+        declaration.line - 1,
+        0,
+    )
+    end = min(
+        max(
+            declaration.line_end,
+            declaration.line,
+        ),
+        len(lines),
+    )
+
+    for match in _PROPERTY_RE.finditer("\n".join(lines[start:end])):
+        schema.setdefault(
+            match.group("name"),
+            match.group("type"),
+        )
+
+    return schema
+
+
+def _chat_key(
+    schema: dict[str, str],
+    body: str,
+    request_name: str | None,
+) -> str | None:
+    for field in schema:
+        if field.lower() in _PROMPT_FIELDS:
+            return field
+
+    if request_name:
+        match = re.search(
+            rf"\b{re.escape(request_name)}"
+            r"\.(?P<field>[A-Za-z_]\w*)",
+            body,
+        )
+
+        if match and match.group("field").lower() in _PROMPT_FIELDS:
+            return match.group("field")
+
+    return None
+
+
+def _response_key(
+    schema: dict[str, str],
+) -> str | None:
+    return next(
+        (field for field in schema if field.lower() in _RESPONSE_FIELDS),
+        None,
+    )
+
+
+def _unwrap_return_type(value: str) -> str:
+    clean = value.strip().rstrip("?")
+    wrappers = (
+        "Task",
+        "ValueTask",
+        "ActionResult",
+        "Results",
+    )
+    changed = True
+
+    while changed:
+        changed = False
+
+        for wrapper in wrappers:
+            match = re.fullmatch(
+                rf"{wrapper}\s*"
+                r"<\s*(.+)\s*>",
+                clean,
+            )
+
+            if match:
+                clean = match.group(1).split(",", 1)[0].strip()
+                changed = True
+                break
+
+    return _base_type(clean)
+
+
+def _base_type(value: str) -> str:
+    clean = value.strip().rstrip("?")
+    clean = clean.removeprefix("global::")
+    clean = clean.split("<", 1)[0]
+    return clean.split(".")[-1]
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpAspNetCoreAdapter"]

--- a/nuguard/sbom/adapters/csharp/aspnet_core.py
+++ b/nuguard/sbom/adapters/csharp/aspnet_core.py
@@ -11,9 +11,11 @@ from ..base import ComponentDetection, RelationshipHint
 from ._csharp_base import CSharpFrameworkAdapter
 from ._source import (
     find_calls,
+    mask_non_code,
     method_source,
     parse_arguments,
     resolve_expression,
+    split_top_level,
     statement_tail,
     string_constants,
 )
@@ -131,7 +133,19 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
             parse_result,
         )
 
-        if not self._detect(result) and "WebApplication.CreateBuilder" not in content:
+        builder_call = next(
+            (
+                call
+                for call in find_calls(
+                    content,
+                    {"CreateBuilder"},
+                )
+                if (call.receiver or "").split(".")[-1] == "WebApplication"
+            ),
+            None,
+        )
+
+        if not self._detect(result) and builder_call is None:
             return []
 
         constants = string_constants(result)
@@ -280,9 +294,15 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                     method_attributes,
                     "Authorize",
                 )
-            ) and not _has_attribute(
-                method_attributes,
-                "AllowAnonymous",
+            ) and not (
+                _has_attribute(
+                    controller_attributes,
+                    "AllowAnonymous",
+                )
+                or _has_attribute(
+                    method_attributes,
+                    "AllowAnonymous",
+                )
             )
 
             params = [
@@ -388,10 +408,20 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 handler,
                 request_name,
             )
-            auth_required = "RequireAuthorization" in statement_tail(
-                content,
-                call.end,
+            tail = mask_non_code(
+                statement_tail(
+                    content,
+                    call.end,
+                )
             )
+            auth_required = "RequireAuthorization" in tail and "AllowAnonymous" not in tail
+            response_type = _minimal_response_type(handler)
+            response_schema = _schema_for_type(
+                content,
+                result,
+                response_type,
+            )
+            response_key = _response_key(response_schema)
             normalized_route = _normalize_route(route)
             method = _MAP_METHODS[call.name]
 
@@ -408,9 +438,9 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                     evidence_kind="ast_call",
                     auth_required=(auth_required),
                     request_schema=(request_schema),
-                    response_schema={},
+                    response_schema=(response_schema),
                     chat_key=chat_key,
-                    response_key=None,
+                    response_key=response_key,
                 )
             )
 
@@ -519,7 +549,11 @@ def _declaration_attributes(
                 depth -= 1
 
                 if depth == 0:
-                    recovered.append(signature[start + 1 : cursor].strip())
+                    recovered.extend(
+                        item.strip()
+                        for item in split_top_level(signature[start + 1 : cursor])
+                        if item.strip()
+                    )
                     cursor += 1
                     break
 
@@ -666,17 +700,58 @@ def _is_ai_endpoint(
     if _AI_ROUTE_RE.search(route_and_name):
         return True
 
-    if _AI_CODE_RE.search(body):
+    code = mask_non_code(body)
+
+    if _AI_CODE_RE.search(code):
         return True
 
     return ai_imported and bool(
         re.search(
             r"\b(?:client|kernel|"
             r"model|prompt)\b",
-            body,
+            code,
             re.IGNORECASE,
         )
     )
+
+
+def _minimal_response_type(
+    handler: str,
+) -> str:
+    """Infer a DTO instantiated by a Minimal API handler."""
+    code = mask_non_code(handler)
+    type_pattern = (
+        r"(?P<type>(?:global::)?"
+        r"[A-Za-z_]\w*"
+        r"(?:\.[A-Za-z_]\w*)*)"
+    )
+    patterns = (
+        (
+            r"\breturn\s+"
+            r"(?:await\s+)?"
+            r"(?:Results\.\w+\s*"
+            r"\(\s*)?"
+            r"new\s+" + type_pattern + r"\s*\("
+        ),
+        (
+            r"=>\s*"
+            r"(?:Results\.\w+\s*"
+            r"\(\s*)?"
+            r"new\s+" + type_pattern + r"\s*\("
+        ),
+    )
+
+    for pattern in patterns:
+        match = re.search(
+            pattern,
+            code,
+            re.DOTALL,
+        )
+
+        if match is not None:
+            return _base_type(match.group("type"))
+
+    return ""
 
 
 def _lambda_parameters(

--- a/nuguard/sbom/adapters/csharp/llm_clients.py
+++ b/nuguard/sbom/adapters/csharp/llm_clients.py
@@ -1,0 +1,410 @@
+"""C# adapters for the Azure OpenAI, OpenAI, and Anthropic SDKs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ..models_kb import get_model_details, infer_provider
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import (
+    find_calls,
+    first_argument,
+    line_number,
+    resolve_expression,
+    string_constants,
+)
+
+_PROVIDER_NAMESPACES: dict[str, tuple[str, ...]] = {
+    "azure": ("Azure.AI.OpenAI",),
+    "openai": ("OpenAI",),
+    "anthropic": ("Anthropic",),
+}
+_CLIENT_CLASSES: dict[str, str] = {
+    "AzureOpenAIClient": "azure",
+    "OpenAIClient": "openai",
+    "ChatClient": "openai",
+    "ResponsesClient": "openai",
+    "EmbeddingClient": "openai",
+    "AssistantClient": "openai",
+    "AnthropicClient": "anthropic",
+}
+_MODEL_CLIENT_CLASSES = {
+    "ChatClient",
+    "ResponsesClient",
+    "EmbeddingClient",
+}
+_MODEL_FACTORY_CALLS = {
+    "GetChatClient",
+    "GetResponsesClient",
+    "GetEmbeddingClient",
+    "GetAssistantClient",
+}
+_MODEL_API_CALLS = {
+    "CompleteChat",
+    "CompleteChatAsync",
+    "Create",
+    "CreateAsync",
+    "GenerateResponse",
+    "GenerateResponseAsync",
+}
+_MODEL_ASSIGNMENT_RE = re.compile(
+    r"\bModel\s*=\s*(?P<value>"
+    r'\$?@?"(?:""|\\.|[^"])*"'
+    r"|[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)",
+    re.MULTILINE,
+)
+
+
+class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
+    """Detect direct C# usage of supported LLM client libraries."""
+
+    name = "csharp_llm_clients"
+    priority = 90
+    handles_namespaces = [
+        "Azure.AI.OpenAI",
+        "OpenAI",
+        "Anthropic",
+    ]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+        providers = _providers_from_result(result)
+
+        strong_markers = (
+            "AzureOpenAIClient",
+            "AnthropicClient",
+            "OpenAI.Chat.ChatClient",
+            "OpenAI.Responses.ResponsesClient",
+            "OpenAI.Embeddings.EmbeddingClient",
+        )
+
+        if not providers and not any(marker in content for marker in strong_markers):
+            return []
+
+        constants = string_constants(result)
+        detections: list[ComponentDetection] = []
+        provider_lines: dict[str, int] = {}
+
+        for directive in result.using_directives:
+            provider = _provider_for_namespace(directive.namespace)
+
+            if provider is not None:
+                provider_lines.setdefault(
+                    provider,
+                    directive.line,
+                )
+
+        calls = find_calls(
+            content,
+            set(_CLIENT_CLASSES) | _MODEL_FACTORY_CALLS | _MODEL_API_CALLS,
+        )
+
+        client_providers: dict[str, str] = {}
+
+        for call in calls:
+            provider = _provider_for_call(
+                call.name,
+                call.receiver,
+                providers,
+                client_providers,
+            )
+
+            if provider is not None and call.assigned_to:
+                client_providers[call.assigned_to] = provider
+
+        for call in calls:
+            provider = _provider_for_call(
+                call.name,
+                call.receiver,
+                providers,
+                client_providers,
+            )
+
+            if provider is None:
+                continue
+
+            provider_lines.setdefault(
+                provider,
+                call.line,
+            )
+            model_name = ""
+
+            if call.name in _MODEL_CLIENT_CLASSES and call.is_constructor:
+                model_name = first_argument(
+                    call,
+                    (
+                        "model",
+                        "modelId",
+                        "model_id",
+                        "deploymentName",
+                    ),
+                    constants,
+                    0,
+                )
+            elif call.name in _MODEL_FACTORY_CALLS:
+                model_name = first_argument(
+                    call,
+                    (
+                        "model",
+                        "modelId",
+                        "deploymentName",
+                        "deployment",
+                    ),
+                    constants,
+                    0,
+                )
+            elif call.name in _MODEL_API_CALLS:
+                model_name = first_argument(
+                    call,
+                    (
+                        "model",
+                        "modelId",
+                        "model_id",
+                    ),
+                    constants,
+                    None,
+                )
+
+            if model_name:
+                detections.append(
+                    _model_node(
+                        adapter=self,
+                        provider=provider,
+                        model_name=model_name,
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        client_class=call.name,
+                    )
+                )
+
+        if "anthropic" in providers or "AnthropicClient" in content:
+            for match in _MODEL_ASSIGNMENT_RE.finditer(content):
+                model_name = resolve_expression(
+                    match.group("value"),
+                    constants,
+                )
+
+                if not model_name:
+                    continue
+
+                line = line_number(
+                    content,
+                    match.start(),
+                )
+                provider_lines.setdefault(
+                    "anthropic",
+                    line,
+                )
+                detections.append(
+                    _model_node(
+                        adapter=self,
+                        provider="anthropic",
+                        model_name=model_name,
+                        file_path=file_path,
+                        line=line,
+                        snippet=" ".join(match.group(0).split()),
+                        client_class="AnthropicClient",
+                    )
+                )
+
+        for provider in sorted(providers | set(provider_lines)):
+            detections.insert(
+                0,
+                _framework_node(
+                    adapter=self,
+                    provider=provider,
+                    file_path=file_path,
+                    line=provider_lines.get(
+                        provider,
+                        0,
+                    ),
+                ),
+            )
+
+        return _dedupe(detections)
+
+
+def _providers_from_result(
+    result: Any,
+) -> set[str]:
+    providers: set[str] = set()
+
+    for directive in result.using_directives:
+        provider = _provider_for_namespace(directive.namespace)
+
+        if provider is not None:
+            providers.add(provider)
+
+    return providers
+
+
+def _provider_for_namespace(
+    namespace: str,
+) -> str | None:
+    clean = namespace.removeprefix("global::")
+
+    for provider, prefixes in _PROVIDER_NAMESPACES.items():
+        if any(clean == prefix or clean.startswith(prefix + ".") for prefix in prefixes):
+            return provider
+
+    return None
+
+
+def _provider_for_call(
+    name: str,
+    receiver: str | None,
+    imported: set[str],
+    client_providers: dict[str, str],
+) -> str | None:
+    if name == "OpenAIClient" and imported == {"azure"}:
+        return "azure"
+
+    if name in _CLIENT_CLASSES:
+        return _CLIENT_CLASSES[name]
+
+    receiver_text = receiver or ""
+    receiver_root = receiver_text.split(
+        ".",
+        1,
+    )[0]
+
+    if receiver_root in client_providers:
+        return client_providers[receiver_root]
+
+    if "AzureOpenAI" in receiver_text:
+        return "azure"
+
+    if "Anthropic" in receiver_text or "Messages" in receiver_text:
+        return "anthropic"
+
+    if "OpenAI" in receiver_text or "Chat" in receiver_text or "Responses" in receiver_text:
+        return "openai"
+
+    if len(imported) == 1:
+        return next(iter(imported))
+
+    return None
+
+
+def _framework_node(
+    adapter: CSharpLLMClientsAdapter,
+    provider: str,
+    file_path: str,
+    line: int,
+) -> ComponentDetection:
+    framework = "azure_openai" if provider == "azure" else provider
+    display = {
+        "azure": "Azure OpenAI .NET SDK",
+        "openai": "OpenAI .NET SDK",
+        "anthropic": "Anthropic C# SDK",
+    }[provider]
+
+    return ComponentDetection(
+        component_type=ComponentType.FRAMEWORK,
+        canonical_name=(f"framework:{framework}"),
+        display_name=display,
+        adapter_name=adapter.name,
+        priority=adapter.priority,
+        confidence=0.95,
+        metadata={
+            "framework": framework,
+            "provider": provider,
+            "language": "csharp",
+            "client_kind": "llm_sdk",
+        },
+        file_path=file_path,
+        line=line,
+        snippet=f"using {display}",
+        evidence_kind="ast_import",
+    )
+
+
+def _model_node(
+    adapter: CSharpLLMClientsAdapter,
+    provider: str,
+    model_name: str,
+    file_path: str,
+    line: int,
+    snippet: str,
+    client_class: str,
+) -> ComponentDetection:
+    inferred = infer_provider(model_name)
+    effective_provider = provider if provider != "azure" else "azure"
+
+    if effective_provider == "openai" and inferred not in {"unknown", "openai"}:
+        effective_provider = inferred
+
+    details = get_model_details(
+        model_name,
+        effective_provider,
+        {},
+    )
+    canonical = canonicalize_text(model_name.lower())
+    framework = "azure_openai" if provider == "azure" else provider
+
+    return ComponentDetection(
+        component_type=ComponentType.MODEL,
+        canonical_name=canonical,
+        display_name=model_name,
+        adapter_name=adapter.name,
+        priority=adapter.priority,
+        confidence=0.93,
+        metadata={
+            "framework": framework,
+            "provider": effective_provider,
+            "client_class": client_class,
+            "language": "csharp",
+            **{key: value for key, value in details.items() if value is not None},
+        },
+        file_path=file_path,
+        line=line,
+        snippet=snippet,
+        evidence_kind="ast_call",
+        relationships=[
+            RelationshipHint(
+                source_canonical=(f"framework:{framework}"),
+                source_type=ComponentType.FRAMEWORK,
+                target_canonical=canonical,
+                target_type=ComponentType.MODEL,
+                relationship_type="USES",
+            )
+        ],
+    )
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpLLMClientsAdapter"]

--- a/nuguard/sbom/adapters/csharp/llm_clients.py
+++ b/nuguard/sbom/adapters/csharp/llm_clients.py
@@ -14,6 +14,7 @@ from ._source import (
     find_calls,
     first_argument,
     line_number,
+    mask_non_code,
     resolve_expression,
     string_constants,
 )
@@ -51,10 +52,10 @@ _MODEL_API_CALLS = {
     "GenerateResponse",
     "GenerateResponseAsync",
 }
-_MODEL_ASSIGNMENT_RE = re.compile(
-    r"\bModel\s*=\s*(?P<value>"
-    r'\$?@?"(?:""|\\.|[^"])*"'
-    r"|[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)",
+_MODEL_ENUM_ASSIGNMENT_RE = re.compile(
+    r"\bModel\s*=\s*"
+    r"(?P<value>[A-Za-z_]\w*"
+    r"(?:\.[A-Za-z_]\w*)*)",
     re.MULTILINE,
 )
 
@@ -81,17 +82,19 @@ class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
             file_path,
             parse_result,
         )
+        code = mask_non_code(content)
         providers = _providers_from_result(result)
 
         strong_markers = (
             "AzureOpenAIClient",
+            "Azure.AI.OpenAI.OpenAIClient",
             "AnthropicClient",
             "OpenAI.Chat.ChatClient",
             "OpenAI.Responses.ResponsesClient",
             "OpenAI.Embeddings.EmbeddingClient",
         )
 
-        if not providers and not any(marker in content for marker in strong_markers):
+        if not providers and not any(marker in code for marker in strong_markers):
             return []
 
         constants = string_constants(result)
@@ -191,8 +194,33 @@ class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
                     )
                 )
 
-        if "anthropic" in providers or "AnthropicClient" in content:
-            for match in _MODEL_ASSIGNMENT_RE.finditer(content):
+        if "anthropic" in providers or "AnthropicClient" in code:
+            for literal in result.string_literals:
+                if (literal.assigned_to or "").casefold() != "model":
+                    continue
+
+                model_name = literal.value.strip()
+
+                if not model_name:
+                    continue
+
+                provider_lines.setdefault(
+                    "anthropic",
+                    literal.line,
+                )
+                detections.append(
+                    _model_node(
+                        adapter=self,
+                        provider="anthropic",
+                        model_name=model_name,
+                        file_path=file_path,
+                        line=literal.line,
+                        snippet=f'Model = "{model_name}"',
+                        client_class="AnthropicClient",
+                    )
+                )
+
+            for match in _MODEL_ENUM_ASSIGNMENT_RE.finditer(code):
                 model_name = resolve_expression(
                     match.group("value"),
                     constants,
@@ -216,7 +244,7 @@ class CSharpLLMClientsAdapter(CSharpFrameworkAdapter):
                         model_name=model_name,
                         file_path=file_path,
                         line=line,
-                        snippet=" ".join(match.group(0).split()),
+                        snippet=" ".join(content[match.start() : match.end()].split()),
                         client_class="AnthropicClient",
                     )
                 )
@@ -270,13 +298,14 @@ def _provider_for_call(
     imported: set[str],
     client_providers: dict[str, str],
 ) -> str | None:
-    if name == "OpenAIClient" and imported == {"azure"}:
+    receiver_text = receiver or ""
+
+    if name == "OpenAIClient" and (imported == {"azure"} or "Azure.AI.OpenAI" in receiver_text):
         return "azure"
 
     if name in _CLIENT_CLASSES:
         return _CLIENT_CLASSES[name]
 
-    receiver_text = receiver or ""
     receiver_root = receiver_text.split(
         ".",
         1,

--- a/nuguard/sbom/adapters/csharp/mlnet.py
+++ b/nuguard/sbom/adapters/csharp/mlnet.py
@@ -41,7 +41,22 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
             parse_result,
         )
 
-        if not self._detect(result) and "MLContext" not in content:
+        calls = find_calls(content)
+        context_calls = [
+            call
+            for call in calls
+            if (
+                call.name == "MLContext"
+                and call.is_constructor
+                and (
+                    self._detect(result)
+                    or not call.receiver
+                    or (call.receiver or "").endswith("Microsoft.ML")
+                )
+            )
+        ]
+
+        if not self._detect(result) and not context_calls:
             return []
 
         root = "framework:mlnet"
@@ -72,9 +87,10 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
             )
         ]
 
-        pipeline_emitted = False
+        emitted_pipeline_ids: set[str] = set()
+        estimator_variables: set[str] = set()
 
-        for call in find_calls(content):
+        for call in calls:
             receiver = call.receiver or ""
 
             if call.name == "MLContext" and call.is_constructor:
@@ -111,6 +127,9 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 continue
 
             if ".Trainers" in receiver:
+                if call.assigned_to:
+                    estimator_variables.add(call.assigned_to)
+
                 task = _task_from_receiver(receiver)
                 display = call.name
                 canonical = canonicalize_text(f"mlnet:trainer:{task}:{display}")
@@ -147,10 +166,15 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 continue
 
             if ".Transforms" in receiver:
-                if pipeline_emitted:
+                pipeline_id = call.assigned_to or f"line:{call.line}"
+
+                if call.assigned_to:
+                    estimator_variables.add(call.assigned_to)
+
+                if pipeline_id in emitted_pipeline_ids:
                     continue
 
-                display = call.assigned_to or "ML.NET pipeline"
+                display = call.assigned_to or f"ML.NET pipeline {call.line}"
                 canonical = canonicalize_text(f"mlnet:pipeline:{display}")
                 detections.append(
                     ComponentDetection(
@@ -172,10 +196,23 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                         evidence_kind="ast_call",
                     )
                 )
-                pipeline_emitted = True
+                emitted_pipeline_ids.add(pipeline_id)
                 continue
 
             if call.name == "Fit" and call.receiver:
+                receiver_root = call.receiver.split(
+                    ".",
+                    1,
+                )[0]
+                is_known_estimator = (
+                    receiver_root in estimator_variables
+                    or ".Transforms" in call.receiver
+                    or ".Trainers" in call.receiver
+                )
+
+                if not is_known_estimator:
+                    continue
+
                 display = call.assigned_to or f"trained_model_{call.line}"
                 canonical = canonicalize_text(f"mlnet:model:{display}")
                 detections.append(

--- a/nuguard/sbom/adapters/csharp/mlnet.py
+++ b/nuguard/sbom/adapters/csharp/mlnet.py
@@ -1,0 +1,245 @@
+"""C# adapter for ML.NET contexts, pipelines, and trainers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import find_calls
+
+_TASK_SEGMENTS = {
+    "BinaryClassification": ("binary_classification"),
+    "MulticlassClassification": ("multiclass_classification"),
+    "Regression": "regression",
+    "Clustering": "clustering",
+    "Ranking": "ranking",
+    "Recommendation": "recommendation",
+    "Forecasting": "forecasting",
+    "AnomalyDetection": "anomaly_detection",
+}
+
+
+class CSharpMLNetAdapter(CSharpFrameworkAdapter):
+    """Detect ML.NET model-building and prediction pipelines."""
+
+    name = "csharp_mlnet"
+    priority = 55
+    handles_namespaces = ["Microsoft.ML"]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result) and "MLContext" not in content:
+            return []
+
+        root = "framework:mlnet"
+        import_line = next(
+            (
+                item.line
+                for item in result.using_directives
+                if (item.namespace == "Microsoft.ML" or item.namespace.startswith("Microsoft.ML."))
+            ),
+            0,
+        )
+        detections: list[ComponentDetection] = [
+            ComponentDetection(
+                component_type=(ComponentType.FRAMEWORK),
+                canonical_name=root,
+                display_name="ML.NET",
+                adapter_name=self.name,
+                priority=self.priority,
+                confidence=0.97,
+                metadata={
+                    "framework": "mlnet",
+                    "language": "csharp",
+                },
+                file_path=file_path,
+                line=import_line,
+                snippet="using Microsoft.ML",
+                evidence_kind="ast_import",
+            )
+        ]
+
+        pipeline_emitted = False
+
+        for call in find_calls(content):
+            receiver = call.receiver or ""
+
+            if call.name == "MLContext" and call.is_constructor:
+                display = call.assigned_to or "MLContext"
+                canonical = canonicalize_text(f"mlnet:context:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.FRAMEWORK),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.95,
+                        metadata={
+                            "framework": "mlnet",
+                            "context_class": ("MLContext"),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind=("ast_instantiation"),
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.FRAMEWORK),
+                                relationship_type=("CONTAINS"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if ".Trainers" in receiver:
+                task = _task_from_receiver(receiver)
+                display = call.name
+                canonical = canonicalize_text(f"mlnet:trainer:{task}:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.MODEL),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.92,
+                        metadata={
+                            "framework": "mlnet",
+                            "provider": "mlnet",
+                            "trainer": call.name,
+                            "task": task,
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.MODEL),
+                                relationship_type="USES",
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if ".Transforms" in receiver:
+                if pipeline_emitted:
+                    continue
+
+                display = call.assigned_to or "ML.NET pipeline"
+                canonical = canonicalize_text(f"mlnet:pipeline:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.FRAMEWORK),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.86,
+                        metadata={
+                            "framework": "mlnet",
+                            "pipeline": True,
+                            "first_stage": call.name,
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                    )
+                )
+                pipeline_emitted = True
+                continue
+
+            if call.name == "Fit" and call.receiver:
+                display = call.assigned_to or f"trained_model_{call.line}"
+                canonical = canonicalize_text(f"mlnet:model:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.MODEL),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.90,
+                        metadata={
+                            "framework": "mlnet",
+                            "provider": "mlnet",
+                            "trained_model": True,
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.MODEL),
+                                relationship_type="USES",
+                            )
+                        ],
+                    )
+                )
+
+        return _dedupe(detections)
+
+
+def _task_from_receiver(
+    receiver: str,
+) -> str:
+    for segment, task in _TASK_SEGMENTS.items():
+        if segment in receiver:
+            return task
+
+    return "machine_learning"
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpMLNetAdapter"]

--- a/nuguard/sbom/adapters/csharp/semantic_kernel.py
+++ b/nuguard/sbom/adapters/csharp/semantic_kernel.py
@@ -66,7 +66,30 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
             parse_result,
         )
 
-        if not self._detect(result) and "Microsoft.SemanticKernel" not in content:
+        calls = find_calls(
+            content,
+            _KERNEL_CALLS | set(_SERVICE_CALLS) | _PLUGIN_CALLS | _PLANNER_CLASSES,
+        )
+        has_kernel_call = any(
+            (call.name == "CreateBuilder" and (call.receiver or "").split(".")[-1] == "Kernel")
+            or (call.name == "KernelBuilder" and call.is_constructor)
+            or call.name in _SERVICE_CALLS
+            or call.name in _PLUGIN_CALLS
+            or (call.name in _PLANNER_CLASSES and call.is_constructor)
+            for call in calls
+        )
+        has_kernel_attribute = any(
+            any(
+                (
+                    attribute.split("(", 1)[0].split(".")[-1].removesuffix("Attribute")
+                    == "KernelFunction"
+                )
+                for attribute in method.attributes
+            )
+            for method in result.method_declarations
+        )
+
+        if not self._detect(result) and not has_kernel_call and not has_kernel_attribute:
             return []
 
         constants = string_constants(result)
@@ -97,11 +120,6 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
                 evidence_kind="ast_import",
             )
         ]
-
-        calls = find_calls(
-            content,
-            _KERNEL_CALLS | set(_SERVICE_CALLS) | _PLUGIN_CALLS | _PLANNER_CLASSES,
-        )
 
         builder_variables: set[str] = set()
 

--- a/nuguard/sbom/adapters/csharp/semantic_kernel.py
+++ b/nuguard/sbom/adapters/csharp/semantic_kernel.py
@@ -1,0 +1,418 @@
+"""C# adapter for Microsoft Semantic Kernel."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+from ..models_kb import get_model_details
+from ._csharp_base import CSharpFrameworkAdapter
+from ._source import (
+    find_calls,
+    first_argument,
+    string_constants,
+)
+
+_SERVICE_CALLS: dict[str, str] = {
+    "AddAzureOpenAIChatCompletion": "azure",
+    "AddAzureOpenAITextEmbeddingGeneration": "azure",
+    "AddOpenAIChatCompletion": "openai",
+    "AddOpenAITextEmbeddingGeneration": "openai",
+    "AddAnthropicChatCompletion": "anthropic",
+    "AddOllamaChatCompletion": "ollama",
+    "AddMistralChatCompletion": "mistral",
+}
+_PLUGIN_CALLS = {
+    "AddFromType",
+    "ImportPluginFromType",
+    "AddFromObject",
+    "ImportPluginFromObject",
+    "AddFromPromptDirectory",
+    "ImportPluginFromPromptDirectory",
+    "CreateFromType",
+}
+_PLANNER_CLASSES = {
+    "ActionPlanner",
+    "FunctionCallingStepwisePlanner",
+    "HandlebarsPlanner",
+    "SequentialPlanner",
+    "StepwisePlanner",
+}
+_KERNEL_CALLS = {
+    "CreateBuilder",
+    "Build",
+    "KernelBuilder",
+}
+
+
+class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
+    """Detect Semantic Kernel services, plugins, planners, and prompts."""
+
+    name = "csharp_semantic_kernel"
+    priority = 40
+    handles_namespaces = ["Microsoft.SemanticKernel"]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result) and "Microsoft.SemanticKernel" not in content:
+            return []
+
+        constants = string_constants(result)
+        root = "framework:semantic_kernel"
+        import_line = next(
+            (
+                item.line
+                for item in result.using_directives
+                if item.namespace.startswith("Microsoft.SemanticKernel")
+            ),
+            0,
+        )
+        detections: list[ComponentDetection] = [
+            ComponentDetection(
+                component_type=(ComponentType.FRAMEWORK),
+                canonical_name=root,
+                display_name=("Microsoft Semantic Kernel"),
+                adapter_name=self.name,
+                priority=self.priority,
+                confidence=0.98,
+                metadata={
+                    "framework": "semantic_kernel",
+                    "language": "csharp",
+                },
+                file_path=file_path,
+                line=import_line,
+                snippet=("using Microsoft.SemanticKernel"),
+                evidence_kind="ast_import",
+            )
+        ]
+
+        calls = find_calls(
+            content,
+            _KERNEL_CALLS | set(_SERVICE_CALLS) | _PLUGIN_CALLS | _PLANNER_CLASSES,
+        )
+
+        builder_variables: set[str] = set()
+
+        for call in calls:
+            if call.name in _KERNEL_CALLS:
+                receiver = call.receiver or ""
+                is_kernel_builder = (
+                    (call.name == "CreateBuilder" and receiver.split(".")[-1] == "Kernel")
+                    or (call.name == "KernelBuilder" and call.is_constructor)
+                    or (call.name == "Build" and receiver.split(".")[0] in builder_variables)
+                )
+
+                if not is_kernel_builder:
+                    continue
+
+                if (
+                    call.name
+                    in {
+                        "CreateBuilder",
+                        "KernelBuilder",
+                    }
+                    and call.assigned_to
+                ):
+                    builder_variables.add(call.assigned_to)
+
+                instance_name = call.assigned_to or "kernel"
+                canonical = canonicalize_text(f"semantic_kernel:{instance_name}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.FRAMEWORK),
+                        canonical_name=canonical,
+                        display_name=instance_name,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.94,
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "builder_call": (call.name),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.FRAMEWORK),
+                                relationship_type=("CONTAINS"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if call.name in _SERVICE_CALLS:
+                provider = _SERVICE_CALLS[call.name]
+                model_name = first_argument(
+                    call,
+                    (
+                        "modelId",
+                        "model_id",
+                        "deploymentName",
+                        "deployment",
+                        "aiModelId",
+                    ),
+                    constants,
+                    0,
+                )
+
+                if not model_name:
+                    model_name = call.name.removeprefix("Add").removesuffix("ChatCompletion")
+
+                canonical = canonicalize_text(model_name.lower())
+                details = get_model_details(
+                    model_name,
+                    provider,
+                    {},
+                )
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.MODEL),
+                        canonical_name=canonical,
+                        display_name=model_name,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=(0.91 if model_name else 0.82),
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "provider": provider,
+                            "registration": (call.name),
+                            "language": "csharp",
+                            **{key: value for key, value in details.items() if value is not None},
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.MODEL),
+                                relationship_type=("USES"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if call.name in _PLUGIN_CALLS:
+                plugin_type = call.generic_arguments[0] if call.generic_arguments else ""
+                plugin_name = first_argument(
+                    call,
+                    (
+                        "pluginName",
+                        "name",
+                    ),
+                    constants,
+                    0,
+                )
+                display = plugin_name or plugin_type or call.assigned_to or f"plugin_{call.line}"
+                canonical = canonicalize_text(f"semantic_kernel:plugin:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.TOOL),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.90,
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "registration": (call.name),
+                            "plugin_type": (plugin_type or None),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind="ast_call",
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.TOOL),
+                                relationship_type=("USES"),
+                            )
+                        ],
+                    )
+                )
+                continue
+
+            if call.name in _PLANNER_CLASSES and call.is_constructor:
+                display = call.assigned_to or call.name
+                canonical = canonicalize_text(f"semantic_kernel:planner:{display}")
+                detections.append(
+                    ComponentDetection(
+                        component_type=(ComponentType.AGENT),
+                        canonical_name=canonical,
+                        display_name=display,
+                        adapter_name=self.name,
+                        priority=self.priority,
+                        confidence=0.90,
+                        metadata={
+                            "framework": ("semantic_kernel"),
+                            "planner_class": (call.name),
+                            "language": "csharp",
+                        },
+                        file_path=file_path,
+                        line=call.line,
+                        snippet=call.snippet,
+                        evidence_kind=("ast_instantiation"),
+                        relationships=[
+                            RelationshipHint(
+                                source_canonical=root,
+                                source_type=(ComponentType.FRAMEWORK),
+                                target_canonical=(canonical),
+                                target_type=(ComponentType.AGENT),
+                                relationship_type=("USES"),
+                            )
+                        ],
+                    )
+                )
+
+        for method in result.method_declarations:
+            is_kernel_function = any(
+                (
+                    attribute.split(
+                        "(",
+                        1,
+                    )[0]
+                    .split(".")[-1]
+                    .removesuffix("Attribute")
+                    == "KernelFunction"
+                )
+                for attribute in method.attributes
+            )
+
+            if not is_kernel_function:
+                continue
+
+            canonical = canonicalize_text(f"semantic_kernel:function:{method.name}")
+            detections.append(
+                ComponentDetection(
+                    component_type=(ComponentType.TOOL),
+                    canonical_name=canonical,
+                    display_name=method.name,
+                    adapter_name=self.name,
+                    priority=self.priority,
+                    confidence=0.93,
+                    metadata={
+                        "framework": ("semantic_kernel"),
+                        "registration": ("KernelFunctionAttribute"),
+                        "containing_type": (method.containing_type),
+                        "language": "csharp",
+                    },
+                    file_path=file_path,
+                    line=method.line,
+                    snippet=method.signature,
+                    evidence_kind="ast_attribute",
+                    relationships=[
+                        RelationshipHint(
+                            source_canonical=root,
+                            source_type=(ComponentType.FRAMEWORK),
+                            target_canonical=(canonical),
+                            target_type=(ComponentType.TOOL),
+                            relationship_type="USES",
+                        )
+                    ],
+                )
+            )
+
+        for literal in result.string_literals:
+            assigned = (literal.assigned_to or "").lower()
+            prompt_name = any(
+                token in assigned
+                for token in (
+                    "prompt",
+                    "template",
+                    "instruction",
+                )
+            )
+
+            if not (literal.is_potential_prompt or prompt_name):
+                continue
+
+            if len(literal.value.strip()) < 12:
+                continue
+
+            display = literal.assigned_to or f"prompt_{literal.line}"
+            canonical = canonicalize_text(f"semantic_kernel:prompt:{display}")
+            detections.append(
+                ComponentDetection(
+                    component_type=(ComponentType.PROMPT),
+                    canonical_name=canonical,
+                    display_name=display,
+                    adapter_name=self.name,
+                    priority=self.priority,
+                    confidence=0.86,
+                    metadata={
+                        "framework": ("semantic_kernel"),
+                        "role": "system",
+                        "content": literal.value,
+                        "char_count": len(literal.value),
+                        "is_template": (literal.is_interpolated),
+                        "template_variables": list(literal.interpolation_expressions),
+                        "language": "csharp",
+                    },
+                    file_path=file_path,
+                    line=literal.line,
+                    snippet=literal.value[:160],
+                    evidence_kind=("ast_string_literal"),
+                    relationships=[
+                        RelationshipHint(
+                            source_canonical=root,
+                            source_type=(ComponentType.FRAMEWORK),
+                            target_canonical=(canonical),
+                            target_type=(ComponentType.PROMPT),
+                            relationship_type="USES",
+                        )
+                    ],
+                )
+            )
+
+        return _dedupe(detections)
+
+
+def _dedupe(
+    detections: list[ComponentDetection],
+) -> list[ComponentDetection]:
+    seen: set[tuple[ComponentType, str]] = set()
+    result: list[ComponentDetection] = []
+
+    for detection in detections:
+        key = (
+            detection.component_type,
+            detection.canonical_name,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        result.append(detection)
+
+    return result
+
+
+__all__ = ["CSharpSemanticKernelAdapter"]

--- a/nuguard/sbom/config.py
+++ b/nuguard/sbom/config.py
@@ -91,6 +91,7 @@ class AiSbomConfig(BaseModel):
     include_extensions: set[str] = Field(
         default_factory=lambda: {
             ".py",
+            ".go",
             ".pyw",
             ".ts",
             ".tsx",

--- a/nuguard/sbom/core/csharp_parser.py
+++ b/nuguard/sbom/core/csharp_parser.py
@@ -1,0 +1,737 @@
+"""Dependency-free structural parsing for C# source files.
+
+The parser is intentionally best-effort. It extracts the source structures
+needed by C# framework adapters without attempting full compiler semantics.
+"""
+
+from __future__ import annotations
+
+import re
+from bisect import bisect_right
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CSharpUsingDirective:
+    """One C# ``using`` directive."""
+
+    namespace: str
+    alias: str | None = None
+    is_static: bool = False
+    is_global: bool = False
+    line: int = 0
+
+    @property
+    def module(self) -> str:
+        return self.namespace
+
+
+@dataclass(frozen=True)
+class CSharpTypeDeclaration:
+    """A class, record, struct, or interface declaration."""
+
+    name: str
+    kind: str
+    modifiers: tuple[str, ...] = ()
+    attributes: tuple[str, ...] = ()
+    base_types: tuple[str, ...] = ()
+    line: int = 0
+    line_end: int = 0
+    signature: str = ""
+
+
+@dataclass(frozen=True)
+class CSharpMethodDeclaration:
+    """A method or constructor declaration."""
+
+    name: str
+    return_type: str | None
+    parameters: tuple[str, ...] = ()
+    modifiers: tuple[str, ...] = ()
+    attributes: tuple[str, ...] = ()
+    containing_type: str | None = None
+    is_constructor: bool = False
+    line: int = 0
+    line_end: int = 0
+    signature: str = ""
+
+
+@dataclass(frozen=True)
+class CSharpStringLiteral:
+    """A regular, verbatim, interpolated, or raw string literal."""
+
+    value: str
+    line: int
+    line_end: int
+    assigned_to: str | None = None
+    enclosing_method: str | None = None
+    is_verbatim: bool = False
+    is_interpolated: bool = False
+    is_raw: bool = False
+    interpolation_expressions: tuple[str, ...] = ()
+
+    @property
+    def is_potential_prompt(self) -> bool:
+        lowered = self.value.lower()
+        return len(self.value) > 100 or any(
+            marker in lowered
+            for marker in (
+                "you are",
+                "system:",
+                "assistant:",
+                "user:",
+                "instructions:",
+            )
+        )
+
+
+@dataclass
+class CSharpParseResult:
+    """Structural information extracted from one C# source file."""
+
+    using_directives: list[CSharpUsingDirective] = field(default_factory=list)
+    type_declarations: list[CSharpTypeDeclaration] = field(default_factory=list)
+    method_declarations: list[CSharpMethodDeclaration] = field(default_factory=list)
+    string_literals: list[CSharpStringLiteral] = field(default_factory=list)
+    source: str = ""
+    file_path: str = ""
+    parse_error: str | None = None
+
+    @property
+    def imports(self) -> list[CSharpUsingDirective]:
+        return self.using_directives
+
+    @property
+    def classes(self) -> list[CSharpTypeDeclaration]:
+        return self.type_declarations
+
+    @property
+    def methods(self) -> list[CSharpMethodDeclaration]:
+        return self.method_declarations
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.using_directives
+            or self.type_declarations
+            or self.method_declarations
+            or self.string_literals
+        )
+
+
+@dataclass(frozen=True)
+class _LiteralToken:
+    start: int
+    end: int
+    value: str
+    is_verbatim: bool
+    is_interpolated: bool
+    is_raw: bool
+    expressions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Span:
+    name: str
+    start: int
+    body_start: int
+    end: int
+
+
+_IDENTIFIER = r"@?[A-Za-z_]\w*"
+
+_TOKEN_RE = re.compile(
+    r"(?P<line_comment>//[^\n]*)"
+    r"|(?P<block_comment>/\*.*?\*/)"
+    r'|(?P<raw>\$*""".*?""")'
+    r'|(?P<verbatim>(?:\$@|@\$|@)"(?:""|[^"])*")'
+    r'|(?P<regular>\$?"(?:\\.|[^"\\\r\n])*")'
+    r"|(?P<char>'(?:\\.|[^'\\\r\n])')",
+    re.DOTALL,
+)
+
+_USING_RE = re.compile(
+    rf"(?m)^[ \t]*(?P<global>global\s+)?using\s+"
+    rf"(?:(?P<static>static)\s+)?"
+    rf"(?:(?P<alias>{_IDENTIFIER})\s*=\s*)?"
+    rf"(?P<namespace>(?:global::)?{_IDENTIFIER}"
+    rf"(?:\.{_IDENTIFIER})*)\s*;"
+)
+
+_TYPE_RE = re.compile(
+    rf"(?m)^[ \t]*"
+    rf"(?P<attributes>(?:(?:\[[^\]\n]+\])[ \t\r\n]*)*)"
+    rf"(?P<modifiers>(?:(?:public|private|protected|internal|abstract|"
+    rf"sealed|static|partial|readonly|ref|unsafe|new|file)\s+)*)"
+    rf"(?P<kind>record(?:\s+(?:class|struct))?|class|struct|interface)\s+"
+    rf"(?P<name>{_IDENTIFIER})(?:\s*<[^>{{}};\n]+>)?"
+    rf"(?P<tail>\s*(?:\([^{{}};]*\))?\s*"
+    rf"(?::[^{{}};]+)?(?:\s+where\s+[^{{}};]+)*)"
+    rf"\s*(?P<terminator>{{|;)"
+)
+
+_METHOD_RE = re.compile(
+    rf"(?m)(?P<start>^[ \t]*|(?<=[{{}};]))"
+    rf"(?P<attributes>(?:(?:\[[^\]\n]+\])[ \t\r\n]*)*)"
+    rf"(?P<modifiers>(?:(?:public|private|protected|internal|static|"
+    rf"abstract|virtual|override|sealed|new|async|extern|unsafe|partial|"
+    rf"readonly|ref|required)\s+)*)"
+    rf"(?:(?P<return>[A-Za-z_][\w.<>,?\[\]\s:]*)\s+)?"
+    rf"(?P<name>{_IDENTIFIER})(?:\s*<[^>{{}};()\n]+>)?\s*"
+    rf"\((?P<params>[^()]*)\)\s*"
+    rf"(?:(?:where\s+[^{{}};=]+)\s*)?"
+    rf"(?P<terminator>{{|=>|;)"
+)
+
+_NON_METHOD_NAMES = {
+    "if",
+    "for",
+    "foreach",
+    "while",
+    "switch",
+    "catch",
+    "using",
+    "lock",
+    "return",
+    "throw",
+    "new",
+    "typeof",
+    "nameof",
+    "sizeof",
+    "default",
+}
+
+
+def parse_csharp(
+    content: str,
+    file_path: str = "",
+) -> CSharpParseResult:
+    """Parse C# source into a best-effort structural result."""
+    newlines = [match.start() for match in re.finditer(r"\n", content)]
+
+    masked, literal_tokens, lexical_error = _mask_non_code(
+        content,
+        newlines,
+    )
+
+    types, type_spans, type_headers = _extract_types(
+        content,
+        masked,
+        newlines,
+    )
+
+    methods, method_spans = _extract_methods(
+        content,
+        masked,
+        newlines,
+        type_spans,
+        type_headers,
+    )
+
+    errors = [
+        error
+        for error in (
+            lexical_error,
+            _brace_error(masked, newlines),
+        )
+        if error
+    ]
+
+    return CSharpParseResult(
+        using_directives=_extract_usings(
+            masked,
+            newlines,
+        ),
+        type_declarations=types,
+        method_declarations=methods,
+        string_literals=_build_literals(
+            content,
+            literal_tokens,
+            newlines,
+            method_spans,
+        ),
+        source=content,
+        file_path=file_path,
+        parse_error="; ".join(errors) if errors else None,
+    )
+
+
+def _line(
+    newlines: list[int],
+    position: int,
+) -> int:
+    return bisect_right(newlines, position) + 1
+
+
+def _mask_non_code(
+    source: str,
+    newlines: list[int],
+) -> tuple[str, list[_LiteralToken], str | None]:
+    masked = list(source)
+    tokens: list[_LiteralToken] = []
+
+    for match in _TOKEN_RE.finditer(source):
+        for index in range(
+            match.start(),
+            match.end(),
+        ):
+            if masked[index] not in {"\n", "\r"}:
+                masked[index] = " "
+
+        kind = match.lastgroup
+
+        if kind in {
+            "line_comment",
+            "block_comment",
+            "char",
+        }:
+            continue
+
+        raw = match.group(0)
+        is_raw = kind == "raw"
+        is_verbatim = kind == "verbatim"
+        is_interpolated = raw.startswith("$") or raw.startswith("@$")
+
+        if is_raw:
+            dollars = len(raw) - len(raw.lstrip("$"))
+            value = raw[dollars + 3 : -3]
+            braces = max(dollars, 1)
+        else:
+            quote = raw.find('"')
+            value = raw[quote + 1 : -1]
+
+            if is_verbatim:
+                value = value.replace('""', '"')
+            else:
+                value = _decode_escapes(value)
+
+            braces = 1
+
+        tokens.append(
+            _LiteralToken(
+                start=match.start(),
+                end=match.end(),
+                value=value,
+                is_verbatim=is_verbatim,
+                is_interpolated=is_interpolated,
+                is_raw=is_raw,
+                expressions=(_interpolations(value, braces) if is_interpolated else ()),
+            )
+        )
+
+    result = "".join(masked)
+    unterminated = result.find("/*")
+
+    error = (
+        f"Unterminated block comment near line {_line(newlines, unterminated)}"
+        if unterminated >= 0
+        else None
+    )
+
+    return result, tokens, error
+
+
+def _decode_escapes(value: str) -> str:
+    replacements = {
+        r"\0": "\0",
+        r"\n": "\n",
+        r"\r": "\r",
+        r"\t": "\t",
+        r"\"": '"',
+        r"\\": "\\",
+    }
+
+    return re.sub(
+        r"\\(?:0|n|r|t|\"|\\)",
+        lambda match: replacements.get(
+            match.group(0),
+            match.group(0),
+        ),
+        value,
+    )
+
+
+def _interpolations(
+    value: str,
+    brace_count: int,
+) -> tuple[str, ...]:
+    opening = "{" * brace_count
+    closing = "}" * brace_count
+
+    pattern = re.compile(
+        rf"(?<!\{{){re.escape(opening)}\s*"
+        rf"([^{{}}]+?)\s*"
+        rf"{re.escape(closing)}(?!\}})"
+    )
+
+    return tuple(dict.fromkeys(match.group(1).strip() for match in pattern.finditer(value)))
+
+
+def _brace_error(
+    masked: str,
+    newlines: list[int],
+) -> str | None:
+    stack: list[int] = []
+
+    for index, char in enumerate(masked):
+        if char == "{":
+            stack.append(index)
+        elif char == "}":
+            if not stack:
+                return f"Unexpected closing brace near line {_line(newlines, index)}"
+
+            stack.pop()
+
+    if stack:
+        return f"Unmatched opening brace near line {_line(newlines, stack[-1])}"
+
+    return None
+
+
+def _extract_usings(
+    masked: str,
+    newlines: list[int],
+) -> list[CSharpUsingDirective]:
+    return [
+        CSharpUsingDirective(
+            namespace=match.group("namespace").removeprefix("global::"),
+            alias=match.group("alias"),
+            is_static=bool(match.group("static")),
+            is_global=bool(match.group("global")),
+            line=_line(
+                newlines,
+                match.start(),
+            ),
+        )
+        for match in _USING_RE.finditer(masked)
+    ]
+
+
+def _extract_types(
+    source: str,
+    masked: str,
+    newlines: list[int],
+) -> tuple[
+    list[CSharpTypeDeclaration],
+    list[_Span],
+    list[tuple[int, int]],
+]:
+    declarations: list[CSharpTypeDeclaration] = []
+    spans: list[_Span] = []
+    headers: list[tuple[int, int]] = []
+
+    for match in _TYPE_RE.finditer(masked):
+        body_start = match.start("terminator")
+        end = match.end("terminator")
+
+        if match.group("terminator") == "{":
+            closing = _matching(
+                masked,
+                body_start,
+                "{",
+                "}",
+            )
+
+            end = len(source) if closing is None else closing + 1
+
+        name = match.group("name").removeprefix("@")
+
+        declaration = CSharpTypeDeclaration(
+            name=name,
+            kind=" ".join(match.group("kind").split()),
+            modifiers=tuple((match.group("modifiers") or "").split()),
+            attributes=_attributes(source[match.start("attributes") : match.end("attributes")]),
+            base_types=_base_types(match.group("tail") or ""),
+            line=_line(
+                newlines,
+                match.start("name"),
+            ),
+            line_end=_line(
+                newlines,
+                max(
+                    end - 1,
+                    match.start(),
+                ),
+            ),
+            signature=source[match.start() : body_start + 1].strip(),
+        )
+
+        declarations.append(declaration)
+
+        spans.append(
+            _Span(
+                name,
+                match.start(),
+                body_start,
+                end,
+            )
+        )
+
+        headers.append(
+            (
+                match.start(),
+                body_start + 1,
+            )
+        )
+
+    return declarations, spans, headers
+
+
+def _extract_methods(
+    source: str,
+    masked: str,
+    newlines: list[int],
+    type_spans: list[_Span],
+    type_headers: list[tuple[int, int]],
+) -> tuple[
+    list[CSharpMethodDeclaration],
+    list[_Span],
+]:
+    declarations: list[CSharpMethodDeclaration] = []
+    spans: list[_Span] = []
+
+    for match in _METHOD_RE.finditer(masked):
+        if any(start <= match.start("name") < end for start, end in type_headers):
+            continue
+
+        name = match.group("name").removeprefix("@")
+
+        if name in _NON_METHOD_NAMES:
+            continue
+
+        containing = _containing(
+            type_spans,
+            match.start("name"),
+        )
+
+        return_type = (match.group("return") or "").strip() or None
+
+        is_constructor = bool(containing and containing.name == name and return_type is None)
+
+        if return_type is None and not is_constructor:
+            continue
+
+        body_start = match.start("terminator")
+        end = match.end("terminator")
+
+        if match.group("terminator") == "{":
+            closing = _matching(
+                masked,
+                body_start,
+                "{",
+                "}",
+            )
+
+            end = len(source) if closing is None else closing + 1
+
+        elif match.group("terminator") == "=>":
+            semicolon = masked.find(
+                ";",
+                body_start,
+            )
+
+            end = len(source) if semicolon < 0 else semicolon + 1
+
+        declaration = CSharpMethodDeclaration(
+            name=name,
+            return_type=return_type,
+            parameters=tuple(
+                part.strip() for part in _split(match.group("params")) if part.strip()
+            ),
+            modifiers=tuple((match.group("modifiers") or "").split()),
+            attributes=_attributes(source[match.start("attributes") : match.end("attributes")]),
+            containing_type=(containing.name if containing else None),
+            is_constructor=is_constructor,
+            line=_line(
+                newlines,
+                match.start("name"),
+            ),
+            line_end=_line(
+                newlines,
+                max(
+                    end - 1,
+                    match.start(),
+                ),
+            ),
+            signature=source[match.start() : match.end()].strip(),
+        )
+
+        declarations.append(declaration)
+
+        spans.append(
+            _Span(
+                name,
+                match.start(),
+                body_start,
+                end,
+            )
+        )
+
+    return declarations, spans
+
+
+def _matching(
+    source: str,
+    start: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    depth = 0
+
+    for index in range(
+        start,
+        len(source),
+    ):
+        if source[index] == opening:
+            depth += 1
+        elif source[index] == closing:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _containing(
+    spans: list[_Span],
+    position: int,
+) -> _Span | None:
+    matches = [span for span in spans if span.body_start < position < span.end]
+
+    return (
+        min(
+            matches,
+            key=lambda span: span.end - span.start,
+        )
+        if matches
+        else None
+    )
+
+
+def _attributes(raw: str) -> tuple[str, ...]:
+    return tuple(
+        match.group(1).strip()
+        for match in re.finditer(
+            r"\[([^\]]+)\]",
+            raw,
+        )
+    )
+
+
+def _base_types(
+    tail: str,
+) -> tuple[str, ...]:
+    if ":" not in tail:
+        return ()
+
+    value = re.split(
+        r"\bwhere\b",
+        tail.split(":", 1)[1],
+        maxsplit=1,
+    )[0]
+
+    return tuple(part.strip() for part in _split(value) if part.strip())
+
+
+def _split(value: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(value):
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+        elif char in {'"', "'"}:
+            quote = char
+        elif char in "([{<":
+            depth += 1
+        elif char in ")]}>":
+            depth = max(
+                depth - 1,
+                0,
+            )
+        elif char == "," and depth == 0:
+            parts.append(value[start:index])
+            start = index + 1
+
+    parts.append(value[start:])
+
+    return parts
+
+
+def _build_literals(
+    source: str,
+    tokens: list[_LiteralToken],
+    newlines: list[int],
+    method_spans: list[_Span],
+) -> list[CSharpStringLiteral]:
+    literals: list[CSharpStringLiteral] = []
+
+    for token in tokens:
+        method = _containing(
+            method_spans,
+            token.start,
+        )
+
+        literals.append(
+            CSharpStringLiteral(
+                value=token.value,
+                line=_line(
+                    newlines,
+                    token.start,
+                ),
+                line_end=_line(
+                    newlines,
+                    token.end - 1,
+                ),
+                assigned_to=_assignment_target(
+                    source,
+                    token.start,
+                ),
+                enclosing_method=(method.name if method else None),
+                is_verbatim=token.is_verbatim,
+                is_interpolated=token.is_interpolated,
+                is_raw=token.is_raw,
+                interpolation_expressions=token.expressions,
+            )
+        )
+
+    return literals
+
+
+def _assignment_target(
+    source: str,
+    position: int,
+) -> str | None:
+    prefix = source[
+        source.rfind(
+            "\n",
+            0,
+            position,
+        )
+        + 1 : position
+    ]
+
+    match = re.search(
+        rf"(?P<name>{_IDENTIFIER})\s*=\s*$",
+        prefix,
+    )
+
+    return match.group("name").removeprefix("@") if match else None
+
+
+__all__ = [
+    "CSharpMethodDeclaration",
+    "CSharpParseResult",
+    "CSharpStringLiteral",
+    "CSharpTypeDeclaration",
+    "CSharpUsingDirective",
+    "parse_csharp",
+]

--- a/nuguard/sbom/core/csharp_parser.py
+++ b/nuguard/sbom/core/csharp_parser.py
@@ -1038,13 +1038,16 @@ def _containing(
 
 
 def _attributes(raw: str) -> tuple[str, ...]:
-    return tuple(
-        match.group(1).strip()
-        for match in re.finditer(
-            r"\[([^\]]+)\]",
-            raw,
-        )
-    )
+    """Extract individual attributes from one or more attribute sections."""
+    attributes: list[str] = []
+
+    for match in re.finditer(
+        r"\[([^\]]+)\]",
+        raw,
+    ):
+        attributes.extend(item.strip() for item in _split(match.group(1)) if item.strip())
+
+    return tuple(attributes)
 
 
 def _base_types(

--- a/nuguard/sbom/core/csharp_parser.py
+++ b/nuguard/sbom/core/csharp_parser.py
@@ -139,16 +139,6 @@ class _Span:
 
 _IDENTIFIER = r"@?[A-Za-z_]\w*"
 
-_TOKEN_RE = re.compile(
-    r"(?P<line_comment>//[^\n]*)"
-    r"|(?P<block_comment>/\*.*?\*/)"
-    r'|(?P<raw>\$*""".*?""")'
-    r'|(?P<verbatim>(?:\$@|@\$|@)"(?:""|[^"])*")'
-    r'|(?P<regular>\$?"(?:\\.|[^"\\\r\n])*")'
-    r"|(?P<char>'(?:\\.|[^'\\\r\n])')",
-    re.DOTALL,
-)
-
 _USING_RE = re.compile(
     rf"(?m)^[ \t]*(?P<global>global\s+)?using\s+"
     rf"(?:(?P<static>static)\s+)?"
@@ -169,17 +159,23 @@ _TYPE_RE = re.compile(
     rf"\s*(?P<terminator>{{|;)"
 )
 
-_METHOD_RE = re.compile(
-    rf"(?m)(?P<start>^[ \t]*|(?<=[{{}};]))"
+_TYPE_TOKEN = (
+    rf"(?:global::)?{_IDENTIFIER}"
+    rf"(?:\.{_IDENTIFIER})*"
+    rf"(?:\s*<[^;{{}}()\n]+>)?"
+    rf"(?:\s*\[\s*\])*\??"
+)
+
+_METHOD_HEAD_RE = re.compile(
+    rf"(?m)(?P<start>^[ \t]*|(?<=[{{}};])[ \t]*)"
     rf"(?P<attributes>(?:(?:\[[^\]\n]+\])[ \t\r\n]*)*)"
     rf"(?P<modifiers>(?:(?:public|private|protected|internal|static|"
     rf"abstract|virtual|override|sealed|new|async|extern|unsafe|partial|"
     rf"readonly|ref|required)\s+)*)"
-    rf"(?:(?P<return>[A-Za-z_][\w.<>,?\[\]\s:]*)\s+)?"
-    rf"(?P<name>{_IDENTIFIER})(?:\s*<[^>{{}};()\n]+>)?\s*"
-    rf"\((?P<params>[^()]*)\)\s*"
-    rf"(?:(?:where\s+[^{{}};=]+)\s*)?"
-    rf"(?P<terminator>{{|=>|;)"
+    rf"(?:(?P<return>{_TYPE_TOKEN})\s+)?"
+    rf"(?P<name>{_IDENTIFIER})"
+    rf"(?:\s*<[^>{{}};()\n]+>)?\s*"
+    rf"(?P<open>\()"
 )
 
 _NON_METHOD_NAMES = {
@@ -245,6 +241,7 @@ def parse_csharp(
         method_declarations=methods,
         string_literals=_build_literals(
             content,
+            masked,
             literal_tokens,
             newlines,
             method_spans,
@@ -266,68 +263,403 @@ def _mask_non_code(
     source: str,
     newlines: list[int],
 ) -> tuple[str, list[_LiteralToken], str | None]:
+    """Mask comments, strings, and characters while preserving offsets."""
     masked = list(source)
     tokens: list[_LiteralToken] = []
+    errors: list[str] = []
+    index = 0
+    end: int | None
+    closing: int | None
 
-    for match in _TOKEN_RE.finditer(source):
-        for index in range(
-            match.start(),
-            match.end(),
-        ):
-            if masked[index] not in {"\n", "\r"}:
-                masked[index] = " "
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index)
 
-        kind = match.lastgroup
+            if end < 0:
+                end = len(source)
 
-        if kind in {
-            "line_comment",
-            "block_comment",
-            "char",
-        }:
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+            index = end
             continue
 
-        raw = match.group(0)
-        is_raw = kind == "raw"
-        is_verbatim = kind == "verbatim"
-        is_interpolated = raw.startswith("$") or raw.startswith("@$")
+        if source.startswith("/*", index):
+            closing = source.find(
+                "*/",
+                index + 2,
+            )
 
-        if is_raw:
-            dollars = len(raw) - len(raw.lstrip("$"))
-            value = raw[dollars + 3 : -3]
-            braces = max(dollars, 1)
-        else:
-            quote = raw.find('"')
-            value = raw[quote + 1 : -1]
+            if closing < 0:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                errors.append(f"Unterminated block comment near line {_line(newlines, index)}")
+                break
+
+            end = closing + 2
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+            index = end
+            continue
+
+        raw_opener = _raw_string_opener(
+            source,
+            index,
+        )
+
+        if raw_opener is not None:
+            (
+                dollar_count,
+                quote_count,
+                content_start,
+            ) = raw_opener
+
+            closing = _raw_string_close(
+                source,
+                content_start,
+                quote_count,
+            )
+
+            if closing is None:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                errors.append(f"Unterminated raw string near line {_line(newlines, index)}")
+                break
+
+            end = closing + quote_count
+            value = source[content_start:closing]
+            is_interpolated = dollar_count > 0
+
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+
+            tokens.append(
+                _LiteralToken(
+                    start=index,
+                    end=end,
+                    value=value,
+                    is_verbatim=False,
+                    is_interpolated=(is_interpolated),
+                    is_raw=True,
+                    expressions=(
+                        _interpolations(
+                            value,
+                            max(
+                                dollar_count,
+                                1,
+                            ),
+                        )
+                        if is_interpolated
+                        else ()
+                    ),
+                )
+            )
+
+            index = end
+            continue
+
+        quoted_prefix = _quoted_string_prefix(
+            source,
+            index,
+        )
+
+        if quoted_prefix is not None:
+            (
+                prefix,
+                is_verbatim,
+                is_interpolated,
+            ) = quoted_prefix
+            body_start = index + len(prefix)
+            end = _quoted_string_end(
+                source,
+                body_start,
+                is_verbatim,
+            )
+
+            if end is None:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                string_kind = "verbatim" if is_verbatim else "regular"
+                errors.append(
+                    f"Unterminated {string_kind} string near line {_line(newlines, index)}"
+                )
+                break
+
+            value = source[body_start : end - 1]
 
             if is_verbatim:
-                value = value.replace('""', '"')
+                value = value.replace(
+                    '""',
+                    '"',
+                )
             else:
                 value = _decode_escapes(value)
 
-            braces = 1
-
-        tokens.append(
-            _LiteralToken(
-                start=match.start(),
-                end=match.end(),
-                value=value,
-                is_verbatim=is_verbatim,
-                is_interpolated=is_interpolated,
-                is_raw=is_raw,
-                expressions=(_interpolations(value, braces) if is_interpolated else ()),
+            _mask_range(
+                masked,
+                index,
+                end,
             )
-        )
 
-    result = "".join(masked)
-    unterminated = result.find("/*")
+            tokens.append(
+                _LiteralToken(
+                    start=index,
+                    end=end,
+                    value=value,
+                    is_verbatim=is_verbatim,
+                    is_interpolated=(is_interpolated),
+                    is_raw=False,
+                    expressions=(
+                        _interpolations(
+                            value,
+                            1,
+                        )
+                        if is_interpolated
+                        else ()
+                    ),
+                )
+            )
 
-    error = (
-        f"Unterminated block comment near line {_line(newlines, unterminated)}"
-        if unterminated >= 0
-        else None
+            index = end
+            continue
+
+        if source[index] == "'":
+            end = _character_literal_end(
+                source,
+                index,
+            )
+
+            if end is None:
+                _mask_range(
+                    masked,
+                    index,
+                    len(source),
+                )
+                errors.append(f"Unterminated character literal near line {_line(newlines, index)}")
+                break
+
+            _mask_range(
+                masked,
+                index,
+                end,
+            )
+            index = end
+            continue
+
+        index += 1
+
+    return (
+        "".join(masked),
+        tokens,
+        "; ".join(errors) if errors else None,
     )
 
-    return result, tokens, error
+
+def _mask_range(
+    masked: list[str],
+    start: int,
+    end: int,
+) -> None:
+    """Mask a source range without changing line positions."""
+    for index in range(start, end):
+        if masked[index] not in {
+            "\n",
+            "\r",
+        }:
+            masked[index] = " "
+
+
+def _raw_string_opener(
+    source: str,
+    start: int,
+) -> tuple[int, int, int] | None:
+    """Return dollar count, quote count, and content start."""
+    cursor = start
+
+    while cursor < len(source) and source[cursor] == "$":
+        cursor += 1
+
+    quote_start = cursor
+
+    while cursor < len(source) and source[cursor] == '"':
+        cursor += 1
+
+    quote_count = cursor - quote_start
+
+    if quote_count < 3:
+        return None
+
+    return (
+        quote_start - start,
+        quote_count,
+        cursor,
+    )
+
+
+def _raw_string_close(
+    source: str,
+    start: int,
+    quote_count: int,
+) -> int | None:
+    """Find a raw-string closing delimiter of the same length."""
+    cursor = start
+
+    while cursor < len(source):
+        if source[cursor] != '"':
+            cursor += 1
+            continue
+
+        run_start = cursor
+
+        while cursor < len(source) and source[cursor] == '"':
+            cursor += 1
+
+        if cursor - run_start == quote_count:
+            return run_start
+
+    return None
+
+
+def _quoted_string_prefix(
+    source: str,
+    start: int,
+) -> tuple[str, bool, bool] | None:
+    """Return prefix, verbatim flag, and interpolation flag."""
+    prefixes = (
+        (
+            '$@"',
+            True,
+            True,
+        ),
+        (
+            '@$"',
+            True,
+            True,
+        ),
+        (
+            '@"',
+            True,
+            False,
+        ),
+        (
+            '$"',
+            False,
+            True,
+        ),
+        (
+            '"',
+            False,
+            False,
+        ),
+    )
+
+    for (
+        prefix,
+        is_verbatim,
+        is_interpolated,
+    ) in prefixes:
+        if source.startswith(
+            prefix,
+            start,
+        ):
+            return (
+                prefix,
+                is_verbatim,
+                is_interpolated,
+            )
+
+    return None
+
+
+def _quoted_string_end(
+    source: str,
+    start: int,
+    is_verbatim: bool,
+) -> int | None:
+    """Return the offset immediately after a closing quote."""
+    cursor = start
+
+    while cursor < len(source):
+        char = source[cursor]
+
+        if is_verbatim:
+            if char == '"':
+                if cursor + 1 < len(source) and source[cursor + 1] == '"':
+                    cursor += 2
+                    continue
+
+                return cursor + 1
+
+            cursor += 1
+            continue
+
+        if char == "\\":
+            if cursor + 1 >= len(source) or source[cursor + 1] in {"\n", "\r"}:
+                return None
+
+            cursor += 2
+            continue
+
+        if char == '"':
+            return cursor + 1
+
+        if char in {
+            "\n",
+            "\r",
+        }:
+            return None
+
+        cursor += 1
+
+    return None
+
+
+def _character_literal_end(
+    source: str,
+    start: int,
+) -> int | None:
+    """Return the offset immediately after a character literal."""
+    cursor = start + 1
+
+    while cursor < len(source):
+        char = source[cursor]
+
+        if char == "\\":
+            if cursor + 1 >= len(source):
+                return None
+
+            cursor += 2
+            continue
+
+        if char == "'":
+            return cursor + 1
+
+        if char in {
+            "\n",
+            "\r",
+        }:
+            return None
+
+        cursor += 1
+
+    return None
 
 
 def _decode_escapes(value: str) -> str:
@@ -489,8 +821,29 @@ def _extract_methods(
     declarations: list[CSharpMethodDeclaration] = []
     spans: list[_Span] = []
 
-    for match in _METHOD_RE.finditer(masked):
-        if any(start <= match.start("name") < end for start, end in type_headers):
+    for match in _METHOD_HEAD_RE.finditer(masked):
+        name_position = match.start("name")
+
+        if any(start <= name_position < end for start, end in type_headers):
+            continue
+
+        # Once a method has been found, do not reinterpret calls or
+        # statements inside its body as additional declarations.
+        if (
+            _containing(
+                spans,
+                name_position,
+            )
+            is not None
+        ):
+            continue
+
+        containing = _containing(
+            type_spans,
+            name_position,
+        )
+
+        if containing is None:
             continue
 
         name = match.group("name").removeprefix("@")
@@ -498,22 +851,48 @@ def _extract_methods(
         if name in _NON_METHOD_NAMES:
             continue
 
-        containing = _containing(
-            type_spans,
-            match.start("name"),
-        )
-
         return_type = (match.group("return") or "").strip() or None
 
-        is_constructor = bool(containing and containing.name == name and return_type is None)
+        if return_type is not None and return_type.casefold() in {
+            "return",
+            "throw",
+            "yield",
+            "await",
+        }:
+            continue
+
+        is_constructor = bool(containing.name == name and return_type is None)
 
         if return_type is None and not is_constructor:
             continue
 
-        body_start = match.start("terminator")
-        end = match.end("terminator")
+        open_paren = match.start("open")
+        close_paren = _matching(
+            masked,
+            open_paren,
+            "(",
+            ")",
+        )
 
-        if match.group("terminator") == "{":
+        if close_paren is None:
+            continue
+
+        terminator_info = _method_terminator(
+            masked,
+            close_paren + 1,
+        )
+
+        if terminator_info is None:
+            continue
+
+        (
+            body_start,
+            terminator,
+        ) = terminator_info
+        terminator_end = body_start + len(terminator)
+        end = terminator_end
+
+        if terminator == "{":
             closing = _matching(
                 masked,
                 body_start,
@@ -523,27 +902,27 @@ def _extract_methods(
 
             end = len(source) if closing is None else closing + 1
 
-        elif match.group("terminator") == "=>":
+        elif terminator == "=>":
             semicolon = masked.find(
                 ";",
-                body_start,
+                terminator_end,
             )
 
             end = len(source) if semicolon < 0 else semicolon + 1
 
+        parameters_text = source[open_paren + 1 : close_paren]
+
         declaration = CSharpMethodDeclaration(
             name=name,
             return_type=return_type,
-            parameters=tuple(
-                part.strip() for part in _split(match.group("params")) if part.strip()
-            ),
+            parameters=tuple(part.strip() for part in _split(parameters_text) if part.strip()),
             modifiers=tuple((match.group("modifiers") or "").split()),
             attributes=_attributes(source[match.start("attributes") : match.end("attributes")]),
-            containing_type=(containing.name if containing else None),
+            containing_type=(containing.name),
             is_constructor=is_constructor,
             line=_line(
                 newlines,
-                match.start("name"),
+                name_position,
             ),
             line_end=_line(
                 newlines,
@@ -552,7 +931,7 @@ def _extract_methods(
                     match.start(),
                 ),
             ),
-            signature=source[match.start() : match.end()].strip(),
+            signature=source[match.start() : terminator_end].strip(),
         )
 
         declarations.append(declaration)
@@ -567,6 +946,56 @@ def _extract_methods(
         )
 
     return declarations, spans
+
+
+def _method_terminator(
+    source: str,
+    start: int,
+) -> tuple[int, str] | None:
+    """Find a declaration terminator after a balanced parameter list."""
+    depths = {
+        "(": 0,
+        "[": 0,
+        "<": 0,
+    }
+    closing = {
+        ")": "(",
+        "]": "[",
+        ">": "<",
+    }
+    cursor = start
+
+    while cursor < len(source):
+        if not any(depths.values()) and source.startswith(
+            "=>",
+            cursor,
+        ):
+            return cursor, "=>"
+
+        char = source[cursor]
+
+        if not any(depths.values()):
+            if char == "{":
+                return cursor, "{"
+
+            if char == ";":
+                return cursor, ";"
+
+            if char == "}":
+                return None
+
+        if char in depths:
+            depths[char] += 1
+        elif char in closing:
+            opener = closing[char]
+            depths[opener] = max(
+                depths[opener] - 1,
+                0,
+            )
+
+        cursor += 1
+
+    return None
 
 
 def _matching(
@@ -668,6 +1097,7 @@ def _split(value: str) -> list[str]:
 
 def _build_literals(
     source: str,
+    masked: str,
     tokens: list[_LiteralToken],
     newlines: list[int],
     method_spans: list[_Span],
@@ -691,15 +1121,18 @@ def _build_literals(
                     newlines,
                     token.end - 1,
                 ),
-                assigned_to=_assignment_target(
-                    source,
-                    token.start,
+                assigned_to=(
+                    _assignment_target(
+                        source,
+                        masked,
+                        token.start,
+                    )
                 ),
                 enclosing_method=(method.name if method else None),
-                is_verbatim=token.is_verbatim,
-                is_interpolated=token.is_interpolated,
+                is_verbatim=(token.is_verbatim),
+                is_interpolated=(token.is_interpolated),
                 is_raw=token.is_raw,
-                interpolation_expressions=token.expressions,
+                interpolation_expressions=(token.expressions),
             )
         )
 
@@ -708,23 +1141,47 @@ def _build_literals(
 
 def _assignment_target(
     source: str,
+    masked: str,
     position: int,
 ) -> str | None:
-    prefix = source[
-        source.rfind(
-            "\n",
-            0,
-            position,
+    """Return the assignment target before a string literal."""
+    statement_start = (
+        max(
+            masked.rfind(
+                ";",
+                0,
+                position,
+            ),
+            masked.rfind(
+                "{",
+                0,
+                position,
+            ),
+            masked.rfind(
+                "}",
+                0,
+                position,
+            ),
         )
-        + 1 : position
-    ]
+        + 1
+    )
+
+    prefix = masked[statement_start:position]
 
     match = re.search(
-        rf"(?P<name>{_IDENTIFIER})\s*=\s*$",
+        rf"(?P<name>{_IDENTIFIER})"
+        rf"\s*=\s*$",
         prefix,
     )
 
-    return match.group("name").removeprefix("@") if match else None
+    if match is None:
+        return None
+
+    # Access source so this helper continues to validate compatible offsets.
+    if len(source) != len(masked):
+        return None
+
+    return match.group("name").removeprefix("@")
 
 
 __all__ = [

--- a/nuguard/sbom/core/go_parser.py
+++ b/nuguard/sbom/core/go_parser.py
@@ -800,9 +800,63 @@ def _parse_with_regex(
         )
         for item in strings
         if (item.line, item.value) not in import_keys
+        and not _is_regex_struct_tag(masked, item.start)
     ]
 
     return result
+
+
+def _is_regex_struct_tag(
+    masked: str,
+    position: int,
+) -> bool:
+    """Return whether a scanned string is a Go struct tag.
+
+    The fallback scanner has already replaced comments and string contents
+    with spaces. A string is treated as a tag when it follows field syntax on
+    the same line and the nearest unmatched opening brace starts a struct body.
+    """
+    line_start = (
+        masked.rfind(
+            "\n",
+            0,
+            position,
+        )
+        + 1
+    )
+
+    if not masked[line_start:position].strip():
+        return False
+
+    nested_braces = 0
+
+    for index in range(
+        position - 1,
+        -1,
+        -1,
+    ):
+        char = masked[index]
+
+        if char == "}":
+            nested_braces += 1
+            continue
+
+        if char != "{":
+            continue
+
+        if nested_braces:
+            nested_braces -= 1
+            continue
+
+        return (
+            re.search(
+                r"\bstruct\s*$",
+                masked[:index],
+            )
+            is not None
+        )
+
+    return False
 
 
 def _regex_imports(content: str) -> list[GoImport]:

--- a/nuguard/sbom/core/go_parser.py
+++ b/nuguard/sbom/core/go_parser.py
@@ -1,0 +1,1325 @@
+"""Structured Go source parsing for SBOM and AI-framework extraction.
+
+The parser prefers ``tree_sitter_go`` for accurate syntax-tree extraction and
+falls back to a best-effort regex parser when the optional grammar cannot be
+loaded. It extracts imports, struct/constructor instantiations, calls, and
+string literals while preserving partial results for malformed source.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+try:
+    import tree_sitter
+    import tree_sitter_go
+
+    HAS_TREE_SITTER = True
+except ImportError:
+    tree_sitter = None  # type: ignore[assignment]
+    tree_sitter_go = None  # type: ignore[assignment]
+    HAS_TREE_SITTER = False
+
+
+@dataclass
+class GoImport:
+    """Information about one Go import specification."""
+
+    path: str
+    alias: str | None
+    line: int
+
+    @property
+    def module(self) -> str:
+        """Return the import path using the shared parser terminology."""
+
+        return self.path
+
+
+@dataclass
+class GoInstantiation:
+    """A named struct literal or conventional ``New*`` constructor call."""
+
+    class_name: str
+    args: dict[str, Any] = field(default_factory=dict)
+    positional_args: list[Any] = field(default_factory=list)
+    assigned_to: str | None = None
+    line: int = 0
+    line_end: int = 0
+    kind: str = "struct_literal"
+    source_snippet: str | None = None
+
+
+@dataclass
+class GoFunctionCall:
+    """Information about a Go function or method call."""
+
+    function_name: str
+    receiver: str | None = None
+    args: dict[str, Any] = field(default_factory=dict)
+    positional_args: list[Any] = field(default_factory=list)
+    assigned_to: str | None = None
+    line: int = 0
+    line_end: int = 0
+    source_snippet: str | None = None
+
+    @property
+    def full_name(self) -> str:
+        """Return the receiver-qualified function name."""
+
+        if self.receiver:
+            return f"{self.receiver}.{self.function_name}"
+        return self.function_name
+
+
+@dataclass
+class GoStringLiteral:
+    """A raw or interpreted Go string literal."""
+
+    value: str
+    line: int
+    context: str | None = None
+    assigned_to: str | None = None
+    is_raw: bool = False
+
+
+@dataclass
+class GoParseResult:
+    """Structured information extracted from one Go source file."""
+
+    imports: list[GoImport] = field(default_factory=list)
+    instantiations: list[GoInstantiation] = field(default_factory=list)
+    function_calls: list[GoFunctionCall] = field(default_factory=list)
+    string_literals: list[GoStringLiteral] = field(default_factory=list)
+    source: str = ""
+    file_path: str = ""
+    parse_error: str | None = None
+    used_tree_sitter: bool = False
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.imports or self.instantiations or self.function_calls or self.string_literals
+        )
+
+
+_GO_LANGUAGE: Any | None = None
+_NAMED_TYPE_NODES = {"type_identifier", "qualified_type", "generic_type"}
+_STRING_NODES = {"interpreted_string_literal", "raw_string_literal"}
+_ASSIGNMENT_NODES = {
+    "assignment_statement",
+    "short_var_declaration",
+    "const_spec",
+    "var_spec",
+}
+_WRAPPER_NODES = {
+    "expression_list",
+    "parenthesized_expression",
+    "unary_expression",
+}
+
+
+def get_go_parser() -> Any | None:
+    """Return a tree-sitter Go parser, or ``None`` when unavailable."""
+
+    global _GO_LANGUAGE
+
+    if not HAS_TREE_SITTER:
+        return None
+
+    assert tree_sitter is not None
+    assert tree_sitter_go is not None
+
+    if _GO_LANGUAGE is None:
+        _GO_LANGUAGE = tree_sitter.Language(tree_sitter_go.language())
+
+    return tree_sitter.Parser(_GO_LANGUAGE)
+
+
+def parse_go(content: str, file_path: str = "") -> GoParseResult:
+    """Parse Go source into a structured :class:`GoParseResult`.
+
+    Tree-sitter is attempted first. If the bindings are missing or parser
+    initialization fails, a best-effort regex parser is used instead.
+    """
+
+    parser_error: str | None = None
+
+    try:
+        parser = get_go_parser()
+    except Exception as exc:  # pragma: no cover - platform-specific binding failures
+        parser = None
+        parser_error = f"tree-sitter initialization failed: {exc}"
+
+    if parser is not None:
+        try:
+            return _parse_with_tree_sitter(content, file_path, parser)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            parser_error = f"tree-sitter parsing failed: {exc}"
+
+    result = _parse_with_regex(content, file_path)
+
+    if parser_error:
+        result.parse_error = parser_error
+
+    return result
+
+
+def _parse_with_tree_sitter(
+    content: str,
+    file_path: str,
+    parser: Any,
+) -> GoParseResult:
+    source = content.encode("utf-8")
+    tree = parser.parse(source)
+    root = tree.root_node
+    symbols = _build_symbol_table(root, source)
+
+    result = GoParseResult(
+        source=content,
+        file_path=file_path,
+        used_tree_sitter=True,
+    )
+
+    for node in _walk(root):
+        if node.type == "import_spec":
+            imported = _tree_sitter_import(node, source)
+            if imported is not None:
+                result.imports.append(imported)
+
+        elif node.type == "composite_literal":
+            instantiation = _tree_sitter_struct_literal(
+                node,
+                source,
+                symbols,
+            )
+            if instantiation is not None:
+                result.instantiations.append(instantiation)
+
+        elif node.type == "call_expression":
+            call = _tree_sitter_call(node, source, symbols)
+
+            if call is not None:
+                result.function_calls.append(call)
+
+                if call.function_name.startswith("New"):
+                    result.instantiations.append(
+                        GoInstantiation(
+                            class_name=call.full_name,
+                            args=dict(call.args),
+                            positional_args=list(call.positional_args),
+                            assigned_to=call.assigned_to,
+                            line=call.line,
+                            line_end=call.line_end,
+                            kind="constructor_call",
+                            source_snippet=call.source_snippet,
+                        )
+                    )
+
+        elif node.type in _STRING_NODES and not _is_non_value_string(node):
+            result.string_literals.append(_tree_sitter_string(node, source))
+
+    if root.has_error:
+        error_line = _first_error_line(root)
+        result.parse_error = f"Go syntax error near line {error_line}"
+
+    return result
+
+
+def _walk(node: Any) -> Iterator[Any]:
+    yield node
+
+    for child in node.children:
+        yield from _walk(child)
+
+
+def _node_text(node: Any | None, source: bytes) -> str:
+    if node is None:
+        return ""
+
+    return source[node.start_byte : node.end_byte].decode(
+        "utf-8",
+        errors="replace",
+    )
+
+
+def _line(node: Any) -> int:
+    return int(node.start_point[0]) + 1
+
+
+def _line_end(node: Any) -> int:
+    return int(node.end_point[0]) + 1
+
+
+def _named_children(node: Any | None) -> list[Any]:
+    if node is None:
+        return []
+
+    return list(node.named_children)
+
+
+def _children_by_field_name(
+    node: Any,
+    field_name: str,
+) -> list[Any]:
+    method = getattr(node, "children_by_field_name", None)
+
+    if callable(method):
+        return list(method(field_name))
+
+    child = node.child_by_field_name(field_name)
+    return [child] if child is not None else []
+
+
+def _tree_sitter_import(
+    node: Any,
+    source: bytes,
+) -> GoImport | None:
+    path_node = node.child_by_field_name("path")
+
+    if path_node is None:
+        return None
+
+    alias_node = node.child_by_field_name("name")
+
+    path = _decode_go_string(
+        _node_text(path_node, source),
+        is_raw=path_node.type == "raw_string_literal",
+    )
+
+    alias = _node_text(alias_node, source) or None
+
+    return GoImport(
+        path=path,
+        alias=alias,
+        line=_line(node),
+    )
+
+
+def _tree_sitter_struct_literal(
+    node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> GoInstantiation | None:
+    type_node = node.child_by_field_name("type")
+    body_node = node.child_by_field_name("body")
+
+    if type_node is None or body_node is None or type_node.type not in _NAMED_TYPE_NODES:
+        return None
+
+    type_name = _node_text(type_node, source)
+
+    args, positional_args = _literal_body_values(
+        body_node,
+        source,
+        symbols,
+    )
+
+    return GoInstantiation(
+        class_name=type_name,
+        args=args,
+        positional_args=positional_args,
+        assigned_to=_assignment_target(node, source),
+        line=_line(node),
+        line_end=_line_end(node),
+        kind="struct_literal",
+        source_snippet=_node_text(node, source),
+    )
+
+
+def _tree_sitter_call(
+    node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> GoFunctionCall | None:
+    function_node = node.child_by_field_name("function")
+    arguments_node = node.child_by_field_name("arguments")
+
+    if function_node is None or arguments_node is None:
+        return None
+
+    callee = _node_text(function_node, source)
+    receiver, function_name = _split_callee(callee)
+
+    positional_args = [
+        _extract_value(child, source, symbols) for child in _named_children(arguments_node)
+    ]
+
+    return GoFunctionCall(
+        function_name=function_name,
+        receiver=receiver,
+        positional_args=positional_args,
+        assigned_to=_assignment_target(node, source),
+        line=_line(node),
+        line_end=_line_end(node),
+        source_snippet=_node_text(node, source),
+    )
+
+
+def _tree_sitter_string(
+    node: Any,
+    source: bytes,
+) -> GoStringLiteral:
+    raw_text = _node_text(node, source)
+
+    return GoStringLiteral(
+        value=_decode_go_string(
+            raw_text,
+            is_raw=node.type == "raw_string_literal",
+        ),
+        line=_line(node),
+        context=_enclosing_context(node, source),
+        assigned_to=_assignment_target(node, source),
+        is_raw=node.type == "raw_string_literal",
+    )
+
+
+def _split_callee(callee: str) -> tuple[str | None, str]:
+    normalized = re.sub(
+        r"\[[^\]]*\]$",
+        "",
+        callee.strip(),
+    )
+
+    if "." not in normalized:
+        return None, normalized
+
+    receiver, function_name = normalized.rsplit(".", 1)
+    return receiver, function_name
+
+
+def _literal_body_values(
+    body_node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> tuple[dict[str, Any], list[Any]]:
+    args: dict[str, Any] = {}
+    positional_args: list[Any] = []
+
+    for child in _named_children(body_node):
+        child = _unwrap_literal_element(child)
+
+        if child.type == "keyed_element":
+            key_node = child.child_by_field_name("key")
+            value_node = child.child_by_field_name("value")
+
+            if key_node is not None and value_node is not None:
+                args[_node_text(key_node, source)] = _extract_value(
+                    value_node,
+                    source,
+                    symbols,
+                )
+        else:
+            positional_args.append(_extract_value(child, source, symbols))
+
+    return args, positional_args
+
+
+def _unwrap_literal_element(node: Any) -> Any:
+    if node.type == "literal_element" and len(node.named_children) == 1:
+        return node.named_children[0]
+
+    return node
+
+
+def _extract_value(
+    node: Any,
+    source: bytes,
+    symbols: dict[str, Any],
+) -> Any:
+    node = _unwrap_literal_element(node)
+    text = _node_text(node, source).strip()
+
+    if node.type == "interpreted_string_literal":
+        return _decode_go_string(text, is_raw=False)
+
+    if node.type == "raw_string_literal":
+        return _decode_go_string(text, is_raw=True)
+
+    if node.type == "int_literal":
+        return _parse_int(text)
+
+    if node.type == "float_literal":
+        try:
+            return float(text.replace("_", ""))
+        except ValueError:
+            return text
+
+    if node.type == "true":
+        return True
+
+    if node.type == "false":
+        return False
+
+    if node.type == "nil":
+        return None
+
+    if node.type == "identifier":
+        return symbols.get(text, f"${text}")
+
+    if node.type == "parenthesized_expression" and node.named_children:
+        return _extract_value(
+            node.named_children[0],
+            source,
+            symbols,
+        )
+
+    if node.type == "unary_expression" and node.named_children:
+        value = _extract_value(
+            node.named_children[-1],
+            source,
+            symbols,
+        )
+
+        if text.startswith("-") and isinstance(value, int | float):
+            return -value
+
+        return value
+
+    if node.type == "composite_literal":
+        type_node = node.child_by_field_name("type")
+        body_node = node.child_by_field_name("body")
+
+        if body_node is not None:
+            args, positional_args = _literal_body_values(
+                body_node,
+                source,
+                symbols,
+            )
+
+            structured: dict[str, Any] = {}
+
+            if type_node is not None:
+                structured["$type"] = _node_text(
+                    type_node,
+                    source,
+                )
+
+            if args:
+                structured.update(args)
+
+            if positional_args:
+                structured["$items"] = positional_args
+
+            return structured
+
+    if node.type == "literal_value":
+        args, positional_args = _literal_body_values(
+            node,
+            source,
+            symbols,
+        )
+
+        if args and not positional_args:
+            return args
+
+        if not args:
+            return positional_args
+
+        return {
+            **args,
+            "$items": positional_args,
+        }
+
+    return f"${text}" if text else None
+
+
+def _parse_int(text: str) -> int | str:
+    normalized = text.replace("_", "")
+
+    try:
+        if re.fullmatch(r"0[0-7]+", normalized):
+            return int(normalized, 8)
+
+        return int(normalized, 0)
+    except ValueError:
+        return text
+
+
+def _decode_go_string(
+    text: str,
+    *,
+    is_raw: bool,
+) -> str:
+    if len(text) < 2:
+        return text
+
+    if is_raw:
+        return text[1:-1].replace("\r", "")
+
+    try:
+        value = ast.literal_eval(text)
+
+        if isinstance(value, str):
+            return value
+
+        return text[1:-1]
+    except (SyntaxError, ValueError):
+        return text[1:-1]
+
+
+def _build_symbol_table(
+    root: Any,
+    source: bytes,
+) -> dict[str, Any]:
+    symbols: dict[str, Any] = {}
+
+    for node in _walk(root):
+        if node.type not in _ASSIGNMENT_NODES:
+            continue
+
+        if node.type in {"const_spec", "var_spec"}:
+            names = [
+                child
+                for child in _children_by_field_name(node, "name")
+                if child.type == "identifier"
+            ]
+            value_container = node.child_by_field_name("value")
+        else:
+            left = node.child_by_field_name("left")
+            names = [child for child in _named_children(left) if child.type == "identifier"]
+            value_container = node.child_by_field_name("right")
+
+        values = _named_children(value_container)
+
+        for name_node, value_node in zip(names, values):
+            name = _node_text(name_node, source)
+            symbols[name] = _extract_value(
+                value_node,
+                source,
+                symbols,
+            )
+
+    return symbols
+
+
+def _assignment_target(
+    node: Any,
+    source: bytes,
+) -> str | None:
+    current = node
+    parent = current.parent
+
+    while parent is not None and parent.type in _WRAPPER_NODES:
+        current = parent
+        parent = parent.parent
+
+    if parent is None or parent.type not in _ASSIGNMENT_NODES:
+        return None
+
+    if parent.type in {"const_spec", "var_spec"}:
+        name_nodes = _children_by_field_name(parent, "name")
+    else:
+        left = parent.child_by_field_name("left")
+        name_nodes = _named_children(left)
+
+    if not name_nodes:
+        return None
+
+    return _node_text(name_nodes[0], source) or None
+
+
+def _enclosing_context(
+    node: Any,
+    source: bytes,
+) -> str | None:
+    parent = node.parent
+
+    while parent is not None:
+        if parent.type in {
+            "function_declaration",
+            "method_declaration",
+        }:
+            name_node = parent.child_by_field_name("name")
+            return _node_text(name_node, source) or None
+
+        parent = parent.parent
+
+    return None
+
+
+def _is_non_value_string(node: Any) -> bool:
+    parent = node.parent
+
+    while parent is not None:
+        if parent.type in {
+            "import_spec",
+            "field_declaration",
+        }:
+            return True
+
+        if parent.type in {
+            "source_file",
+            "function_declaration",
+            "method_declaration",
+        }:
+            return False
+
+        parent = parent.parent
+
+    return False
+
+
+def _first_error_line(root: Any) -> int:
+    for node in _walk(root):
+        if node.type == "ERROR" or node.is_missing:
+            return _line(node)
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Regex fallback
+# ---------------------------------------------------------------------------
+
+_IMPORT_SINGLE_RE = re.compile(
+    r"(?m)^\s*import\s+"
+    r"(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"
+    r'(?P<path>"(?:\\.|[^"\\])*")\s*(?://.*)?$'
+)
+
+_IMPORT_BLOCK_RE = re.compile(r"(?ms)^\s*import\s*\((?P<body>.*?)^\s*\)")
+
+_IMPORT_SPEC_RE = re.compile(
+    r"(?m)^\s*"
+    r"(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"
+    r'(?P<path>"(?:\\.|[^"\\])*")\s*(?://.*)?$'
+)
+
+_CALL_RE = re.compile(
+    r"\b"
+    r"(?P<callee>"
+    r"[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\.[A-Za-z_][A-Za-z0-9_]*)*"
+    r")\s*\("
+)
+
+_STRUCT_RE = re.compile(
+    r"\b"
+    r"(?P<type>"
+    r"[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\.[A-Za-z_][A-Za-z0-9_]*)*"
+    r")\s*\{"
+)
+
+_SYMBOL_RE = re.compile(
+    r"(?m)^\s*"
+    r"(?:const|var)?\s*"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:\s+[A-Za-z_][A-Za-z0-9_.\[\]*]*)?"
+    r"\s*(?::=|=)\s*"
+    r"(?P<value>"
+    r"`[^`]*`|"
+    r'"(?:\\.|[^"\\])*"|'
+    r"true|false|nil|[-+]?\d[\d_]*"
+    r")\s*$"
+)
+
+_SKIP_CALL_NAMES = {
+    "append",
+    "cap",
+    "clear",
+    "close",
+    "complex",
+    "copy",
+    "defer",
+    "delete",
+    "for",
+    "func",
+    "go",
+    "if",
+    "imag",
+    "import",
+    "len",
+    "make",
+    "max",
+    "min",
+    "new",
+    "panic",
+    "print",
+    "println",
+    "real",
+    "recover",
+    "return",
+    "select",
+    "switch",
+}
+
+
+@dataclass
+class _ScannedString:
+    value: str
+    start: int
+    end: int
+    line: int
+    is_raw: bool
+
+
+def _parse_with_regex(
+    content: str,
+    file_path: str,
+) -> GoParseResult:
+    result = GoParseResult(
+        source=content,
+        file_path=file_path,
+        used_tree_sitter=False,
+    )
+
+    result.imports = _regex_imports(content)
+    symbols = _regex_symbols(content)
+    masked, strings = _mask_non_code(content)
+
+    result.instantiations = _regex_struct_literals(
+        content,
+        masked,
+        symbols,
+    )
+
+    calls, constructors = _regex_calls(
+        content,
+        masked,
+        symbols,
+    )
+
+    result.function_calls = calls
+    result.instantiations.extend(constructors)
+
+    import_keys = {(item.line, item.path) for item in result.imports}
+
+    result.string_literals = [
+        GoStringLiteral(
+            value=item.value,
+            line=item.line,
+            assigned_to=_regex_assignment_target(
+                content,
+                item.start,
+            ),
+            is_raw=item.is_raw,
+        )
+        for item in strings
+        if (item.line, item.value) not in import_keys
+    ]
+
+    return result
+
+
+def _regex_imports(content: str) -> list[GoImport]:
+    imports: list[GoImport] = []
+
+    for match in _IMPORT_SINGLE_RE.finditer(content):
+        imports.append(
+            GoImport(
+                path=_decode_go_string(
+                    match.group("path"),
+                    is_raw=False,
+                ),
+                alias=match.group("alias"),
+                line=content.count(
+                    "\n",
+                    0,
+                    match.start(),
+                )
+                + 1,
+            )
+        )
+
+    for block in _IMPORT_BLOCK_RE.finditer(content):
+        body = block.group("body")
+        body_start = block.start("body")
+
+        for match in _IMPORT_SPEC_RE.finditer(body):
+            imports.append(
+                GoImport(
+                    path=_decode_go_string(
+                        match.group("path"),
+                        is_raw=False,
+                    ),
+                    alias=match.group("alias"),
+                    line=content.count(
+                        "\n",
+                        0,
+                        body_start + match.start("path"),
+                    )
+                    + 1,
+                )
+            )
+
+    return sorted(
+        imports,
+        key=lambda item: item.line,
+    )
+
+
+def _regex_symbols(content: str) -> dict[str, Any]:
+    symbols: dict[str, Any] = {}
+
+    for match in _SYMBOL_RE.finditer(content):
+        symbols[match.group("name")] = _parse_value_text(
+            match.group("value"),
+            symbols,
+        )
+
+    return symbols
+
+
+def _regex_struct_literals(
+    content: str,
+    masked: str,
+    symbols: dict[str, Any],
+) -> list[GoInstantiation]:
+    instantiations: list[GoInstantiation] = []
+    seen: set[tuple[int, int]] = set()
+
+    for match in _STRUCT_RE.finditer(masked):
+        type_name = match.group("type")
+
+        if not type_name.rsplit(".", 1)[-1][:1].isupper():
+            continue
+
+        open_brace = match.end() - 1
+        close_brace = _find_matching(
+            masked,
+            open_brace,
+            "{",
+            "}",
+        )
+
+        if close_brace is None or (match.start(), close_brace) in seen:
+            continue
+
+        seen.add((match.start(), close_brace))
+
+        args, positional_args = _parse_regex_literal_body(
+            content[open_brace + 1 : close_brace],
+            symbols,
+        )
+
+        instantiations.append(
+            GoInstantiation(
+                class_name=type_name,
+                args=args,
+                positional_args=positional_args,
+                assigned_to=_regex_assignment_target(
+                    content,
+                    match.start(),
+                ),
+                line=content.count(
+                    "\n",
+                    0,
+                    match.start(),
+                )
+                + 1,
+                line_end=content.count(
+                    "\n",
+                    0,
+                    close_brace,
+                )
+                + 1,
+                kind="struct_literal",
+                source_snippet=content[match.start() : close_brace + 1],
+            )
+        )
+
+    return instantiations
+
+
+def _regex_calls(
+    content: str,
+    masked: str,
+    symbols: dict[str, Any],
+) -> tuple[
+    list[GoFunctionCall],
+    list[GoInstantiation],
+]:
+    calls: list[GoFunctionCall] = []
+    constructors: list[GoInstantiation] = []
+    seen: set[tuple[int, int]] = set()
+
+    for match in _CALL_RE.finditer(masked):
+        if _looks_like_function_declaration(
+            masked,
+            match.start(),
+        ):
+            continue
+
+        callee = match.group("callee")
+        receiver, function_name = _split_callee(callee)
+
+        if receiver is None and function_name in _SKIP_CALL_NAMES:
+            continue
+
+        open_paren = match.end() - 1
+        close_paren = _find_matching(
+            masked,
+            open_paren,
+            "(",
+            ")",
+        )
+
+        if close_paren is None or (match.start(), close_paren) in seen:
+            continue
+
+        seen.add((match.start(), close_paren))
+
+        positional_args = [
+            _parse_value_text(argument, symbols)
+            for argument in _split_top_level(content[open_paren + 1 : close_paren])
+            if argument.strip()
+        ]
+
+        call = GoFunctionCall(
+            function_name=function_name,
+            receiver=receiver,
+            positional_args=positional_args,
+            assigned_to=_regex_assignment_target(
+                content,
+                match.start(),
+            ),
+            line=content.count(
+                "\n",
+                0,
+                match.start(),
+            )
+            + 1,
+            line_end=content.count(
+                "\n",
+                0,
+                close_paren,
+            )
+            + 1,
+            source_snippet=content[match.start() : close_paren + 1],
+        )
+
+        calls.append(call)
+
+        if function_name.startswith("New"):
+            constructors.append(
+                GoInstantiation(
+                    class_name=call.full_name,
+                    positional_args=list(call.positional_args),
+                    assigned_to=call.assigned_to,
+                    line=call.line,
+                    line_end=call.line_end,
+                    kind="constructor_call",
+                    source_snippet=call.source_snippet,
+                )
+            )
+
+    return calls, constructors
+
+
+def _parse_regex_literal_body(
+    body: str,
+    symbols: dict[str, Any],
+) -> tuple[dict[str, Any], list[Any]]:
+    args: dict[str, Any] = {}
+    positional_args: list[Any] = []
+
+    for element in _split_top_level(body):
+        if not element.strip():
+            continue
+
+        key_value = _split_top_level_key_value(element)
+
+        if key_value is None:
+            positional_args.append(_parse_value_text(element, symbols))
+        else:
+            key, value = key_value
+            args[key.strip()] = _parse_value_text(
+                value,
+                symbols,
+            )
+
+    return args, positional_args
+
+
+def _parse_value_text(
+    text: str,
+    symbols: dict[str, Any],
+) -> Any:
+    value = text.strip()
+
+    while value.startswith(("&", "*")):
+        value = value[1:].strip()
+
+    if len(value) >= 2 and value[0] == value[-1] == "`":
+        return _decode_go_string(value, is_raw=True)
+
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return _decode_go_string(value, is_raw=False)
+
+    if value == "true":
+        return True
+
+    if value == "false":
+        return False
+
+    if value == "nil":
+        return None
+
+    if re.fullmatch(r"[-+]?\d[\d_]*", value):
+        sign = -1 if value.startswith("-") else 1
+        unsigned = value.lstrip("+-")
+        parsed = _parse_int(unsigned)
+
+        if isinstance(parsed, int):
+            return sign * parsed
+
+        return value
+
+    if re.fullmatch(
+        r"[-+]?"
+        r"(?:"
+        r"\d[\d_]*\.\d[\d_]*|"
+        r"\d[\d_]*[eE][-+]?\d+"
+        r")",
+        value,
+    ):
+        try:
+            return float(value.replace("_", ""))
+        except ValueError:
+            return value
+
+    if re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*",
+        value,
+    ):
+        return symbols.get(value, f"${value}")
+
+    return f"${value}" if value else None
+
+
+def _mask_non_code(
+    content: str,
+) -> tuple[str, list[_ScannedString]]:
+    masked = list(content)
+    strings: list[_ScannedString] = []
+    index = 0
+    line = 1
+
+    def blank(start: int, end: int) -> None:
+        for position in range(start, end):
+            if masked[position] != "\n":
+                masked[position] = " "
+
+    while index < len(content):
+        if content.startswith("//", index):
+            end = content.find("\n", index)
+            end = len(content) if end == -1 else end
+            blank(index, end)
+            index = end
+            continue
+
+        if content.startswith("/*", index):
+            end = content.find("*/", index + 2)
+            end = len(content) if end == -1 else end + 2
+            line += content.count("\n", index, end)
+            blank(index, end)
+            index = end
+            continue
+
+        if content[index] in {'"', "`", "'"}:
+            quote = content[index]
+            start = index
+            start_line = line
+            index += 1
+
+            while index < len(content):
+                if quote != "`" and content[index] == "\\":
+                    index += 2
+                    continue
+
+                if content[index] == quote:
+                    index += 1
+                    break
+
+                if content[index] == "\n":
+                    line += 1
+
+                index += 1
+
+            raw = content[start:index]
+
+            if quote != "'":
+                strings.append(
+                    _ScannedString(
+                        value=_decode_go_string(
+                            raw,
+                            is_raw=quote == "`",
+                        ),
+                        start=start,
+                        end=index,
+                        line=start_line,
+                        is_raw=quote == "`",
+                    )
+                )
+
+            blank(start, index)
+            continue
+
+        if content[index] == "\n":
+            line += 1
+
+        index += 1
+
+    return "".join(masked), strings
+
+
+def _find_matching(
+    text: str,
+    start: int,
+    opener: str,
+    closer: str,
+) -> int | None:
+    depth = 0
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if char == opener:
+            depth += 1
+
+        elif char == closer:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _split_top_level(text: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+    }
+    closers = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(text):
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            continue
+
+        if char in {'"', "'", "`"}:
+            quote = char
+
+        elif char in depths:
+            depths[char] += 1
+
+        elif char in closers:
+            depths[closers[char]] = max(
+                0,
+                depths[closers[char]] - 1,
+            )
+
+        elif char == "," and not any(depths.values()):
+            parts.append(text[start:index].strip())
+            start = index + 1
+
+    parts.append(text[start:].strip())
+    return parts
+
+
+def _split_top_level_key_value(
+    text: str,
+) -> tuple[str, str] | None:
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+    }
+    closers = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(text):
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            continue
+
+        if char in {'"', "'", "`"}:
+            quote = char
+
+        elif char in depths:
+            depths[char] += 1
+
+        elif char in closers:
+            depths[closers[char]] = max(
+                0,
+                depths[closers[char]] - 1,
+            )
+
+        elif char == ":" and not any(depths.values()):
+            return text[:index], text[index + 1 :]
+
+    return None
+
+
+def _regex_assignment_target(
+    content: str,
+    position: int,
+) -> str | None:
+    boundary = max(
+        content.rfind("\n", 0, position),
+        content.rfind(";", 0, position),
+        content.rfind("{", 0, position),
+    )
+
+    prefix = content[boundary + 1 : position]
+
+    match = re.search(
+        r"^\s*"
+        r"(?:(?:var|const)\s+)?"
+        r"(?P<first>[A-Za-z_][A-Za-z0-9_]*)"
+        r"(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*"
+        r"\s*(?::=|=)\s*$",
+        prefix,
+    )
+
+    return match.group("first") if match else None
+
+
+def _looks_like_function_declaration(
+    masked: str,
+    position: int,
+) -> bool:
+    line_start = masked.rfind("\n", 0, position) + 1
+    prefix = masked[line_start:position]
+
+    return bool(
+        re.search(
+            r"\bfunc(?:\s*\([^)]*\))?\s*$",
+            prefix,
+        )
+    )

--- a/nuguard/sbom/deps.py
+++ b/nuguard/sbom/deps.py
@@ -10,6 +10,11 @@ Python:
 JavaScript / TypeScript:
 - ``package.json``    — dependencies, devDependencies, peerDependencies
 
+C# / .NET:
+- ``*.csproj`` — NuGet ``PackageReference`` entries
+- ``packages.config`` — legacy NuGet package declarations
+- ``Directory.Packages.props`` — central package management
+
 The scanner is intentionally shallow: it reads *declared* dependencies, not the
 full transitive closure.  For a complete lock-file SBOM combine this with
 ``pip-audit`` / ``cyclonedx-python`` (Python) or ``cyclonedx-npm`` (JS).
@@ -21,6 +26,7 @@ import json
 import os
 import re
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
@@ -39,7 +45,7 @@ else:
 
 
 class PackageDep(BaseModel):
-    """A single declared package dependency (Python or JavaScript)."""
+    """A single declared package dependency."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -61,11 +67,11 @@ class LifecycleScript(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    name: str        # script name, e.g. "postinstall", "preinstall", "build-backend"
-    body: str        # script body, truncated to 2000 chars
+    name: str  # script name, e.g. "postinstall", "preinstall", "build-backend"
+    body: str  # script body, truncated to 2000 chars
     source_file: str  # relative path to package.json / pyproject.toml / setup.py
-    ecosystem: str   # "npm" | "python"
-    phase: str       # "install-hook" | "build-hook" | "publish-hook"
+    ecosystem: str  # "npm" | "python"
+    phase: str  # "install-hook" | "build-hook" | "publish-hook"
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +81,7 @@ class LifecycleScript(BaseModel):
 _SPLIT_RE = re.compile(r"[><=!~\[;\s]")
 _COMMENT_RE = re.compile(r"#.*$")
 _DIGIT_START = re.compile(r"\d")
+_NUGET_VERSION_RE = re.compile(r"^\d+(?:\.\d+){0,3}(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 _MANIFEST_SKIP_DIRS = {
     ".venv",
     "venv",
@@ -145,6 +152,57 @@ def _to_npm_purl(name: str, spec: str) -> str:
     return f"pkg:npm/{encoded}"
 
 
+def _nuget_version_spec(raw_version: str) -> str:
+    """Normalize concrete NuGet versions and preserve unresolved expressions."""
+    version = raw_version.strip()
+    if _NUGET_VERSION_RE.fullmatch(version):
+        return f"=={version}"
+    return version
+
+
+def _to_nuget_purl(name: str, spec: str) -> str:
+    """Build a ``pkg:nuget/`` PURL when *spec* contains a concrete version."""
+    package_name = name.strip()
+    version = spec.strip()
+    if version.startswith("=="):
+        version = version[2:].strip()
+    if _NUGET_VERSION_RE.fullmatch(version):
+        return f"pkg:nuget/{package_name}@{version}"
+    return f"pkg:nuget/{package_name}"
+
+
+def _xml_local_name(tag: str) -> str:
+    """Return an XML tag or attribute name without its namespace."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _xml_attr(element: ET.Element, name: str) -> str:
+    """Read an XML attribute by local name, including namespaced attributes."""
+    direct = element.attrib.get(name)
+    if direct is not None:
+        return direct.strip()
+    for key, value in element.attrib.items():
+        if _xml_local_name(key) == name:
+            return value.strip()
+    return ""
+
+
+def _xml_child_text(element: ET.Element, name: str) -> str:
+    """Read the text of a direct XML child by local name."""
+    for child in element:
+        if isinstance(child.tag, str) and _xml_local_name(child.tag) == name:
+            return (child.text or "").strip()
+    return ""
+
+
+def _parse_xml(path: Path) -> ET.Element | None:
+    """Parse *path*, returning ``None`` for unreadable or malformed XML."""
+    try:
+        return ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return None
+
+
 def _poetry_spec(ver: object) -> str:
     if isinstance(ver, str) and _DIGIT_START.match(ver):
         return f"=={ver}"
@@ -170,6 +228,9 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
     requirements_paths: list[Path] = []
     setup_cfg_paths: list[Path] = []
     package_json_paths: list[Path] = []
+    csproj_paths: list[Path] = []
+    packages_config_paths: list[Path] = []
+    directory_packages_props_paths: list[Path] = []
 
     for current_root, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in _MANIFEST_SKIP_DIRS]
@@ -184,6 +245,12 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
                 setup_cfg_paths.append(path)
             elif filename == "package.json":
                 package_json_paths.append(path)
+            elif filename.endswith(".csproj"):
+                csproj_paths.append(path)
+            elif filename == "packages.config":
+                packages_config_paths.append(path)
+            elif filename == "Directory.Packages.props":
+                directory_packages_props_paths.append(path)
             elif filename.endswith(".txt") and (
                 filename.startswith("requirements") or in_requirements_dir
             ):
@@ -194,6 +261,11 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
         "requirements": sorted(set(requirements_paths)),
         "setup_cfg": _root_first_sorted(root, setup_cfg_paths, "setup.cfg"),
         "package_json": _root_first_sorted(root, package_json_paths, "package.json"),
+        "csproj": sorted(set(csproj_paths)),
+        "packages_config": _root_first_sorted(root, packages_config_paths, "packages.config"),
+        "directory_packages_props": _root_first_sorted(
+            root, directory_packages_props_paths, "Directory.Packages.props"
+        ),
     }
 
 
@@ -203,7 +275,7 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
 
 
 class DependencyScanner:
-    """Scan a project root directory and collect declared Python dependencies.
+    """Scan a project root directory and collect declared package dependencies.
 
     Usage::
 
@@ -225,15 +297,31 @@ class DependencyScanner:
         """
         seen: dict[str, PackageDep] = {}
         manifest_candidates = _collect_manifest_candidates(root)
+        directory_package_versions = self._read_directory_package_versions(
+            manifest_candidates["directory_packages_props"]
+        )
         for dep in [
             *self._scan_pyproject(root, manifest_candidates["pyproject"]),
             *self._scan_requirements(root, manifest_candidates["requirements"]),
             *self._scan_setup_cfg(root, manifest_candidates["setup_cfg"]),
             *self._scan_package_json(root, manifest_candidates["package_json"]),
+            *self._scan_csproj(
+                root,
+                manifest_candidates["csproj"],
+                directory_package_versions,
+            ),
+            *self._scan_packages_config(root, manifest_candidates["packages_config"]),
+            *self._scan_directory_packages_props(
+                root,
+                manifest_candidates["directory_packages_props"],
+                directory_package_versions,
+            ),
         ]:
             # Strip version from PURL for dedup key so pkg:pypi/foo and
             # pkg:npm/foo are treated as distinct entries.
             key = dep.purl.split("@")[0] if "@" in dep.purl else dep.purl
+            if key.startswith("pkg:nuget/"):
+                key = key.casefold()
             seen.setdefault(key, dep)
         return list(seen.values())
 
@@ -241,7 +329,9 @@ class DependencyScanner:
     # Manifest parsers
     # ------------------------------------------------------------------
 
-    def _scan_pyproject(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
+    def _scan_pyproject(
+        self, root: Path, candidate_paths: list[Path] | None = None
+    ) -> list[PackageDep]:
         """Parse ``pyproject.toml`` files found under *root*.
 
         Scans the root-level file first; then recursively finds any
@@ -339,7 +429,9 @@ class DependencyScanner:
 
         return deps
 
-    def _scan_requirements(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
+    def _scan_requirements(
+        self, root: Path, candidate_paths: list[Path] | None = None
+    ) -> list[PackageDep]:
         """Return deps from all requirements files found anywhere under *root*.
 
         Recursively globs for ``requirements*.txt`` (e.g. ``requirements.txt``,
@@ -367,7 +459,9 @@ class DependencyScanner:
                 pass
         return deps
 
-    def _scan_setup_cfg(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
+    def _scan_setup_cfg(
+        self, root: Path, candidate_paths: list[Path] | None = None
+    ) -> list[PackageDep]:
         if candidate_paths is None:
             candidate_paths = _collect_manifest_candidates(root)["setup_cfg"]
         if not candidate_paths:
@@ -396,7 +490,9 @@ class DependencyScanner:
                         deps.append(dep)
         return deps
 
-    def _scan_package_json(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
+    def _scan_package_json(
+        self, root: Path, candidate_paths: list[Path] | None = None
+    ) -> list[PackageDep]:
         """Parse ``package.json`` files and return npm deps with versions.
 
         Reads the standard dependency sections:
@@ -452,6 +548,160 @@ class DependencyScanner:
                     )
         return deps
 
+    def _read_directory_package_versions(
+        self,
+        candidate_paths: list[Path],
+    ) -> dict[Path, dict[str, tuple[str, str]]]:
+        """Read central NuGet versions, keyed by props path and package ID."""
+        versions_by_path: dict[Path, dict[str, tuple[str, str]]] = {}
+        for path in candidate_paths:
+            package_versions: dict[str, tuple[str, str]] = {}
+            versions_by_path[path] = package_versions
+            xml_root = _parse_xml(path)
+            if xml_root is None:
+                continue
+            for element in xml_root.iter():
+                if not isinstance(element.tag, str):
+                    continue
+                if _xml_local_name(element.tag) != "PackageVersion":
+                    continue
+                name = _xml_attr(element, "Include") or _xml_attr(element, "Update")
+                raw_version = _xml_attr(element, "Version") or _xml_child_text(element, "Version")
+                if not name or not raw_version:
+                    continue
+                package_versions.setdefault(name.casefold(), (name, raw_version))
+        return versions_by_path
+
+    @staticmethod
+    def _nearest_directory_package_versions(
+        project_path: Path,
+        versions_by_path: dict[Path, dict[str, tuple[str, str]]],
+    ) -> dict[str, tuple[str, str]]:
+        """Return the nearest ancestor ``Directory.Packages.props`` map."""
+        matching_paths = [path for path in versions_by_path if path.parent in project_path.parents]
+        if not matching_paths:
+            return {}
+        nearest = max(
+            matching_paths,
+            key=lambda path: len(path.parent.parts),
+        )
+        return versions_by_path[nearest]
+
+    def _scan_csproj(
+        self,
+        root: Path,
+        candidate_paths: list[Path] | None = None,
+        directory_package_versions: (dict[Path, dict[str, tuple[str, str]]] | None) = None,
+    ) -> list[PackageDep]:
+        """Parse NuGet ``PackageReference`` entries from C# project files."""
+        paths = candidate_paths
+        versions_by_path = directory_package_versions
+        if paths is None or versions_by_path is None:
+            candidates = _collect_manifest_candidates(root)
+            if paths is None:
+                paths = candidates["csproj"]
+            if versions_by_path is None:
+                versions_by_path = self._read_directory_package_versions(
+                    candidates["directory_packages_props"]
+                )
+
+        deps: list[PackageDep] = []
+        for path in paths:
+            xml_root = _parse_xml(path)
+            if xml_root is None:
+                continue
+            src = str(path.relative_to(root))
+            central_versions = self._nearest_directory_package_versions(path, versions_by_path)
+            for element in xml_root.iter():
+                if not isinstance(element.tag, str):
+                    continue
+                if _xml_local_name(element.tag) != "PackageReference":
+                    continue
+                name = _xml_attr(element, "Include") or _xml_attr(element, "Update")
+                if not name:
+                    continue
+                raw_version = _xml_attr(element, "Version") or _xml_child_text(element, "Version")
+                if not raw_version:
+                    central = central_versions.get(name.casefold())
+                    raw_version = central[1] if central is not None else ""
+                spec = _nuget_version_spec(raw_version)
+                deps.append(
+                    PackageDep(
+                        name=name,
+                        version_spec=spec,
+                        purl=_to_nuget_purl(name, spec),
+                        group="runtime",
+                        source_file=src,
+                    )
+                )
+        return deps
+
+    def _scan_packages_config(
+        self,
+        root: Path,
+        candidate_paths: list[Path] | None = None,
+    ) -> list[PackageDep]:
+        """Parse legacy NuGet ``packages.config`` files."""
+        if candidate_paths is None:
+            candidate_paths = _collect_manifest_candidates(root)["packages_config"]
+
+        deps: list[PackageDep] = []
+        for path in candidate_paths:
+            xml_root = _parse_xml(path)
+            if xml_root is None:
+                continue
+            src = str(path.relative_to(root))
+            for element in xml_root.iter():
+                if not isinstance(element.tag, str):
+                    continue
+                if _xml_local_name(element.tag) != "package":
+                    continue
+                name = _xml_attr(element, "id")
+                raw_version = _xml_attr(element, "version")
+                if not name or not raw_version:
+                    continue
+                spec = _nuget_version_spec(raw_version)
+                is_dev = _xml_attr(element, "developmentDependency").casefold() == "true"
+                deps.append(
+                    PackageDep(
+                        name=name,
+                        version_spec=spec,
+                        purl=_to_nuget_purl(name, spec),
+                        group="dev" if is_dev else "runtime",
+                        source_file=src,
+                    )
+                )
+        return deps
+
+    def _scan_directory_packages_props(
+        self,
+        root: Path,
+        candidate_paths: list[Path] | None = None,
+        directory_package_versions: (dict[Path, dict[str, tuple[str, str]]] | None) = None,
+    ) -> list[PackageDep]:
+        """Emit dependencies declared by central package management files."""
+        if candidate_paths is None:
+            candidate_paths = _collect_manifest_candidates(root)["directory_packages_props"]
+        if directory_package_versions is None:
+            directory_package_versions = self._read_directory_package_versions(candidate_paths)
+
+        deps: list[PackageDep] = []
+        for path in candidate_paths:
+            src = str(path.relative_to(root))
+            package_versions = directory_package_versions.get(path, {})
+            for name, raw_version in package_versions.values():
+                spec = _nuget_version_spec(raw_version)
+                deps.append(
+                    PackageDep(
+                        name=name,
+                        version_spec=spec,
+                        purl=_to_nuget_purl(name, spec),
+                        group="runtime",
+                        source_file=src,
+                    )
+                )
+        return deps
+
     # ------------------------------------------------------------------
     # Supply-chain extensions — no changes to existing scan() interface
     # ------------------------------------------------------------------
@@ -469,8 +719,15 @@ class DependencyScanner:
 
         # ── npm lifecycle scripts ─────────────────────────────────────
         _NPM_LIFECYCLE = {
-            "preinstall", "install", "postinstall", "prepare",
-            "prepack", "postpack", "prepublish", "prepublishOnly", "publish",
+            "preinstall",
+            "install",
+            "postinstall",
+            "prepare",
+            "prepack",
+            "postpack",
+            "prepublish",
+            "prepublishOnly",
+            "publish",
         }
         for path in candidates["package_json"]:
             src = str(path.relative_to(root))
@@ -495,13 +752,15 @@ class DependencyScanner:
                     hook_phase = "publish-hook"
                 else:
                     hook_phase = "build-hook"
-                scripts.append(LifecycleScript(
-                    name=phase,
-                    body=body[:2000],
-                    source_file=src,
-                    ecosystem="npm",
-                    phase=hook_phase,
-                ))
+                scripts.append(
+                    LifecycleScript(
+                        name=phase,
+                        body=body[:2000],
+                        source_file=src,
+                        ecosystem="npm",
+                        phase=hook_phase,
+                    )
+                )
 
         # ── Python build hooks ────────────────────────────────────────
         scripts.extend(self.parse_python_build_hooks(root))
@@ -522,25 +781,29 @@ class DependencyScanner:
             build_sys = data.get("build-system", {})
             backend = build_sys.get("build-backend")
             if backend and isinstance(backend, str):
-                scripts.append(LifecycleScript(
-                    name="build-backend",
-                    body=backend[:2000],
-                    source_file=src,
-                    ecosystem="python",
-                    phase="build-hook",
-                ))
+                scripts.append(
+                    LifecycleScript(
+                        name="build-backend",
+                        body=backend[:2000],
+                        source_file=src,
+                        ecosystem="python",
+                        phase="build-hook",
+                    )
+                )
             tool = data.get("tool", {})
             hatch = tool.get("hatch", {})
             for hook_name, hook_cfg in hatch.get("build", {}).get("hooks", {}).items():
                 if isinstance(hook_cfg, dict):
                     body = json.dumps(hook_cfg)[:2000]
-                    scripts.append(LifecycleScript(
-                        name=f"hatch.build.hooks.{hook_name}",
-                        body=body,
-                        source_file=src,
-                        ecosystem="python",
-                        phase="build-hook",
-                    ))
+                    scripts.append(
+                        LifecycleScript(
+                            name=f"hatch.build.hooks.{hook_name}",
+                            body=body,
+                            source_file=src,
+                            ecosystem="python",
+                            phase="build-hook",
+                        )
+                    )
 
         # setup.py presence: flag for manual review
         for setup_py in root.rglob("setup.py"):
@@ -551,13 +814,15 @@ class DependencyScanner:
                 body = setup_py.read_text(encoding="utf-8", errors="replace")[:2000]
             except OSError:
                 continue
-            scripts.append(LifecycleScript(
-                name="setup.py",
-                body=body,
-                source_file=src,
-                ecosystem="python",
-                phase="build-hook",
-            ))
+            scripts.append(
+                LifecycleScript(
+                    name="setup.py",
+                    body=body,
+                    source_file=src,
+                    ecosystem="python",
+                    phase="build-hook",
+                )
+            )
         return scripts
 
     def parse_lockfiles(self, root: Path) -> list[dict[str, str]]:
@@ -584,16 +849,22 @@ class DependencyScanner:
         for pkg_key, pkg_data in packages.items():
             if not isinstance(pkg_data, dict):
                 continue
-            name = pkg_key.removeprefix("node_modules/") if pkg_key.startswith("node_modules/") else pkg_key
+            name = (
+                pkg_key.removeprefix("node_modules/")
+                if pkg_key.startswith("node_modules/")
+                else pkg_key
+            )
             if not name:
                 continue
-            records.append({
-                "name": name,
-                "version": str(pkg_data.get("version", "")),
-                "resolved_url": str(pkg_data.get("resolved", "")),
-                "integrity_hash": str(pkg_data.get("integrity", "")),
-                "ecosystem": "npm",
-            })
+            records.append(
+                {
+                    "name": name,
+                    "version": str(pkg_data.get("version", "")),
+                    "resolved_url": str(pkg_data.get("resolved", "")),
+                    "integrity_hash": str(pkg_data.get("integrity", "")),
+                    "ecosystem": "npm",
+                }
+            )
         return records
 
     def _parse_uv_lockfile(self, root: Path) -> list[dict[str, str]]:
@@ -612,22 +883,28 @@ class DependencyScanner:
                 continue
             name = str(pkg.get("name", ""))
             version = str(pkg.get("version", ""))
-            for src in pkg.get("source", {}).values() if isinstance(pkg.get("source"), dict) else []:
-                records.append({
-                    "name": name,
-                    "version": version,
-                    "resolved_url": str(src),
-                    "integrity_hash": "",
-                    "ecosystem": "python",
-                })
+            for src in (
+                pkg.get("source", {}).values() if isinstance(pkg.get("source"), dict) else []
+            ):
+                records.append(
+                    {
+                        "name": name,
+                        "version": version,
+                        "resolved_url": str(src),
+                        "integrity_hash": "",
+                        "ecosystem": "python",
+                    }
+                )
                 break
             else:
                 if name:
-                    records.append({
-                        "name": name,
-                        "version": version,
-                        "resolved_url": "",
-                        "integrity_hash": "",
-                        "ecosystem": "python",
-                    })
+                    records.append(
+                        {
+                            "name": name,
+                            "version": version,
+                            "resolved_url": "",
+                            "integrity_hash": "",
+                            "ecosystem": "python",
+                        }
+                    )
         return records

--- a/nuguard/sbom/deps.py
+++ b/nuguard/sbom/deps.py
@@ -152,22 +152,34 @@ def _to_npm_purl(name: str, spec: str) -> str:
     return f"pkg:npm/{encoded}"
 
 
+def _concrete_nuget_version(spec: str) -> str | None:
+    """Return the exact version represented by a concrete NuGet specifier."""
+    version = spec.strip()
+
+    if version.startswith("=="):
+        version = version[2:].strip()
+    elif version.startswith("[") and version.endswith("]") and "," not in version:
+        version = version[1:-1].strip()
+
+    return version if _NUGET_VERSION_RE.fullmatch(version) else None
+
+
 def _nuget_version_spec(raw_version: str) -> str:
     """Normalize concrete NuGet versions and preserve unresolved expressions."""
     version = raw_version.strip()
-    if _NUGET_VERSION_RE.fullmatch(version):
-        return f"=={version}"
-    return version
+    concrete_version = _concrete_nuget_version(version)
+
+    return f"=={concrete_version}" if concrete_version else version
 
 
 def _to_nuget_purl(name: str, spec: str) -> str:
     """Build a ``pkg:nuget/`` PURL when *spec* contains a concrete version."""
     package_name = name.strip()
-    version = spec.strip()
-    if version.startswith("=="):
-        version = version[2:].strip()
-    if _NUGET_VERSION_RE.fullmatch(version):
-        return f"pkg:nuget/{package_name}@{version}"
+    concrete_version = _concrete_nuget_version(spec)
+
+    if concrete_version:
+        return f"pkg:nuget/{package_name}@{concrete_version}"
+
     return f"pkg:nuget/{package_name}"
 
 
@@ -568,22 +580,69 @@ class DependencyScanner:
     ) -> dict[Path, dict[str, tuple[str, str]]]:
         """Read central NuGet versions, keyed by props path and package ID."""
         versions_by_path: dict[Path, dict[str, tuple[str, str]]] = {}
+
         for path in candidate_paths:
             package_versions: dict[str, tuple[str, str]] = {}
             versions_by_path[path] = package_versions
+
             xml_root = _parse_xml(path)
+
             if xml_root is None:
                 continue
+
             for element in xml_root.iter():
                 if not isinstance(element.tag, str):
                     continue
+
                 if _xml_local_name(element.tag) != "PackageVersion":
                     continue
-                name = _xml_attr(element, "Include") or _xml_attr(element, "Update")
-                raw_version = _xml_attr(element, "Version") or _xml_child_text(element, "Version")
+
+                include_name = _xml_attr(
+                    element,
+                    "Include",
+                )
+
+                update_name = _xml_attr(
+                    element,
+                    "Update",
+                )
+
+                name = include_name or update_name
+
+                raw_version = _xml_attr(
+                    element,
+                    "Version",
+                ) or _xml_child_text(
+                    element,
+                    "Version",
+                )
+
                 if not name or not raw_version:
                     continue
-                package_versions.setdefault(name.casefold(), (name, raw_version))
+
+                key = name.casefold()
+
+                if update_name:
+                    existing = package_versions.get(key)
+
+                    # Update mutates an item already declared in this file.
+                    # Imported props-chain evaluation remains out of scope.
+                    if existing is not None:
+                        package_versions[key] = (
+                            existing[0],
+                            raw_version,
+                        )
+
+                    continue
+
+                package_versions.setdefault(
+                    key,
+                    (
+                        name,
+                        raw_version,
+                    ),
+                )
+
         return versions_by_path
 
     @staticmethod
@@ -610,44 +669,112 @@ class DependencyScanner:
         """Parse NuGet ``PackageReference`` entries from C# project files."""
         paths = candidate_paths
         versions_by_path = directory_package_versions
+
         if paths is None or versions_by_path is None:
             candidates = _collect_manifest_candidates(root)
+
             if paths is None:
                 paths = candidates["csproj"]
+
             if versions_by_path is None:
                 versions_by_path = self._read_directory_package_versions(
                     candidates["directory_packages_props"]
                 )
 
         deps: list[PackageDep] = []
+
         for path in paths:
             xml_root = _parse_xml(path)
+
             if xml_root is None:
                 continue
+
             src = str(path.relative_to(root))
-            central_versions = self._nearest_directory_package_versions(path, versions_by_path)
+
+            central_versions = self._nearest_directory_package_versions(
+                path,
+                versions_by_path,
+            )
+
+            references: dict[
+                str,
+                tuple[str, str],
+            ] = {}
+
             for element in xml_root.iter():
                 if not isinstance(element.tag, str):
                     continue
+
                 if _xml_local_name(element.tag) != "PackageReference":
                     continue
-                name = _xml_attr(element, "Include") or _xml_attr(element, "Update")
+
+                include_name = _xml_attr(
+                    element,
+                    "Include",
+                )
+
+                update_name = _xml_attr(
+                    element,
+                    "Update",
+                )
+
+                name = include_name or update_name
+
                 if not name:
                     continue
-                raw_version = _xml_attr(element, "Version") or _xml_child_text(element, "Version")
+
+                raw_version = _xml_attr(
+                    element,
+                    "Version",
+                ) or _xml_child_text(
+                    element,
+                    "Version",
+                )
+
+                key = name.casefold()
+
+                if update_name:
+                    existing = references.get(key)
+
+                    # Update mutates a reference already declared in this
+                    # project. Imported reference evaluation is out of scope.
+                    if existing is not None:
+                        references[key] = (
+                            existing[0],
+                            raw_version or existing[1],
+                        )
+
+                    continue
+
+                references.setdefault(
+                    key,
+                    (
+                        name,
+                        raw_version,
+                    ),
+                )
+
+            for name, raw_version in references.values():
                 if not raw_version:
                     central = central_versions.get(name.casefold())
+
                     raw_version = central[1] if central is not None else ""
+
                 spec = _nuget_version_spec(raw_version)
+
                 deps.append(
                     PackageDep(
                         name=name,
                         version_spec=spec,
-                        purl=_to_nuget_purl(name, spec),
+                        purl=_to_nuget_purl(
+                            name,
+                            spec,
+                        ),
                         group="runtime",
                         source_file=src,
                     )
                 )
+
         return deps
 
     def _scan_packages_config(

--- a/nuguard/sbom/deps.py
+++ b/nuguard/sbom/deps.py
@@ -200,6 +200,7 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
         "go_mod": _root_first_sorted(root, go_mod_paths, "go.mod"),
     }
 
+
 def _to_go_purl(module: str, version: str) -> str:
     """Build a ``pkg:go/`` PURL for a Go module."""
     module_clean = module.strip()
@@ -465,88 +466,94 @@ class DependencyScanner:
         return deps
 
     def _scan_go_mod(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
-            """Parse ``go.mod`` and ``go.sum`` files and return Go module dependencies.
+        """Parse ``go.mod`` and ``go.sum`` files and return Go module dependencies.
 
-            Parses both single-line require directives:
-                require github.com/gin-gonic/gin v1.9.1
-            And block require directives:
-                require (
-                    github.com/google/uuid v1.3.0
-                )
-            Also parses ``go.sum`` for exact pinned module versions.
-            """
-            if candidate_paths is None:
-                candidate_paths = _collect_manifest_candidates(root)["go_mod"]
+        Parses both single-line require directives:
+            require github.com/gin-gonic/gin v1.9.1
+        And block require directives:
+            require (
+                github.com/google/uuid v1.3.0
+            )
+        Also parses ``go.sum`` for exact pinned module versions.
+        """
+        if candidate_paths is None:
+            candidate_paths = _collect_manifest_candidates(root)["go_mod"]
 
-            deps: list[PackageDep] = []
-            for path in candidate_paths:
-                src = str(path.relative_to(root))
-                try:
-                    content = path.read_text(encoding="utf-8")
-                except OSError:
-                    continue
+        # Ensure go.sum paths are processed before go.mod so exact version pins win
+        sorted_candidates = sorted(
+            candidate_paths,
+            key=lambda p: 0 if p.name == "go.sum" else 1
+        )
 
-                # Parse go.sum
-                if path.name == "go.sum":
-                    for line in content.splitlines():
-                        parts = line.strip().split()
-                        if len(parts) >= 2:
-                            mod, ver = parts[0], parts[1].split("/go.mod")[0]
-                            deps.append(
-                                PackageDep(
-                                    name=mod,
-                                    version_spec=f"=={ver}",
-                                    purl=_to_go_purl(mod, ver),
-                                    group="runtime",
-                                    source_file=src,
-                                )
-                            )
-                    continue
+        deps: list[PackageDep] = []
+        for path in sorted_candidates:
+            src = str(path.relative_to(root))
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
 
-                # Parse go.mod
-                in_require_block = False
+            # Parse go.sum
+            if path.name == "go.sum":
                 for line in content.splitlines():
-                    line = line.strip()
-                    if not line or line.startswith("//"):
-                        continue
-
-                    if line == "require (" or line.startswith("require ("):
-                        in_require_block = True
-                        continue
-
-                    if in_require_block:
-                        if line == ")":
-                            in_require_block = False
-                            continue
-                        parts = line.split()
-                        if len(parts) >= 2:
-                            mod, ver = parts[0], parts[1]
-                            group = "runtime" if "// indirect" not in line else "optional:indirect"
-                            deps.append(
-                                PackageDep(
-                                    name=mod,
-                                    version_spec=f"=={ver}",
-                                    purl=_to_go_purl(mod, ver),
-                                    group=group,
-                                    source_file=src,
-                                )
+                    parts = line.strip().split()
+                    if len(parts) >= 2:
+                        mod, ver = parts[0], parts[1].split("/go.mod")[0]
+                        deps.append(
+                            PackageDep(
+                                name=mod,
+                                version_spec=f"=={ver}",
+                                purl=_to_go_purl(mod, ver),
+                                group="runtime",
+                                source_file=src,
                             )
-                    elif line.startswith("require "):
-                        parts = line.split()
-                        if len(parts) >= 3:
-                            mod, ver = parts[1], parts[2]
-                            group = "runtime" if "// indirect" not in line else "optional:indirect"
-                            deps.append(
-                                PackageDep(
-                                    name=mod,
-                                    version_spec=f"=={ver}",
-                                    purl=_to_go_purl(mod, ver),
-                                    group=group,
-                                    source_file=src,
-                                )
-                            )
+                        )
+                continue
 
-            return deps
+            # Parse go.mod
+            in_require_block = False
+            for line in content.splitlines():
+                line = line.strip()
+                if not line or line.startswith("//"):
+                    continue
+
+                if line == "require (" or line.startswith("require ("):
+                    in_require_block = True
+                    continue
+
+                if in_require_block:
+                    if line == ")":
+                        in_require_block = False
+                        continue
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        mod, ver = parts[0], parts[1]
+                        group = "runtime" if "// indirect" not in line else "optional:indirect"
+                        deps.append(
+                            PackageDep(
+                                name=mod,
+                                version_spec=f"=={ver}",
+                                purl=_to_go_purl(mod, ver),
+                                group=group,
+                                source_file=src,
+                            )
+                        )
+                elif line.startswith("require "):
+                    parts = line.split()
+                    if len(parts) >= 3:
+                        mod, ver = parts[1], parts[2]
+                        group = "runtime" if "// indirect" not in line else "optional:indirect"
+                        deps.append(
+                            PackageDep(
+                                name=mod,
+                                version_spec=f"=={ver}",
+                                purl=_to_go_purl(mod, ver),
+                                group=group,
+                                source_file=src,
+                            )
+                        )
+
+        return deps
     # ------------------------------------------------------------------
     # Supply-chain extensions — no changes to existing scan() interface
     # ------------------------------------------------------------------

--- a/nuguard/sbom/deps.py
+++ b/nuguard/sbom/deps.py
@@ -170,6 +170,7 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
     requirements_paths: list[Path] = []
     setup_cfg_paths: list[Path] = []
     package_json_paths: list[Path] = []
+    go_mod_paths: list[Path] = []
 
     for current_root, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in _MANIFEST_SKIP_DIRS]
@@ -184,6 +185,8 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
                 setup_cfg_paths.append(path)
             elif filename == "package.json":
                 package_json_paths.append(path)
+            elif filename in ("go.mod", "go.sum"):
+                go_mod_paths.append(path)
             elif filename.endswith(".txt") and (
                 filename.startswith("requirements") or in_requirements_dir
             ):
@@ -194,8 +197,16 @@ def _collect_manifest_candidates(root: Path) -> dict[str, list[Path]]:
         "requirements": sorted(set(requirements_paths)),
         "setup_cfg": _root_first_sorted(root, setup_cfg_paths, "setup.cfg"),
         "package_json": _root_first_sorted(root, package_json_paths, "package.json"),
+        "go_mod": _root_first_sorted(root, go_mod_paths, "go.mod"),
     }
 
+def _to_go_purl(module: str, version: str) -> str:
+    """Build a ``pkg:go/`` PURL for a Go module."""
+    module_clean = module.strip()
+    ver_clean = version.strip()
+    if ver_clean:
+        return f"pkg:go/{module_clean}@{ver_clean}"
+    return f"pkg:go/{module_clean}"
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -230,6 +241,7 @@ class DependencyScanner:
             *self._scan_requirements(root, manifest_candidates["requirements"]),
             *self._scan_setup_cfg(root, manifest_candidates["setup_cfg"]),
             *self._scan_package_json(root, manifest_candidates["package_json"]),
+            *self._scan_go_mod(root, manifest_candidates["go_mod"]),
         ]:
             # Strip version from PURL for dedup key so pkg:pypi/foo and
             # pkg:npm/foo are treated as distinct entries.
@@ -452,6 +464,89 @@ class DependencyScanner:
                     )
         return deps
 
+    def _scan_go_mod(self, root: Path, candidate_paths: list[Path] | None = None) -> list[PackageDep]:
+            """Parse ``go.mod`` and ``go.sum`` files and return Go module dependencies.
+
+            Parses both single-line require directives:
+                require github.com/gin-gonic/gin v1.9.1
+            And block require directives:
+                require (
+                    github.com/google/uuid v1.3.0
+                )
+            Also parses ``go.sum`` for exact pinned module versions.
+            """
+            if candidate_paths is None:
+                candidate_paths = _collect_manifest_candidates(root)["go_mod"]
+
+            deps: list[PackageDep] = []
+            for path in candidate_paths:
+                src = str(path.relative_to(root))
+                try:
+                    content = path.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+
+                # Parse go.sum
+                if path.name == "go.sum":
+                    for line in content.splitlines():
+                        parts = line.strip().split()
+                        if len(parts) >= 2:
+                            mod, ver = parts[0], parts[1].split("/go.mod")[0]
+                            deps.append(
+                                PackageDep(
+                                    name=mod,
+                                    version_spec=f"=={ver}",
+                                    purl=_to_go_purl(mod, ver),
+                                    group="runtime",
+                                    source_file=src,
+                                )
+                            )
+                    continue
+
+                # Parse go.mod
+                in_require_block = False
+                for line in content.splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("//"):
+                        continue
+
+                    if line == "require (" or line.startswith("require ("):
+                        in_require_block = True
+                        continue
+
+                    if in_require_block:
+                        if line == ")":
+                            in_require_block = False
+                            continue
+                        parts = line.split()
+                        if len(parts) >= 2:
+                            mod, ver = parts[0], parts[1]
+                            group = "runtime" if "// indirect" not in line else "optional:indirect"
+                            deps.append(
+                                PackageDep(
+                                    name=mod,
+                                    version_spec=f"=={ver}",
+                                    purl=_to_go_purl(mod, ver),
+                                    group=group,
+                                    source_file=src,
+                                )
+                            )
+                    elif line.startswith("require "):
+                        parts = line.split()
+                        if len(parts) >= 3:
+                            mod, ver = parts[1], parts[2]
+                            group = "runtime" if "// indirect" not in line else "optional:indirect"
+                            deps.append(
+                                PackageDep(
+                                    name=mod,
+                                    version_spec=f"=={ver}",
+                                    purl=_to_go_purl(mod, ver),
+                                    group=group,
+                                    source_file=src,
+                                )
+                            )
+
+            return deps
     # ------------------------------------------------------------------
     # Supply-chain extensions — no changes to existing scan() interface
     # ------------------------------------------------------------------

--- a/nuguard/sbom/schemas/aibom.schema.json
+++ b/nuguard/sbom/schemas/aibom.schema.json
@@ -1874,7 +1874,7 @@
       "type": "object"
     },
     "PackageDep": {
-      "description": "A single declared package dependency (Python or JavaScript).",
+      "description": "A single declared package dependency.",
       "properties": {
         "name": {
           "title": "Name",

--- a/nuguard/sbom/tests/test_csharp_base.py
+++ b/nuguard/sbom/tests/test_csharp_base.py
@@ -1,0 +1,149 @@
+"""Tests for the shared C# framework-adapter base class."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from nuguard.sbom.adapters.base import ComponentDetection
+from nuguard.sbom.adapters.csharp import CSharpFrameworkAdapter
+from nuguard.sbom.core.csharp_parser import (
+    CSharpParseResult,
+    parse_csharp,
+)
+
+
+class _ExampleAdapter(CSharpFrameworkAdapter):
+    name = "example_csharp"
+    priority = 25
+
+    handles_namespaces = [
+        "Azure.AI.OpenAI",
+        "Microsoft.SemanticKernel",
+    ]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = self._parse_result(
+            content,
+            file_path,
+            parse_result,
+        )
+
+        if not self._detect(result):
+            return []
+
+        line = result.using_directives[0].line if result.using_directives else 0
+
+        return [
+            self._fw_node(
+                file_path,
+                line,
+            )
+        ]
+
+
+def test_base_class_is_abstract() -> None:
+    assert inspect.isabstract(CSharpFrameworkAdapter)
+
+
+def test_can_handle_exact_descendant_and_global_namespace() -> None:
+    adapter = _ExampleAdapter()
+
+    assert adapter.can_handle({"Azure.AI.OpenAI"})
+    assert adapter.can_handle({"Azure.AI.OpenAI.Chat"})
+    assert adapter.can_handle({"global::Microsoft.SemanticKernel.Connectors.OpenAI"})
+
+
+def test_can_handle_rejects_siblings_and_substrings() -> None:
+    adapter = _ExampleAdapter()
+
+    assert not adapter.can_handle({"Azure.AI"})
+    assert not adapter.can_handle({"Contoso.Azure.AI.OpenAI"})
+    assert not adapter.can_handle({"Microsoft.SemanticKernelish"})
+
+
+def test_detect_and_extract_use_structural_parse_result() -> None:
+    adapter = _ExampleAdapter()
+
+    source = "using Azure.AI.OpenAI;\npublic class App {}\n"
+
+    result = parse_csharp(
+        source,
+        "App.cs",
+    )
+
+    assert adapter._detect(result)
+
+    detections = adapter.extract(
+        source,
+        "App.cs",
+        result,
+    )
+
+    assert len(detections) == 1
+    assert detections[0].file_path == "App.cs"
+    assert detections[0].line == 1
+
+
+def test_parse_result_reuses_typed_result_or_parses_content() -> None:
+    existing = CSharpParseResult(file_path="Existing.cs")
+
+    assert (
+        _ExampleAdapter._parse_result(
+            "ignored",
+            "Other.cs",
+            existing,
+        )
+        is existing
+    )
+
+    parsed = _ExampleAdapter._parse_result(
+        "using Microsoft.SemanticKernel;",
+        "Kernel.cs",
+        None,
+    )
+
+    assert parsed.file_path == "Kernel.cs"
+    assert parsed.using_directives[0].namespace == "Microsoft.SemanticKernel"
+
+
+def test_framework_node_uses_csharp_metadata() -> None:
+    node = _ExampleAdapter()._fw_node(
+        "Program.cs",
+        7,
+    )
+
+    assert node.canonical_name == "framework:example_csharp"
+    assert node.adapter_name == "example_csharp"
+    assert node.priority == 25
+    assert node.metadata == {
+        "framework": "example_csharp",
+        "language": "csharp",
+    }
+    assert node.evidence_kind == "ast_import"
+
+
+def test_common_helpers_clean_assignments_and_template_variables() -> None:
+    assert _ExampleAdapter._clean('$"gpt-4o"') == "gpt-4o"
+
+    assert _ExampleAdapter._clean("$(ModelName)") == ""
+
+    assert (
+        _ExampleAdapter._assignment_name(
+            'var client = new AzureOpenAIClient("endpoint");',
+            1,
+        )
+        == "client"
+    )
+
+    assert _ExampleAdapter._template_vars(
+        "Hello {user.Name}; total {amount:N2}; escaped {{literal}}"
+    ) == [
+        "user.Name",
+        "amount",
+    ]

--- a/nuguard/sbom/tests/test_csharp_deps.py
+++ b/nuguard/sbom/tests/test_csharp_deps.py
@@ -1,0 +1,229 @@
+"""Tests for C# project and NuGet manifest dependency scanning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nuguard.sbom.deps import DependencyScanner, _to_nuget_purl
+
+
+class TestNugetPurl:
+    def test_concrete_version_is_embedded(self) -> None:
+        assert (
+            _to_nuget_purl("Microsoft.SemanticKernel", "==1.45.0")
+            == "pkg:nuget/Microsoft.SemanticKernel@1.45.0"
+        )
+
+    def test_non_concrete_version_is_not_embedded(self) -> None:
+        assert (
+            _to_nuget_purl("Azure.AI.OpenAI", "$(AzureOpenAIVersion)")
+            == "pkg:nuget/Azure.AI.OpenAI"
+        )
+
+
+class TestCsprojScanning:
+    def test_inline_and_nested_versions(self, tmp_path: Path) -> None:
+        (tmp_path / "App.csproj").write_text(
+            """<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel"
+                      Version="1.45.0" />
+    <PackageReference Include="Azure.AI.OpenAI">
+      <Version>2.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+""",
+            encoding="utf-8",
+        )
+
+        deps = {dep.name: dep for dep in DependencyScanner().scan(tmp_path)}
+
+        semantic_kernel = deps["Microsoft.SemanticKernel"]
+        assert semantic_kernel.version_spec == "==1.45.0"
+        assert semantic_kernel.version == "1.45.0"
+        assert semantic_kernel.purl == "pkg:nuget/Microsoft.SemanticKernel@1.45.0"
+        assert semantic_kernel.source_file == "App.csproj"
+
+        azure_openai = deps["Azure.AI.OpenAI"]
+        assert azure_openai.version_spec == "==2.1.0"
+        assert azure_openai.purl == "pkg:nuget/Azure.AI.OpenAI@2.1.0"
+
+    def test_xml_namespace_is_supported(self, tmp_path: Path) -> None:
+        (tmp_path / "Legacy.csproj").write_text(
+            """<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML" Version="4.0.1" />
+  </ItemGroup>
+</Project>
+""",
+            encoding="utf-8",
+        )
+
+        deps = DependencyScanner().scan(tmp_path)
+
+        assert [dep.purl for dep in deps] == ["pkg:nuget/Microsoft.ML@4.0.1"]
+
+    def test_msbuild_property_version_remains_unresolved(self, tmp_path: Path) -> None:
+        (tmp_path / "App.csproj").write_text(
+            """<Project>
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI"
+                      Version="$(AzureOpenAIVersion)" />
+  </ItemGroup>
+</Project>
+""",
+            encoding="utf-8",
+        )
+
+        dep = DependencyScanner().scan(tmp_path)[0]
+
+        assert dep.version_spec == "$(AzureOpenAIVersion)"
+        assert dep.version is None
+        assert dep.purl == "pkg:nuget/Azure.AI.OpenAI"
+
+    def test_central_package_management_and_inline_override(self, tmp_path: Path) -> None:
+        (tmp_path / "Directory.Packages.props").write_text(
+            """<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.SemanticKernel"
+                    Version="1.45.0" />
+    <PackageVersion Include="Azure.AI.OpenAI">
+      <Version>2.1.0</Version>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.ML" Version="4.0.1" />
+  </ItemGroup>
+</Project>
+""",
+            encoding="utf-8",
+        )
+
+        app_dir = tmp_path / "src" / "App"
+        app_dir.mkdir(parents=True)
+
+        (app_dir / "App.csproj").write_text(
+            """<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0" />
+  </ItemGroup>
+</Project>
+""",
+            encoding="utf-8",
+        )
+
+        deps = {dep.name: dep for dep in DependencyScanner().scan(tmp_path)}
+
+        semantic_kernel = deps["Microsoft.SemanticKernel"]
+        assert semantic_kernel.purl == "pkg:nuget/Microsoft.SemanticKernel@1.45.0"
+        assert semantic_kernel.source_file == "src/App/App.csproj"
+
+        azure_openai = deps["Azure.AI.OpenAI"]
+        assert azure_openai.purl == "pkg:nuget/Azure.AI.OpenAI@2.2.0"
+        assert azure_openai.source_file == "src/App/App.csproj"
+
+        central_only = deps["Microsoft.ML"]
+        assert central_only.purl == "pkg:nuget/Microsoft.ML@4.0.1"
+        assert central_only.source_file == "Directory.Packages.props"
+
+    def test_nearest_directory_packages_props_wins(self, tmp_path: Path) -> None:
+        (tmp_path / "Directory.Packages.props").write_text(
+            """<Project><ItemGroup>
+  <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        nested = tmp_path / "src"
+        nested.mkdir()
+
+        (nested / "Directory.Packages.props").write_text(
+            """<Project><ItemGroup>
+  <PackageVersion Include="Azure.AI.OpenAI" Version="2.2.0" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        (nested / "App.csproj").write_text(
+            """<Project><ItemGroup>
+  <PackageReference Include="Azure.AI.OpenAI" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        dep = next(
+            dep for dep in DependencyScanner().scan(tmp_path) if dep.source_file == "src/App.csproj"
+        )
+
+        assert dep.purl == "pkg:nuget/Azure.AI.OpenAI@2.2.0"
+
+
+class TestPackagesConfigScanning:
+    def test_packages_config_and_development_dependency(self, tmp_path: Path) -> None:
+        (tmp_path / "packages.config").write_text(
+            """<packages xmlns="urn:nuget-packages">
+  <package id="Newtonsoft.Json" version="13.0.3" />
+  <package id="Microsoft.CodeAnalysis"
+           version="4.11.0"
+           developmentDependency="true" />
+</packages>
+""",
+            encoding="utf-8",
+        )
+
+        deps = {dep.name: dep for dep in DependencyScanner().scan(tmp_path)}
+
+        assert deps["Newtonsoft.Json"].purl == "pkg:nuget/Newtonsoft.Json@13.0.3"
+        assert deps["Newtonsoft.Json"].group == "runtime"
+        assert deps["Microsoft.CodeAnalysis"].group == "dev"
+        assert deps["Microsoft.CodeAnalysis"].source_file == "packages.config"
+
+
+class TestCsharpManifestRobustness:
+    def test_malformed_or_incomplete_xml_is_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "Broken.csproj").write_text(
+            "<Project><ItemGroup><PackageReference",
+            encoding="utf-8",
+        )
+
+        (tmp_path / "packages.config").write_text(
+            "<packages><package id='Newtonsoft.Json'",
+            encoding="utf-8",
+        )
+
+        (tmp_path / "Directory.Packages.props").write_text(
+            "<Project><ItemGroup>",
+            encoding="utf-8",
+        )
+
+        assert DependencyScanner().scan(tmp_path) == []
+
+    def test_duplicates_are_deduplicated_and_unrelated_xml_is_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "App.csproj").write_text(
+            """<Project><ItemGroup>
+  <PackageReference Include="Microsoft.SemanticKernel"
+                    Version="1.45.0" />
+  <PackageReference Include="microsoft.semantickernel"
+                    Version="1.45.0" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        (tmp_path / "unrelated.xml").write_text(
+            """<Project><ItemGroup>
+  <PackageReference Include="Should.Not.Be.Scanned"
+                    Version="9.9.9" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        deps = DependencyScanner().scan(tmp_path)
+
+        assert len(deps) == 1
+        assert deps[0].name == "Microsoft.SemanticKernel"
+        assert deps[0].purl == "pkg:nuget/Microsoft.SemanticKernel@1.45.0"

--- a/nuguard/sbom/tests/test_csharp_deps.py
+++ b/nuguard/sbom/tests/test_csharp_deps.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from nuguard.sbom.deps import DependencyScanner, _to_nuget_purl
+from nuguard.sbom.deps import (
+    DependencyScanner,
+    _nuget_version_spec,
+    _to_nuget_purl,
+)
 
 
 class TestNugetPurl:
@@ -18,6 +22,28 @@ class TestNugetPurl:
         assert (
             _to_nuget_purl("Azure.AI.OpenAI", "$(AzureOpenAIVersion)")
             == "pkg:nuget/Azure.AI.OpenAI"
+        )
+
+    def test_exact_bracket_version_is_concrete(self) -> None:
+        assert _nuget_version_spec("[1.2.3]") == "==1.2.3"
+
+        assert (
+            _to_nuget_purl(
+                "Example.Package",
+                "[1.2.3]",
+            )
+            == "pkg:nuget/Example.Package@1.2.3"
+        )
+
+    def test_version_range_is_not_concrete(self) -> None:
+        assert _nuget_version_spec("[1.2.3,2.0.0)") == "[1.2.3,2.0.0)"
+
+        assert (
+            _to_nuget_purl(
+                "Example.Package",
+                "[1.2.3,2.0.0)",
+            )
+            == "pkg:nuget/Example.Package"
         )
 
 
@@ -159,6 +185,74 @@ class TestCsprojScanning:
         )
 
         assert dep.purl == "pkg:nuget/Azure.AI.OpenAI@2.2.0"
+
+    def test_central_package_version_update_overrides_include(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "Directory.Packages.props").write_text(
+            """<Project><ItemGroup>
+  <PackageVersion Include="Microsoft.SemanticKernel"
+                  Version="1.0.0" />
+  <PackageVersion Update="microsoft.semantickernel"
+                  Version="2.0.0" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        (tmp_path / "App.csproj").write_text(
+            """<Project><ItemGroup>
+  <PackageReference Include="Microsoft.SemanticKernel" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        matches = [
+            dep
+            for dep in DependencyScanner().scan(tmp_path)
+            if (dep.name.casefold() == "microsoft.semantickernel")
+        ]
+
+        assert len(matches) == 1
+
+        dep = matches[0]
+
+        assert dep.name == "Microsoft.SemanticKernel"
+
+        assert dep.version_spec == "==2.0.0"
+
+        assert dep.purl == "pkg:nuget/Microsoft.SemanticKernel@2.0.0"
+
+        assert dep.source_file == "App.csproj"
+
+    def test_package_reference_update_mutates_existing_reference(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "App.csproj").write_text(
+            """<Project><ItemGroup>
+  <PackageReference Include="Azure.AI.OpenAI" />
+  <PackageReference Update="azure.ai.openai"
+                    Version="[2.1.0]" />
+</ItemGroup></Project>
+""",
+            encoding="utf-8",
+        )
+
+        deps = DependencyScanner().scan(tmp_path)
+
+        assert len(deps) == 1
+
+        dep = deps[0]
+
+        assert dep.name == "Azure.AI.OpenAI"
+        assert dep.version_spec == "==2.1.0"
+
+        assert dep.purl == "pkg:nuget/Azure.AI.OpenAI@2.1.0"
+
+        assert dep.source_file == "App.csproj"
 
 
 class TestPackagesConfigScanning:

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -17,6 +17,7 @@ from nuguard.sbom.adapters.csharp import (
 )
 from nuguard.sbom.adapters.csharp._source import (
     find_calls,
+    string_constants,
 )
 from nuguard.sbom.core.csharp_parser import (
     parse_csharp,
@@ -480,3 +481,202 @@ public class Greeter
         )
         == []
     )
+
+
+def test_review_fixes_use_only_const_strings() -> None:
+    source = """const string ModelName = "gpt-4o";
+var mutable = "first";
+mutable = "second";
+"""
+    result = parse_csharp(source)
+
+    assert string_constants(result) == {"ModelName": "gpt-4o"}
+
+
+def test_fully_qualified_legacy_azure_client_is_azure() -> None:
+    source = """var client =
+    new Azure.AI.OpenAI.OpenAIClient(
+        new Uri("https://example.openai.azure.com"),
+        credential);
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    providers = {
+        detection.metadata["provider"]
+        for detection in _by_type(
+            detections,
+            ComponentType.FRAMEWORK,
+        )
+    }
+
+    assert providers == {"azure"}
+
+
+def test_anthropic_model_scan_ignores_comments_and_strings() -> None:
+    source = """using Anthropic;
+var client = new AnthropicClient(apiKey);
+var text = "Model = \\"claude-fake\\"";
+// Model = Model.ClaudeFake;
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+
+    assert (
+        _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+        == []
+    )
+
+
+def test_anthropic_string_model_assignment_is_detected() -> None:
+    source = """using Anthropic;
+var client = new AnthropicClient(apiKey);
+var request = new MessageParameters
+{
+    Model = "claude-3-5-sonnet",
+};
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert [model.display_name for model in models] == ["claude-3-5-sonnet"]
+
+
+def test_semantic_kernel_marker_in_string_is_ignored() -> None:
+    source = 'var marker = "Microsoft.SemanticKernel";'
+
+    assert (
+        _extract(
+            CSharpSemanticKernelAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_mlnet_marker_in_string_is_ignored() -> None:
+    source = 'var marker = "MLContext";'
+
+    assert (
+        _extract(
+            CSharpMLNetAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_mlnet_emits_multiple_independent_pipelines() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext();
+var first = ml.Transforms.Text.FeaturizeText(
+    "Features1", "Text1");
+var second = ml.Transforms.Text.FeaturizeText(
+    "Features2", "Text2");
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+    pipelines = [
+        detection for detection in detections if detection.metadata.get("pipeline") is True
+    ]
+
+    assert {pipeline.display_name for pipeline in pipelines} == {
+        "first",
+        "second",
+    }
+
+
+def test_mlnet_ignores_unrelated_fit_calls() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext();
+var result = curveFitter.Fit(data);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+
+    assert not any(detection.metadata.get("trained_model") is True for detection in detections)
+
+
+def test_aspnet_builder_marker_in_string_is_ignored() -> None:
+    source = 'var marker = "WebApplication.CreateBuilder";'
+
+    assert (
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_controller_allow_anonymous_overrides_method_authorize() -> None:
+    source = """using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+[ApiController, AllowAnonymous, Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost, Authorize]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["auth_required"] is False
+
+
+def test_minimal_api_allow_anonymous_and_response_schema() -> None:
+    source = """using Microsoft.AspNetCore.Builder;
+public record ChatRequest(string Prompt);
+public record ChatResponse(string Answer);
+var app = WebApplication.CreateBuilder(args).Build();
+app.MapPost(
+    "/chat",
+    (ChatRequest request) =>
+        new ChatResponse("ok"))
+    .RequireAuthorization()
+    .AllowAnonymous();
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["auth_required"] is False
+    assert endpoint.metadata["response_body_schema"] == {"Answer": "string"}
+    assert endpoint.metadata["response_text_key"] == "Answer"

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -1,0 +1,482 @@
+"""Tests for C# AI and web framework adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nuguard.sbom.adapters.base import (
+    ComponentDetection,
+)
+from nuguard.sbom.adapters.csharp import (
+    CSharpAspNetCoreAdapter,
+    CSharpLLMClientsAdapter,
+    CSharpMLNetAdapter,
+    CSharpSemanticKernelAdapter,
+)
+from nuguard.sbom.adapters.csharp._source import (
+    find_calls,
+)
+from nuguard.sbom.core.csharp_parser import (
+    parse_csharp,
+)
+from nuguard.sbom.types import ComponentType
+
+
+def _extract(
+    adapter: Any,
+    source: str,
+    path: str = "App.cs",
+) -> list[ComponentDetection]:
+    return adapter.extract(
+        source,
+        path,
+        parse_csharp(source, path),
+    )
+
+
+def _by_type(
+    detections: list[ComponentDetection],
+    component_type: ComponentType,
+) -> list[ComponentDetection]:
+    return [detection for detection in detections if detection.component_type == component_type]
+
+
+def test_call_parser_extracts_generic_and_named_arguments() -> None:
+    source = (
+        "var plugin = "
+        "kernel.Plugins."
+        "AddFromType<WeatherPlugin>("
+        '"Weather", '
+        "serviceProvider: services);\n"
+    )
+
+    call = find_calls(
+        source,
+        {"AddFromType"},
+    )[0]
+
+    assert call.receiver == "kernel.Plugins"
+    assert call.generic_arguments == ("WeatherPlugin",)
+    assert call.positional_arguments == ('"Weather"',)
+    assert call.named_arguments == {"serviceProvider": "services"}
+    assert call.assigned_to == "plugin"
+
+
+def test_call_parser_ignores_comments_and_string_contents() -> None:
+    source = """// kernel.Plugins.AddFromType<FakePlugin>("Fake");
+var text = "client.GetChatClient(\\\"not-a-model\\\")";
+var actual = client.GetChatClient("gpt-4o");
+"""
+
+    calls = find_calls(
+        source,
+        {
+            "AddFromType",
+            "GetChatClient",
+        },
+    )
+
+    assert len(calls) == 1
+    assert calls[0].name == "GetChatClient"
+
+
+def test_llm_clients_detect_azure_and_openai_models() -> None:
+    source = """using Azure.AI.OpenAI;
+using OpenAI.Chat;
+var azure = new AzureOpenAIClient(
+    new Uri(endpoint), credential);
+var azureChat = azure.GetChatClient("gpt-4o");
+var direct = new ChatClient(
+    model: "gpt-4.1-mini",
+    apiKey: key);
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    frameworks = {
+        detection.metadata["provider"]
+        for detection in _by_type(
+            detections,
+            ComponentType.FRAMEWORK,
+        )
+    }
+    models = {
+        detection.display_name: detection
+        for detection in _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+    }
+
+    assert frameworks == {
+        "azure",
+        "openai",
+    }
+    assert {
+        "gpt-4o",
+        "gpt-4.1-mini",
+    } <= set(models)
+    assert models["gpt-4o"].metadata["framework"] == "azure_openai"
+    assert models["gpt-4o"].relationships[0].relationship_type == "USES"
+
+
+def test_llm_clients_detect_anthropic_model_constants() -> None:
+    source = """using Anthropic;
+var client = new AnthropicClient(apiKey);
+var request = new MessageParameters
+{
+    Model = Model.ClaudeSonnet4_20250514,
+};
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+        "Anthropic.cs",
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert len(models) == 1
+    assert models[0].display_name == "Model.ClaudeSonnet4_20250514"
+    assert models[0].metadata["provider"] == "anthropic"
+
+
+def test_generic_chat_client_without_supported_namespace_is_ignored() -> None:
+    source = """using Contoso.Chat;
+var client = new ChatClient("internal-model");
+"""
+
+    assert (
+        _extract(
+            CSharpLLMClientsAdapter(),
+            source,
+        )
+        == []
+    )
+
+
+def test_semantic_kernel_detects_services_plugins_planners_and_prompts() -> None:
+    source = """using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Planning.Handlebars;
+var builder = Kernel.CreateBuilder();
+builder.AddAzureOpenAIChatCompletion(
+    deploymentName: "gpt-4o",
+    endpoint: endpoint,
+    apiKey: key);
+var kernel = builder.Build();
+kernel.Plugins.AddFromType<WeatherPlugin>(
+    "Weather");
+var planner = new HandlebarsPlanner();
+public class WeatherPlugin
+{
+    [KernelFunction]
+    public string GetWeather() => "sunny";
+}
+var systemPrompt = "You are a weather assistant.";
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+        "Kernel.cs",
+    )
+
+    assert _by_type(
+        detections,
+        ComponentType.FRAMEWORK,
+    )
+    assert any(
+        detection.display_name == "gpt-4o"
+        for detection in _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+    )
+    assert {
+        "Weather",
+        "GetWeather",
+    } <= {
+        detection.display_name
+        for detection in _by_type(
+            detections,
+            ComponentType.TOOL,
+        )
+    }
+    assert _by_type(
+        detections,
+        ComponentType.AGENT,
+    )
+    assert _by_type(
+        detections,
+        ComponentType.PROMPT,
+    )
+
+
+def test_semantic_kernel_accepts_kernel_function_attribute_suffix() -> None:
+    source = """using Microsoft.SemanticKernel;
+public class SearchPlugin
+{
+    [KernelFunctionAttribute]
+    public string Search(string query) => query;
+}
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+
+    assert any(
+        detection.display_name == "Search"
+        for detection in _by_type(
+            detections,
+            ComponentType.TOOL,
+        )
+    )
+
+
+def test_semantic_kernel_ignores_unrelated_build_calls() -> None:
+    source = """using Microsoft.SemanticKernel;
+var result = unrelated.Build();
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+    frameworks = _by_type(
+        detections,
+        ComponentType.FRAMEWORK,
+    )
+
+    assert [detection.canonical_name for detection in frameworks] == ["framework:semantic_kernel"]
+
+
+def test_mlnet_detects_context_pipeline_trainer_and_fit() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext(seed: 1);
+var pipeline =
+    ml.Transforms.Conversion.MapValueToKey("Label")
+    .Append(
+        ml.Transforms.Text.FeaturizeText(
+            "Features", "Text"))
+    .Append(
+        ml.MulticlassClassification.Trainers
+        .SdcaMaximumEntropy());
+var model = pipeline.Fit(data);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+        "Train.cs",
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert _by_type(
+        detections,
+        ComponentType.FRAMEWORK,
+    )
+    assert any(detection.metadata.get("trainer") == "SdcaMaximumEntropy" for detection in models)
+    assert any(detection.metadata.get("trained_model") is True for detection in models)
+
+
+def test_mlnet_does_not_treat_unrelated_append_as_pipeline() -> None:
+    source = """using Microsoft.ML;
+items.Append(value);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+
+    assert not any(detection.metadata.get("pipeline") is True for detection in detections)
+
+
+def test_aspnet_controller_emits_ai_endpoint_metadata() -> None:
+    source = """using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenAI.Chat;
+public record ChatRequest(string Message);
+public record ChatResponse(string Answer);
+[ApiController]
+[Route("api/[controller]")]
+public class ChatController : ControllerBase
+{
+    [HttpPost("complete")]
+    [Authorize]
+    public async Task<ActionResult<ChatResponse>> Complete(
+        ChatRequest request)
+    {
+        var answer = await client.CompleteChatAsync(
+            request.Message);
+        return new ChatResponse(answer);
+    }
+}
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+        "ChatController.cs",
+    )
+    endpoints = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert endpoint.metadata["method"] == "POST"
+    assert endpoint.metadata["endpoint"] == "/api/Chat/complete"
+    assert endpoint.metadata["auth_required"] is True
+    assert endpoint.metadata["chat_payload_key"] == "Message"
+    assert endpoint.metadata["response_text_key"] == "Answer"
+
+
+def test_aspnet_controller_expands_action_route_token() -> None:
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/[controller]/[action]")]
+public class ChatController : ControllerBase
+{
+    [HttpPost]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["endpoint"] == "/api/Chat/Complete"
+
+
+def test_aspnet_allow_anonymous_overrides_controller_authorization() -> None:
+    source = """using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Authorize]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost]
+    [AllowAnonymous]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+    )
+    endpoint = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["auth_required"] is False
+
+
+def test_aspnet_minimal_api_emits_route_schema_and_auth() -> None:
+    source = """using Microsoft.AspNetCore.Builder;
+using OpenAI.Chat;
+public record ChatRequest(string Prompt);
+var app = WebApplication.CreateBuilder(args).Build();
+app.MapPost(
+    "/chat",
+    async (
+        ChatRequest request,
+        ChatClient client) =>
+    {
+        return await client.CompleteChatAsync(
+            request.Prompt);
+    }).RequireAuthorization();
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+        "Program.cs",
+    )
+    endpoints = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert endpoint.metadata["endpoint"] == "/chat"
+    assert endpoint.metadata["request_body_schema"] == {"Prompt": "string"}
+    assert endpoint.metadata["chat_payload_key"] == "Prompt"
+    assert endpoint.metadata["auth_required"] is True
+
+
+def test_non_ai_aspnet_route_is_not_emitted() -> None:
+    source = """using Microsoft.AspNetCore.Builder;
+var app = WebApplication.CreateBuilder(args).Build();
+app.MapGet("/health", () => Results.Ok());
+"""
+
+    detections = _extract(
+        CSharpAspNetCoreAdapter(),
+        source,
+        "Program.cs",
+    )
+
+    assert (
+        _by_type(
+            detections,
+            ComponentType.API_ENDPOINT,
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "adapter",
+    [
+        CSharpLLMClientsAdapter(),
+        CSharpSemanticKernelAdapter(),
+        CSharpMLNetAdapter(),
+        CSharpAspNetCoreAdapter(),
+    ],
+)
+def test_adapters_ignore_unrelated_csharp(
+    adapter: Any,
+) -> None:
+    source = """using System;
+public class Greeter
+{
+    public string Hello(string name) =>
+        $"Hello {name}";
+}
+"""
+
+    assert (
+        _extract(
+            adapter,
+            source,
+        )
+        == []
+    )

--- a/nuguard/sbom/tests/test_csharp_parser.py
+++ b/nuguard/sbom/tests/test_csharp_parser.py
@@ -355,3 +355,24 @@ def test_unterminated_strings_are_masked_and_reported() -> None:
         assert expected_error in result.parse_error.lower()
         assert [item.name for item in result.type_declarations] == ["Real"]
         assert [item.name for item in result.method_declarations] == ["Run"]
+
+
+def test_combined_attribute_sections_are_split() -> None:
+    result = parse_csharp(
+        """public class SearchPlugin
+{
+    [KernelFunction, Description("query, text")]
+    public string Search(string query) => query;
+}
+"""
+    )
+
+    assert len(result.method_declarations) == 1
+
+    method = result.method_declarations[0]
+
+    assert method.name == "Search"
+    assert method.attributes == (
+        "KernelFunction",
+        'Description("query, text")',
+    )

--- a/nuguard/sbom/tests/test_csharp_parser.py
+++ b/nuguard/sbom/tests/test_csharp_parser.py
@@ -216,3 +216,142 @@ def test_empty_source_is_false_and_preserves_context() -> None:
     assert not result
     assert result.file_path == "Empty.cs"
     assert result.parse_error is None
+
+
+def test_method_parser_handles_nested_parameters_and_initializer() -> None:
+    result = parse_csharp(
+        """public class Service : BaseService
+{
+    public Service(
+        string name = nameof(DefaultName),
+        Func<(int X, int Y), Task> handler = null)
+        : base(CreateOptions())
+    {
+    }
+
+    public void Run(
+        (int X, int Y) point,
+        Action<Func<int, string>> callback)
+    {
+    }
+}
+"""
+    )
+
+    assert [method.name for method in result.method_declarations] == [
+        "Service",
+        "Run",
+    ]
+
+    constructor, method = result.method_declarations
+
+    assert constructor.is_constructor
+    assert constructor.parameters == (
+        "string name = nameof(DefaultName)",
+        "Func<(int X, int Y), Task> handler = null",
+    )
+    assert ": base(CreateOptions())" in constructor.signature
+
+    assert method.parameters == (
+        "(int X, int Y) point",
+        "Action<Func<int, string>> callback",
+    )
+
+
+def test_method_calls_inside_bodies_are_not_declarations() -> None:
+    result = parse_csharp(
+        """public class PromptBuilder
+{
+    public string Run()
+    {
+        return BuildPrompt();
+    }
+
+    private string BuildPrompt() => "prompt";
+}
+"""
+    )
+
+    assert [method.name for method in result.method_declarations] == [
+        "Run",
+        "BuildPrompt",
+    ]
+
+
+def test_raw_string_uses_matching_quote_delimiter_length() -> None:
+    result = parse_csharp(
+        "public class RawPrompt\n"
+        "{\n"
+        "    public void Run()\n"
+        "    {\n"
+        '        var prompt = """"text with """ inside"""";\n'
+        "    }\n"
+        "}\n"
+    )
+
+    assert result.parse_error is None
+    assert len(result.string_literals) == 1
+
+    literal = result.string_literals[0]
+
+    assert literal.is_raw
+    assert literal.value == 'text with """ inside'
+    assert literal.assigned_to == "prompt"
+    assert literal.enclosing_method == "Run"
+
+
+def test_multiline_string_assignment_preserves_target() -> None:
+    result = parse_csharp(
+        """public class PromptBuilder
+{
+    public string Build()
+    {
+        var prompt =
+            "You are a careful assistant.";
+        return prompt;
+    }
+}
+"""
+    )
+
+    assert len(result.string_literals) == 1
+    assert result.string_literals[0].assigned_to == "prompt"
+
+
+def test_unterminated_strings_are_masked_and_reported() -> None:
+    cases = (
+        (
+            '"',
+            "unterminated regular string",
+        ),
+        (
+            '@"',
+            "unterminated verbatim string",
+        ),
+        (
+            '""""',
+            "unterminated raw string",
+        ),
+    )
+
+    for opener, expected_error in cases:
+        source = (
+            "public class Real\n"
+            "{\n"
+            "    public void Run()\n"
+            "    {\n"
+            f"        var broken = {opener}unterminated\n"
+            "        public class Fake\n"
+            "        {\n"
+            "            public void Bad() {}\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+
+        result = parse_csharp(source)
+
+        assert result.parse_error is not None
+        assert expected_error in result.parse_error.lower()
+        assert [item.name for item in result.type_declarations] == ["Real"]
+        assert [item.name for item in result.method_declarations] == ["Run"]

--- a/nuguard/sbom/tests/test_csharp_parser.py
+++ b/nuguard/sbom/tests/test_csharp_parser.py
@@ -1,0 +1,218 @@
+"""Tests for the lightweight C# structural parser."""
+
+from __future__ import annotations
+
+from nuguard.sbom.core.csharp_parser import parse_csharp
+
+
+def test_using_directives_capture_global_static_and_alias() -> None:
+    result = parse_csharp(
+        """global using Azure.AI.OpenAI;
+using static System.Math;
+using SK = Microsoft.SemanticKernel;
+""",
+        "Imports.cs",
+    )
+
+    assert result.file_path == "Imports.cs"
+
+    assert [item.namespace for item in result.using_directives] == [
+        "Azure.AI.OpenAI",
+        "System.Math",
+        "Microsoft.SemanticKernel",
+    ]
+
+    assert result.using_directives[0].is_global
+    assert result.using_directives[1].is_static
+    assert result.using_directives[2].alias == "SK"
+    assert result.imports == result.using_directives
+
+
+def test_type_declarations_capture_kinds_modifiers_and_bases() -> None:
+    result = parse_csharp(
+        """public sealed class ChatService<T> : IChatService, IDisposable
+    where T : class
+{
+}
+public interface IChatClient {}
+public readonly record struct ChatResult(string Value);
+"""
+    )
+
+    assert [item.name for item in result.type_declarations] == [
+        "ChatService",
+        "IChatClient",
+        "ChatResult",
+    ]
+
+    chat_service = result.type_declarations[0]
+
+    assert chat_service.kind == "class"
+    assert chat_service.modifiers == (
+        "public",
+        "sealed",
+    )
+    assert chat_service.base_types == (
+        "IChatService",
+        "IDisposable",
+    )
+    assert result.type_declarations[2].kind == "record struct"
+    assert result.classes == result.type_declarations
+
+
+def test_methods_and_constructor_capture_signatures() -> None:
+    result = parse_csharp(
+        """public class ChatService
+{
+    public ChatService(string name, int retries = 3) {}
+
+    public async Task<string> CompleteAsync(
+        string input,
+        CancellationToken cancellationToken = default)
+    {
+        return input;
+    }
+}
+"""
+    )
+
+    constructor, method = result.method_declarations
+
+    assert constructor.is_constructor
+    assert constructor.return_type is None
+    assert constructor.containing_type == "ChatService"
+    assert constructor.parameters == (
+        "string name",
+        "int retries = 3",
+    )
+
+    assert method.name == "CompleteAsync"
+    assert method.return_type == "Task<string>"
+    assert method.modifiers == (
+        "public",
+        "async",
+    )
+    assert method.parameters[1] == "CancellationToken cancellationToken = default"
+    assert result.methods == result.method_declarations
+
+
+def test_interface_and_expression_bodied_methods_are_parsed() -> None:
+    result = parse_csharp(
+        """public interface IChatClient
+{
+    Task<string> CompleteAsync(string prompt);
+}
+[ApiController]
+[Route("api/format")]
+public class Formatter
+{
+    [HttpPost("trim")]
+    public string Format(string value) => value.Trim();
+}
+"""
+    )
+
+    assert [
+        (
+            item.name,
+            item.return_type,
+        )
+        for item in result.method_declarations
+    ] == [
+        (
+            "CompleteAsync",
+            "Task<string>",
+        ),
+        (
+            "Format",
+            "string",
+        ),
+    ]
+
+    assert result.type_declarations[1].attributes == (
+        "ApiController",
+        'Route("api/format")',
+    )
+
+    assert result.method_declarations[1].attributes == ('HttpPost("trim")',)
+
+
+def test_strings_capture_forms_assignment_and_method_context() -> None:
+    source = (
+        "public class PromptBuilder\n"
+        "{\n"
+        "    public string Build(string user)\n"
+        "    {\n"
+        '        var regular = "System: be helpful\\nUser:";\n'
+        '        var verbatim = @"C:\\prompts\\system.txt";\n'
+        '        var interpolated = $"Hello {user}";\n'
+        '        var raw = """\n'
+        "You are a careful assistant.\n"
+        '""";\n'
+        '        var rawInterpolated = $$"""Hello {{user}}""";\n'
+        "        return interpolated;\n"
+        "    }\n"
+        "}\n"
+    )
+
+    result = parse_csharp(source)
+
+    literals = {item.assigned_to: item for item in result.string_literals}
+
+    assert literals["regular"].value == "System: be helpful\nUser:"
+    assert literals["regular"].enclosing_method == "Build"
+    assert literals["verbatim"].is_verbatim
+    assert literals["interpolated"].interpolation_expressions == ("user",)
+    assert literals["raw"].is_raw
+    assert literals["raw"].is_potential_prompt
+    assert literals["rawInterpolated"].interpolation_expressions == ("user",)
+
+
+def test_comments_chars_and_string_contents_are_not_declarations() -> None:
+    result = parse_csharp(
+        """// using Fake.Namespace;
+/* public class FakeBlock { void Bad() {} } */
+public class Real
+{
+    private char quote = '\\'';
+    private string sample = "class FakeString { void Nope() {} }";
+    public void Good() {}
+}
+"""
+    )
+
+    assert [item.name for item in result.type_declarations] == ["Real"]
+
+    assert [item.name for item in result.method_declarations] == ["Good"]
+
+    assert result.using_directives == []
+
+
+def test_malformed_source_preserves_partial_results() -> None:
+    result = parse_csharp(
+        """using Azure.AI.OpenAI;
+public class Broken
+{
+    public void Run()
+    {
+        var prompt = "You are still visible";
+"""
+    )
+
+    assert result.parse_error is not None
+    assert "Unmatched opening brace" in result.parse_error
+    assert result.using_directives[0].namespace == "Azure.AI.OpenAI"
+    assert result.type_declarations[0].name == "Broken"
+    assert result.method_declarations[0].name == "Run"
+    assert result.string_literals[0].assigned_to == "prompt"
+
+
+def test_empty_source_is_false_and_preserves_context() -> None:
+    result = parse_csharp(
+        "",
+        "Empty.cs",
+    )
+
+    assert not result
+    assert result.file_path == "Empty.cs"
+    assert result.parse_error is None

--- a/nuguard/sbom/tests/test_deps.py
+++ b/nuguard/sbom/tests/test_deps.py
@@ -467,7 +467,7 @@ class TestEdgeCases:
 class TestGoModScanner:
     """Tests for Go module parsing from go.mod and go.sum files."""
 
-    def test_scan_go_mod_single_and_block_require(self, tmp_path: Path):
+    def test_scan_go_mod_single_and_block_require(self, tmp_path: Path) -> None:
         go_mod_content = """
 module github.com/myorg/myapp
 
@@ -498,7 +498,7 @@ require (
         direct_dep = next(d for d in deps if d.name == "github.com/gin-gonic/gin")
         assert direct_dep.group == "runtime"
 
-    def test_scan_go_sum_pins(self, tmp_path: Path):
+    def test_scan_go_sum_pins(self, tmp_path: Path) -> None:
         go_sum_content = """
 github.com/gin-gonic/gin v1.9.1 h1:4A3XlY04t2a
 github.com/gin-gonic/gin v1.9.1/go.mod h1:A0A3XlY04t2a

--- a/nuguard/sbom/tests/test_deps.py
+++ b/nuguard/sbom/tests/test_deps.py
@@ -463,3 +463,53 @@ class TestEdgeCases:
         assert "openai" in names
         # pywin32 may or may not be included depending on marker stripping,
         # but it should not cause a crash
+
+class TestGoModScanner:
+    """Tests for Go module parsing from go.mod and go.sum files."""
+
+    def test_scan_go_mod_single_and_block_require(self, tmp_path: Path):
+        go_mod_content = """
+module github.com/myorg/myapp
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.1
+
+require (
+    github.com/google/uuid v1.3.0
+    golang.org/x/crypto v0.14.0 // indirect
+)
+"""
+        go_mod_path = tmp_path / "go.mod"
+        go_mod_path.write_text(go_mod_content, encoding="utf-8")
+
+        scanner = DependencyScanner()
+        deps = scanner.scan(tmp_path)
+
+        purls = {d.purl for d in deps}
+        assert "pkg:go/github.com/gin-gonic/gin@v1.9.1" in purls
+        assert "pkg:go/github.com/google/uuid@v1.3.0" in purls
+        assert "pkg:go/golang.org/x/crypto@v0.14.0" in purls
+
+        # Verify group mapping for indirect vs direct dependencies
+        indirect_dep = next(d for d in deps if d.name == "golang.org/x/crypto")
+        assert indirect_dep.group == "optional:indirect"
+
+        direct_dep = next(d for d in deps if d.name == "github.com/gin-gonic/gin")
+        assert direct_dep.group == "runtime"
+
+    def test_scan_go_sum_pins(self, tmp_path: Path):
+        go_sum_content = """
+github.com/gin-gonic/gin v1.9.1 h1:4A3XlY04t2a
+github.com/gin-gonic/gin v1.9.1/go.mod h1:A0A3XlY04t2a
+github.com/google/uuid v1.3.0 h1:t6JiO
+"""
+        go_sum_path = tmp_path / "go.sum"
+        go_sum_path.write_text(go_sum_content, encoding="utf-8")
+
+        scanner = DependencyScanner()
+        deps = scanner.scan(tmp_path)
+
+        purls = {d.purl for d in deps}
+        assert "pkg:go/github.com/gin-gonic/gin@v1.9.1" in purls
+        assert "pkg:go/github.com/google/uuid@v1.3.0" in purls

--- a/nuguard/sbom/tests/test_go_parser.py
+++ b/nuguard/sbom/tests/test_go_parser.py
@@ -1,0 +1,242 @@
+"""Tests for structured Go source parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuguard.sbom.core import go_parser
+from nuguard.sbom.core.go_parser import parse_go
+
+
+def test_tree_sitter_parser_is_available_and_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert go_parser.HAS_TREE_SITTER is True
+    assert go_parser.get_go_parser() is not None
+
+    def fail_if_called(
+        *_args: object,
+        **_kwargs: object,
+    ) -> object:
+        raise AssertionError("regex fallback should not run")
+
+    monkeypatch.setattr(
+        go_parser,
+        "_parse_with_regex",
+        fail_if_called,
+    )
+
+    result = parse_go('package main\nimport "fmt"\n')
+
+    assert result.used_tree_sitter is True
+    assert result.parse_error is None
+    assert [item.path for item in result.imports] == ["fmt"]
+
+
+def test_extracts_single_and_grouped_imports_with_aliases() -> None:
+    result = parse_go(
+        """package main
+
+import "fmt"
+import (
+    openai "github.com/sashabaranov/go-openai"
+    _ "github.com/lib/pq"
+    . "github.com/example/helpers"
+)
+"""
+    )
+
+    imports = {(item.path, item.alias) for item in result.imports}
+
+    assert imports == {
+        ("fmt", None),
+        (
+            "github.com/sashabaranov/go-openai",
+            "openai",
+        ),
+        ("github.com/lib/pq", "_"),
+        ("github.com/example/helpers", "."),
+    }
+
+
+def test_extracts_struct_literal_and_resolves_simple_values() -> None:
+    result = parse_go(
+        """package main
+
+const model = "gpt-4o-mini"
+
+func build() {
+    request := openai.ChatCompletionRequest{
+        Model: model,
+        Temperature: 0.2,
+        Stream: true,
+    }
+    _ = request
+}
+"""
+    )
+
+    request = next(
+        item for item in result.instantiations if item.class_name == "openai.ChatCompletionRequest"
+    )
+
+    assert request.kind == "struct_literal"
+    assert request.assigned_to == "request"
+    assert request.args["Model"] == "gpt-4o-mini"
+    assert request.args["Temperature"] == 0.2
+    assert request.args["Stream"] is True
+
+
+def test_extracts_constructor_and_method_calls() -> None:
+    result = parse_go(
+        """package main
+
+func build(apiKey string, server *Server) {
+    client, err := openai.NewClient(
+        openai.WithAPIKey(apiKey),
+    )
+    server.AddTool(mcp.NewTool("search"))
+    _, _ = client, err
+}
+"""
+    )
+
+    calls = {item.full_name: item for item in result.function_calls}
+
+    constructors = {
+        item.class_name: item for item in result.instantiations if item.kind == "constructor_call"
+    }
+
+    assert calls["openai.NewClient"].assigned_to == "client"
+    assert calls["server.AddTool"].receiver == "server"
+    assert calls["server.AddTool"].function_name == "AddTool"
+
+    assert "openai.NewClient" in constructors
+    assert constructors["openai.NewClient"].assigned_to == "client"
+
+    assert "mcp.NewTool" in constructors
+
+
+def test_extracts_raw_and_interpreted_strings_with_context() -> None:
+    result = parse_go(
+        r"""package main
+
+import "fmt"
+
+const systemPrompt = `You are a careful assistant.`
+
+type Tagged struct {
+    Name string `json:"name"`
+}
+
+func run() {
+    prompt := "hello\nworld"
+    fmt.Println(prompt)
+}
+"""
+    )
+
+    values = {item.value: item for item in result.string_literals}
+
+    assert "fmt" not in values
+    assert 'json:"name"' not in values
+
+    assert values["You are a careful assistant."].is_raw is True
+
+    assert values["You are a careful assistant."].assigned_to == "systemPrompt"
+
+    assert values["hello\nworld"].is_raw is False
+    assert values["hello\nworld"].context == "run"
+    assert values["hello\nworld"].assigned_to == "prompt"
+
+
+def test_malformed_source_returns_partial_result_with_error() -> None:
+    result = parse_go(
+        """package main
+
+import "fmt"
+
+func main( {
+    prompt := "hello"
+"""
+    )
+
+    assert result.used_tree_sitter is True
+    assert result.parse_error is not None
+
+    assert any(item.path == "fmt" for item in result.imports)
+
+
+def test_regex_fallback_extracts_core_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        go_parser,
+        "get_go_parser",
+        lambda: None,
+    )
+
+    result = parse_go(
+        """package main
+
+import (
+    openai "github.com/sashabaranov/go-openai"
+)
+
+const model = "gpt-4o-mini"
+
+func (server *Server) Register() {
+    config := openai.ClientConfig{
+        Model: model,
+        Temperature: 0.2,
+        Debug: true,
+    }
+    client, err := openai.NewClient(config)
+    server.AddTool(mcp.NewTool(`search`))
+    _, _ = client, err
+}
+"""
+    )
+
+    assert result.used_tree_sitter is False
+    assert result.parse_error is None
+
+    assert [(item.path, item.alias) for item in result.imports] == [
+        (
+            "github.com/sashabaranov/go-openai",
+            "openai",
+        )
+    ]
+
+    structs = {item.class_name: item for item in result.instantiations}
+
+    calls = {item.full_name: item for item in result.function_calls}
+
+    assert structs["openai.ClientConfig"].args == {
+        "Model": "gpt-4o-mini",
+        "Temperature": 0.2,
+        "Debug": True,
+    }
+
+    assert structs["openai.ClientConfig"].assigned_to == "config"
+
+    assert structs["openai.NewClient"].assigned_to == "client"
+
+    assert "server.AddTool" in calls
+    assert "mcp.NewTool" in calls
+
+    # A method declaration is not a function call.
+    assert "server.Register" not in calls
+
+    assert any(item.value == "search" and item.is_raw for item in result.string_literals)
+
+
+def test_empty_source_returns_empty_result() -> None:
+    result = parse_go(
+        "",
+        file_path="empty.go",
+    )
+
+    assert result.file_path == "empty.go"
+    assert not result
+    assert result.parse_error is None

--- a/nuguard/sbom/tests/test_go_parser.py
+++ b/nuguard/sbom/tests/test_go_parser.py
@@ -231,6 +231,45 @@ func (server *Server) Register() {
     assert any(item.value == "search" and item.is_raw for item in result.string_literals)
 
 
+def test_regex_fallback_excludes_struct_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        go_parser,
+        "get_go_parser",
+        lambda: None,
+    )
+
+    result = parse_go(
+        r"""package main
+
+type Embedded struct{}
+
+type Tagged struct {
+    Name string `json:"name"`
+    Alias string "xml:\"alias\""
+    Embedded `yaml:",inline"`
+}
+
+func run() {
+    raw := `keep raw`
+    interpreted := "keep interpreted"
+    _, _ = raw, interpreted
+}
+"""
+    )
+
+    assert result.used_tree_sitter is False
+    assert result.parse_error is None
+
+    values = {item.value for item in result.string_literals}
+
+    assert values == {
+        "keep raw",
+        "keep interpreted",
+    }
+
+
 def test_empty_source_returns_empty_result() -> None:
     result = parse_go(
         "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "tree-sitter-typescript>=0.23",
     "python-dotenv>=1.0",
     "pathspec>=0.12",
+    "tree-sitter-go>=0.23",
 ]
 
 [project.optional-dependencies]

--- a/tests/cli/test_output_parent_dir.py
+++ b/tests/cli/test_output_parent_dir.py
@@ -11,7 +11,6 @@ can be supplied on the CLI instead of only via ``nuguard.yaml``.
 
 from __future__ import annotations
 
-import json
 import shutil
 from pathlib import Path
 
@@ -118,7 +117,13 @@ def test_behavior_creates_missing_parent_dir_for_output(fresh_tmp: Path) -> None
 
 
 def test_behavior_accepts_sbom_flag(fresh_tmp: Path) -> None:
-    """``nuguard behavior --sbom <path>`` must load the SBOM from the CLI flag."""
+    """``nuguard behavior --sbom <path>`` must load the SBOM from the CLI flag.
+
+    The proof is the literal "Loaded SBOM:" log line on stdout — not just a
+    successful exit or an output file. The CLI ``--sbom`` flag is the only
+    source for this log line; without it the orchestrator's
+    ``cfg.sbom_path`` is empty and the SBOM-load step is skipped silently.
+    """
     out_path = fresh_tmp / "behavior_sbom_flag.md"
     result = runner.invoke(
         app,
@@ -131,11 +136,30 @@ def test_behavior_accepts_sbom_flag(fresh_tmp: Path) -> None:
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
-    assert "Loaded SBOM:" in result.output or out_path.exists()
+    # Concrete assertion: the CLI flag reached the orchestrator and was used
+    # to load the SBOM. Without the forwarding fix, this log line is absent.
+    # Rich soft-wraps long paths and may insert a space inside the path
+    # (e.g. ``minimal.sbom .json``); we strip inter-word whitespace before
+    # substring matching. The assertion still proves that the literal path
+    # supplied via ``--sbom`` reached the orchestrator — a different (or
+    # missing) path would never produce this string.
+    normalised = result.output.replace(" ", "").replace("\n", "")
+    assert "LoadedSBOM:" in normalised, (
+        f"Expected 'Loaded SBOM:' in output, got:\n{result.output}"
+    )
+    assert str(_FIXTURE_SBOM).replace(" ", "") in normalised, (
+        f"Expected fixture path {str(_FIXTURE_SBOM)!r} in output, got:\n{result.output}"
+    )
 
 
 def test_behavior_sbom_flag_takes_precedence_over_config(tmp_path: Path) -> None:
-    """CLI ``--sbom`` should be used when set, ignoring ``sbom:`` in nuguard.yaml."""
+    """CLI ``--sbom`` should be used when set, ignoring ``sbom:`` in nuguard.yaml.
+
+    The bogus path configured in ``sbom:`` would error loudly if reached
+    ("Could not load SBOM from /nonexistent/path.sbom.json" warning + exit
+    non-zero with --mode static). Since ``--sbom`` is also supplied, the
+    CLI value must win and load the real fixture.
+    """
     config = tmp_path / "nuguard.yaml"
     config.write_text(
         "behavior:\n  target: http://localhost:1\nsbom: /nonexistent/path.sbom.json\n",
@@ -153,6 +177,18 @@ def test_behavior_sbom_flag_takes_precedence_over_config(tmp_path: Path) -> None
         ],
         catch_exceptions=False,
     )
-    # Should succeed using the CLI flag, ignoring the bogus sbom: in config.
     assert result.exit_code == 0, result.output
-    assert out_path.exists()
+    # Concrete assertion: the CLI flag won the precedence race, so the load
+    # log line shows the fixture path, not the bogus config path. Strip
+    # whitespace so Rich's soft-wrap (e.g. inserting a space inside a long
+    # path) does not mask a real "Loaded SBOM: <config path>" leak.
+    normalised = result.output.replace(" ", "").replace("\n", "")
+    assert "LoadedSBOM:" in normalised, (
+        f"Expected 'Loaded SBOM:' in output, got:\n{result.output}"
+    )
+    assert str(_FIXTURE_SBOM).replace(" ", "") in normalised, (
+        f"Expected fixture path {str(_FIXTURE_SBOM)!r} in output, got:\n{result.output}"
+    )
+    assert "/nonexistent/path.sbom.json".replace(" ", "") not in normalised, (
+        "Configured bogus sbom: path should have been overridden by --sbom."
+    )

--- a/tests/cli/test_output_parent_dir.py
+++ b/tests/cli/test_output_parent_dir.py
@@ -1,0 +1,158 @@
+"""CLI tests for output-path parent directory auto-creation.
+
+Issue #233: ``nuguard analyze`` and ``nuguard redteam`` failed when the
+parent directory of ``--output`` did not exist, while ``nuguard behavior``
+silently auto-created it. These tests pin the unified behaviour so the
+three commands stay in sync.
+
+Also covers the ``--sbom`` flag added to ``nuguard behavior`` so the SBOM
+can be supplied on the CLI instead of only via ``nuguard.yaml``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nuguard.cli.main import app
+
+runner = CliRunner()
+
+
+_FIXTURE_SBOM = (
+    Path(__file__).parent.parent.parent
+    / "nuguard"
+    / "analysis"
+    / "tests"
+    / "fixtures"
+    / "minimal.sbom.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# --output parent-dir auto-creation
+# ---------------------------------------------------------------------------
+
+
+def _ensure_missing(path: Path) -> None:
+    if path.exists():
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+@pytest.fixture()
+def fresh_tmp(tmp_path: Path) -> Path:
+    """Return *tmp_path* with the parent of an ``--output`` target removed."""
+    nested = tmp_path / "a" / "b" / "c"
+    _ensure_missing(nested)
+    return tmp_path
+
+
+def test_analyze_creates_missing_parent_dir_for_output(fresh_tmp: Path) -> None:
+    """``nuguard analyze --output <nested>/report.md`` must auto-create parents."""
+    out_path = fresh_tmp / "a" / "b" / "c" / "report.md"
+    assert not out_path.parent.exists()
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "--sbom", str(_FIXTURE_SBOM),
+            "--output", str(out_path),
+            "--format", "markdown",
+            "--no-atlas",
+            "--no-osv",
+            "--no-supply-chain",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out_path.exists(), "Expected the report to be written under the missing parent dir"
+
+
+def test_analyze_creates_missing_parent_dir_for_sarif(fresh_tmp: Path) -> None:
+    out_path = fresh_tmp / "a" / "b" / "c" / "report.sarif"
+    assert not out_path.parent.exists()
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "--sbom", str(_FIXTURE_SBOM),
+            "--output", str(out_path),
+            "--format", "sarif",
+            "--no-atlas",
+            "--no-osv",
+            "--no-supply-chain",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out_path.exists()
+
+
+def test_behavior_creates_missing_parent_dir_for_output(fresh_tmp: Path) -> None:
+    """Behaviour already auto-creates parents — keep that contract under test."""
+    out_path = fresh_tmp / "a" / "b" / "c" / "behavior.md"
+    result = runner.invoke(
+        app,
+        [
+            "behavior",
+            "--sbom", str(_FIXTURE_SBOM),
+            "--output", str(out_path),
+            "--mode", "static",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# --sbom flag on nuguard behavior
+# ---------------------------------------------------------------------------
+
+
+def test_behavior_accepts_sbom_flag(fresh_tmp: Path) -> None:
+    """``nuguard behavior --sbom <path>`` must load the SBOM from the CLI flag."""
+    out_path = fresh_tmp / "behavior_sbom_flag.md"
+    result = runner.invoke(
+        app,
+        [
+            "behavior",
+            "--sbom", str(_FIXTURE_SBOM),
+            "--output", str(out_path),
+            "--mode", "static",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Loaded SBOM:" in result.output or out_path.exists()
+
+
+def test_behavior_sbom_flag_takes_precedence_over_config(tmp_path: Path) -> None:
+    """CLI ``--sbom`` should be used when set, ignoring ``sbom:`` in nuguard.yaml."""
+    config = tmp_path / "nuguard.yaml"
+    config.write_text(
+        "behavior:\n  target: http://localhost:1\nsbom: /nonexistent/path.sbom.json\n",
+        encoding="utf-8",
+    )
+    out_path = tmp_path / "behavior_out.md"
+    result = runner.invoke(
+        app,
+        [
+            "behavior",
+            "--config", str(config),
+            "--sbom", str(_FIXTURE_SBOM),
+            "--output", str(out_path),
+            "--mode", "static",
+        ],
+        catch_exceptions=False,
+    )
+    # Should succeed using the CLI flag, ignoring the bogus sbom: in config.
+    assert result.exit_code == 0, result.output
+    assert out_path.exists()

--- a/tests/cli/test_output_parent_dir.py
+++ b/tests/cli/test_output_parent_dir.py
@@ -192,3 +192,70 @@ def test_behavior_sbom_flag_takes_precedence_over_config(tmp_path: Path) -> None
     assert "/nonexistent/path.sbom.json".replace(" ", "") not in normalised, (
         "Configured bogus sbom: path should have been overridden by --sbom."
     )
+
+
+# ---------------------------------------------------------------------------
+# redteam parent-dir auto-creation (issue #233 parity with analyze/behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_redteam_creates_missing_parent_dir_for_output(fresh_tmp: Path) -> None:
+    """``nuguard redteam --output <nested>/report.<fmt>`` must auto-create parents.
+
+    Issues #233 aligns CLI behaviour across analyze / redteam / behavior so
+    the three commands all auto-create the parent directory of ``--output``.
+    analyze and behavior are covered above; this test pins the redteam
+    path. The redteam orchestrator is mocked to return a no-findings
+    13-tuple so the test does not depend on a live target or the LLM.
+    """
+    import json as _json
+    from unittest.mock import patch as _patch
+
+    from nuguard.models.token_usage import TokenUsage as _TokenUsage
+
+    out_path = fresh_tmp / "a" / "b" / "c" / "redteam.json"
+    assert not out_path.parent.exists()
+
+    async def _fake_run_redteam(*_args, **_kwargs):
+        # Empty findings — the test only cares about the parent-dir mkdir,
+        # not the redteam content itself.
+        return (
+            [],     # findings
+            [],     # scenario_records
+            "no_findings",  # scan_outcome
+            [],     # config_notes
+            None,   # catalog_coverage
+            0,      # input_tokens_used
+            0,      # output_tokens_used
+            None,   # coverage_tracker
+            _TokenUsage(),  # token_usage
+            "/chat",  # resolved_chat_path
+            "default",  # resolved_chat_path_source
+            [],     # remediation_plan
+        )
+
+    with _patch("nuguard.cli.commands.redteam._run_redteam", new=_fake_run_redteam):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(_FIXTURE_SBOM),
+                "--target", "http://localhost:9999",
+                "--output", str(out_path),
+                "--format", "json",
+            ],
+        )
+
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by any finding)
+    # are both acceptable — the contract is that the parent dir is created
+    # and the file is written before the threshold check runs.
+    assert result.exit_code in (0, 2), result.output
+    assert out_path.parent.exists(), (
+        f"Expected parent dir {out_path.parent} to be created; stdout:\n{result.output}"
+    )
+    assert out_path.exists(), (
+        f"Expected redteam report at {out_path}; stdout:\n{result.output}"
+    )
+    # The output file must be valid JSON — proves the dispatch loop ran
+    # through the JSON-format branch, not the text-format branch.
+    _json.loads(out_path.read_text(encoding="utf-8"))

--- a/tests/cli/test_redteam_format_output.py
+++ b/tests/cli/test_redteam_format_output.py
@@ -1,0 +1,275 @@
+"""Regression tests for the redteam --output / --format dispatch.
+
+Background
+----------
+``nuguard redteam --output foo.txt`` historically wrote JSON content into
+``foo.txt`` regardless of the requested format. The ``--output`` branch in
+``nuguard/cli/commands/redteam.py`` only had explicit handling for
+``markdown`` and ``sarif``; ``text`` (the default format) and ``json`` both
+fell into the same ``else`` block that JSON-serialised the findings. The
+``text`` default therefore produced a JSON file with a ``.txt`` extension
+when ``--output`` was used, which is incorrect — the file should match
+the stdout text format (minus ANSI escapes).
+
+These tests pin the contract:
+
+* ``_render_findings_text(findings, meta, scan_outcome, colour=False)``
+  returns plain text (no JSON, no ANSI escapes).
+* ``_render_findings_text(..., colour=True)`` is the stdout form and
+  contains ANSI escapes for severity labels.
+* When the dispatch loop encounters ``fmt == "text"``, the written file is
+  the plain-text report — not a JSON document.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from nuguard.cli.commands.redteam import _render_findings_text
+from nuguard.cli.main import app
+from nuguard.cli.report_meta import ReportMeta
+from nuguard.models.finding import Finding, Severity
+from nuguard.models.token_usage import TokenUsage
+
+
+def _make_findings() -> list[Finding]:
+    return [
+        Finding(
+            finding_id="redteam-test-001",
+            title="Prompt injection via tool description",
+            severity=Severity.HIGH,
+            description=(
+                "An attacker-controlled page injected a tool description that "
+                "exfiltrated adjacent user data through tool-call arguments."
+            ),
+            remediation="Strip tool descriptions from untrusted sources.",
+            owasp_asi_ref="ASI-01",
+        ),
+        Finding(
+            finding_id="redteam-test-002",
+            title="Data exfiltration via canary value",
+            severity=Severity.CRITICAL,
+            description=(
+                "The agent echoed the canary tenant record into a public "
+                "response, confirming cross-tenant data leakage."
+            ),
+            remediation="Enforce per-tenant tool scoping.",
+            owasp_asi_ref="ASI-02",
+        ),
+    ]
+
+
+def _make_minimal_sbom(tmp_path: Path) -> Path:
+    """Write a minimal valid AI-SBOM JSON file the redteam CLI will accept."""
+    sbom_path = tmp_path / "minimal.sbom.json"
+    sbom_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.5.0",
+                "generator": "nuguard",
+                "target": "https://github.com/test/test",
+                "nodes": [],
+                "edges": [],
+                "deps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return sbom_path
+
+
+def _mock_run_redteam_outcome():
+    """Return a coroutine that yields the 13-tuple ``_run_redteam`` produces."""
+    async def _coro(*_args, **_kwargs):
+        return (
+            _make_findings(),  # findings
+            [],                 # scenario_records
+            "no_findings",      # scan_outcome
+            [],                 # config_notes
+            None,               # catalog_coverage
+            0,                  # input_tokens_used
+            0,                  # output_tokens_used
+            None,               # coverage_tracker
+            TokenUsage(),       # token_usage
+            "/chat",            # resolved_chat_path
+            "default",          # resolved_chat_path_source
+            [],                 # remediation_plan
+        )
+    return _coro
+
+
+# ---------------------------------------------------------------------------
+# _render_findings_text helper
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_plain_is_not_json() -> None:
+    """Plain text must not be JSON-serialised and must have no ANSI escapes."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    assert not txt.lstrip().startswith("{"), (
+        "Plain text output must not start with '{' (would indicate JSON)."
+    )
+    assert "\x1b[" not in txt, "Plain text output must not contain ANSI escapes."
+
+
+def test_render_text_plain_contains_expected_sections() -> None:
+    """Plain text should contain the report header, finding count, and outcome."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    assert "NuGuard Red-Team" in txt
+    assert "2 finding(s)" in txt
+    assert "Outcome: no_findings" in txt
+
+
+def test_render_text_plain_severity_ordering() -> None:
+    """Findings must be sorted by descending severity (CRITICAL before HIGH)."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    crit_pos = txt.index("CRITICAL")
+    high_pos = txt.index("HIGH")
+    assert crit_pos < high_pos, (
+        "CRITICAL findings must appear before HIGH findings in the text report."
+    )
+
+
+def test_render_text_plain_no_ansi_even_with_findings() -> None:
+    """Severity labels must not be wrapped in colour escapes for plain output."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=False)
+
+    # No escape introducer anywhere in the document.
+    assert "\x1b" not in txt
+
+
+def test_render_text_colour_contains_ansi_escapes() -> None:
+    """Colour=True must inject ANSI escapes (for stdout on a TTY)."""
+    findings = _make_findings()
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text(findings, meta, "no_findings", colour=True)
+
+    assert "\x1b[" in txt, "Colour output should contain ANSI escape sequences."
+
+
+def test_render_text_empty_findings_has_no_table_block() -> None:
+    """An empty findings list produces the short 'No findings' message, not the
+    full table block (which would be misleading)."""
+    meta = ReportMeta(verbose=False)
+
+    txt = _render_findings_text([], meta, "no_findings", colour=False)
+
+    assert "No findings — scan complete" in txt
+    assert "NuGuard Red-Team — 0 finding(s)" not in txt
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: when --output is used and the format is "text", the file must be
+# plain text, not JSON. This is the regression test for the original bug.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_text_format_writes_plain_text_file(tmp_path: Path) -> None:
+    """End-to-end: ``nuguard redteam --output foo.txt --format text`` writes
+    the plain-text report, not JSON.
+
+    Regression for #254 — the pre-fix dispatch fell through to the JSON
+    ``else`` branch when ``fmt='text'`` was requested, producing a JSON file
+    with a ``.txt`` extension. This test exercises the real CLI through
+    ``CliRunner`` so it will fail the moment the production dispatch loop
+    stops routing ``text`` to :func:`_render_findings_text`.
+    """
+    sbom_path = _make_minimal_sbom(tmp_path)
+    output = tmp_path / "redteam.txt"
+
+    runner = CliRunner()
+    with patch(
+        "nuguard.cli.commands.redteam._run_redteam",
+        new=_mock_run_redteam_outcome(),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(sbom_path),
+                "--target", "http://localhost:9999",
+                "--output", str(output),
+                "--format", "text",
+            ],
+        )
+
+    assert output.exists(), (
+        f"Output file was not written to {output}.\nstdout:\n{result.stdout}"
+    )
+
+    content = output.read_text(encoding="utf-8")
+    assert not content.lstrip().startswith("{"), (
+        "--format text --output must write plain text, not JSON (regression for #254)."
+    )
+    assert "\x1b[" not in content, "File output must not contain ANSI escapes."
+    assert "NuGuard Red-Team" in content
+    assert "2 finding(s)" in content
+
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by CRITICAL/HIGH
+    # findings) are both acceptable — the dispatch contract is that the file
+    # is written before the threshold check runs.
+    assert result.exit_code in (0, 2), (
+        f"Unexpected exit code {result.exit_code}; stdout:\n{result.stdout}"
+    )
+
+
+def test_dispatch_json_format_still_writes_json_file(tmp_path: Path) -> None:
+    """Sanity check: ``--format json --output foo.json`` still writes valid JSON.
+
+    The fix must not regress the JSON output path. Same end-to-end shape as
+    the text-format test above — exercises the real CLI dispatcher.
+    """
+    sbom_path = _make_minimal_sbom(tmp_path)
+    output = tmp_path / "redteam.json"
+
+    runner = CliRunner()
+    with patch(
+        "nuguard.cli.commands.redteam._run_redteam",
+        new=_mock_run_redteam_outcome(),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "redteam",
+                "--sbom", str(sbom_path),
+                "--target", "http://localhost:9999",
+                "--output", str(output),
+                "--format", "json",
+            ],
+        )
+
+    assert output.exists(), (
+        f"Output file was not written to {output}.\nstdout:\n{result.stdout}"
+    )
+
+    content = output.read_text(encoding="utf-8")
+    parsed = json.loads(content)
+    assert "_meta" in parsed
+    assert len(parsed["findings"]) == 2
+
+    # exit_code 0 (clean) or 2 (fail-on threshold tripped by CRITICAL/HIGH
+    # findings) are both acceptable — the dispatch contract is that the file
+    # is written before the threshold check runs.
+    assert result.exit_code in (0, 2), (
+        f"Unexpected exit code {result.exit_code}; stdout:\n{result.stdout}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1491,6 +1491,7 @@ dependencies = [
     { name = "rich" },
     { name = "structlog" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-go" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-typescript" },
     { name = "typer" },
@@ -1556,6 +1557,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'mcp'", specifier = ">=1.3.1" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tree-sitter", specifier = ">=0.23" },
+    { name = "tree-sitter-go", specifier = ">=0.23" },
     { name = "tree-sitter-javascript", specifier = ">=0.23" },
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
     { name = "typer", specifier = ">=0.12" },
@@ -2668,6 +2670,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/727308adbbc79bcb1c92fc0ea10556a735f9d0f0a5435a18f59d40f7fd77/tree_sitter_go-0.25.0.tar.gz", hash = "sha256:a7466e9b8d94dda94cae8d91629f26edb2d26166fd454d4831c3bf6dfa2e8d68", size = 93890, upload-time = "2025-08-29T06:20:25.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/aa/0984707acc2b9bb461fe4a41e7e0fc5b2b1e245c32820f0c83b3c602957c/tree_sitter_go-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b852993063a3429a443e7bd0aa376dd7dd329d595819fabf56ac4cf9d7257b54", size = 47117, upload-time = "2025-08-29T06:20:14.286Z" },
+    { url = "https://files.pythonhosted.org/packages/32/16/dd4cb124b35e99239ab3624225da07d4cb8da4d8564ed81d03fcb3a6ba9f/tree_sitter_go-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:503b81a2b4c31e302869a1de3a352ad0912ccab3df9ac9950197b0a9ceeabd8f", size = 48674, upload-time = "2025-08-29T06:20:17.557Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fb/b30d63a08044115d8b8bd196c6c2ab4325fb8db5757249a4ef0563966e2e/tree_sitter_go-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04b3b3cb4aff18e74e28d49b716c6f24cb71ddfdd66768987e26e4d0fa812f74", size = 66418, upload-time = "2025-08-29T06:20:18.345Z" },
+    { url = "https://files.pythonhosted.org/packages/26/21/d3d88a30ad007419b2c97b3baeeef7431407faf9f686195b6f1cad0aedf9/tree_sitter_go-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:148255aca2f54b90d48c48a9dbb4c7faad6cad310a980b2c5a5a9822057ed145", size = 72006, upload-time = "2025-08-29T06:20:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/0dd6442353ced8a88bbda9e546f4ea29e381b59b5a40b122e5abb586bb6c/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4d338116cdf8a6c6ff990d2441929b41323ef17c710407abe0993c13417d6aad", size = 70603, upload-time = "2025-08-29T06:20:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves the last remaining conflict blocking #271 (main -> develop).

After #274 landed on develop, the conflict in `nuguard/cli/commands/redteam.py`
shrank to a single line: develop's `--output` dispatch loop calls
`out_path.parent.mkdir(parents=True, exist_ok=True)` before writing (matching
`analyze.py`/`behavior.py`), but main never had that line. This adds it to
main so the file matches develop and the merge conflict goes away.

## Test plan
- [x] `python3 -m pytest tests/cli -q` — 86 passed
- [x] `mypy nuguard/cli/commands/redteam.py` — clean
- [x] `ruff check nuguard/cli/commands/redteam.py` — clean
- [x] Resolved file confirmed byte-identical to develop's current version

🤖 Generated with [Claude Code](https://claude.com/claude-code)