### PR TITLE
fix(ci): repair broken YAML in cherry-pick-to-develop.yml

### DIFF
--- a/.github/workflows/cherry-pick-to-develop.yml
+++ b/.github/workflows/cherry-pick-to-develop.yml
@@ -124,9 +124,7 @@ jobs:
             --base develop \
             --head "${{ steps.cherry.outputs.branch }}" \
             --title "Cherry-pick #${PR_NUMBER} into develop" \
-            --body "Automated cherry-pick of #${PR_NUMBER} (merged into \`main\`) onto \`develop\`. Auto-merges once required checks pass.
-
-Closes #${PR_NUMBER}." \
+            --body "Automated cherry-pick of #${PR_NUMBER} (merged into \`main\`) onto \`develop\`. Auto-merges once required checks pass. Closes #${PR_NUMBER}." \
             --label "cherry-pick")
           echo "url=$url" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Closes #285

## What

#286's fix for the require-linked-issue check broke the workflow file
entirely: the multi-line PR body it added had a continuation line at
column 0, dedenting past the enclosing `run: |` block scalar's required
indentation. YAML then tried to read that line as a new mapping key,
found no `:`, and the whole file became unparseable.

Confirmed via the run that fired on push after #286 merged
(31773772752): zero jobs were created at all — GitHub couldn't even
schedule `find-pr`, let alone `cherry-pick`. So the bot went from
"runs but fails the linked-issue check" to "doesn't run at all."

## Fix

Collapses the PR body to a single line, avoiding the block-scalar
indentation hazard. Validated with `python3 -c "import yaml; yaml.safe_load(...)"`
before pushing this time.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly
- [ ] Next cherry-pick bot run will be the live test

🤖 Generated with [Claude Code](https://claude.com/claude-code)