### PR TITLE
fix(cli): resolve remaining PR #271 conflict (mkdir before redteam output write)

### DIFF
--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -426,6 +426,7 @@ def redteam(
                 all_formats=effective_formats,
                 extension_map=extension_map,
             )
+            out_path.parent.mkdir(parents=True, exist_ok=True)
             if fmt == "text":
                 # Plain-text report — no ANSI escapes in a file. Identical
                 # content to what ``nuguard redteam`` emits to stdout.


### PR DESCRIPTION
Resolves the last remaining conflict blocking #271 (main -> develop).

After #274 landed on develop, the conflict in `nuguard/cli/commands/redteam.py`
shrank to a single line: develop's `--output` dispatch loop calls
`out_path.parent.mkdir(parents=True, exist_ok=True)` before writing (matching
`analyze.py`/`behavior.py`), but main never had that line. This adds it to
main so the file matches develop and the merge conflict goes away.

Scoped to just this one line — verified `git diff origin/main --stat` shows
only `nuguard/cli/commands/redteam.py | 1 +`.

## Test plan
- [x] `python3 -m pytest tests/cli -q` — 80 passed
- [x] `mypy nuguard/cli/commands/redteam.py` — clean
- [x] `ruff check nuguard/cli/commands/redteam.py` — clean
- [x] Simulated `git merge origin/develop` on top of this branch — 0 conflicts (aborted after verifying, not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)