### PR TITLE
feat(sbom): harden C# framework adapter edge cases

### DIFF
--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -86,7 +86,8 @@ def find_calls(
 ) -> list[CSharpCall]:
     """Return call expressions whose simple name is in *names*, if supplied."""
     masked = mask_non_code(source)
-    calls: list[CSharpCall] = []
+    all_calls: list[CSharpCall] = []
+    selected_calls: list[CSharpCall] = []
 
     for match in _CALL_RE.finditer(masked):
         callee = re.sub(
@@ -105,9 +106,6 @@ def find_calls(
         if name in _CONTROL_NAMES:
             continue
 
-        if names is not None and name not in names:
-            continue
-
         open_paren = match.end() - 1
         close_paren = _matching(
             masked,
@@ -122,37 +120,79 @@ def find_calls(
         args_text = source[open_paren + 1 : close_paren]
         named, positional = parse_arguments(args_text)
         receiver = ".".join(simple_parts[:-1]) or None
+        chain_parent = _chained_parent(
+            all_calls,
+            masked,
+            match.start(),
+        )
+        snippet_start = match.start()
+
+        if chain_parent is not None:
+            parent_expression = re.sub(
+                r"\s*(\?\.|\.)\s*",
+                r"\1",
+                " ".join(source[chain_parent.start : chain_parent.end].strip().split()),
+            )
+            receiver = f"{parent_expression}.{receiver}" if receiver else parent_expression
+            snippet_start = chain_parent.start
+
         prefix = masked[max(0, match.start() - 12) : match.start()]
         is_constructor = bool(re.search(r"\bnew\s*$", prefix))
         assigned_to = _assignment_target(
             masked,
             match.start(),
         )
+
+        if assigned_to is None and chain_parent is not None:
+            assigned_to = chain_parent.assigned_to
+
         end = close_paren + 1
-        snippet = " ".join(source[match.start() : end].strip().split())[:240]
-
-        calls.append(
-            CSharpCall(
-                callee=callee,
-                name=name,
-                receiver=receiver,
-                generic_arguments=generic_arguments,
-                arguments_text=args_text,
-                named_arguments=named,
-                positional_arguments=tuple(positional),
-                assigned_to=assigned_to,
-                is_constructor=is_constructor,
-                line=line_number(
-                    source,
-                    match.start(),
-                ),
-                start=match.start(),
-                end=end,
-                snippet=snippet,
-            )
+        snippet = " ".join(source[snippet_start:end].strip().split())[:240]
+        call = CSharpCall(
+            callee=callee,
+            name=name,
+            receiver=receiver,
+            generic_arguments=generic_arguments,
+            arguments_text=args_text,
+            named_arguments=named,
+            positional_arguments=tuple(positional),
+            assigned_to=assigned_to,
+            is_constructor=is_constructor,
+            line=line_number(
+                source,
+                match.start(),
+            ),
+            start=snippet_start,
+            end=end,
+            snippet=snippet,
         )
+        all_calls.append(call)
 
-    return calls
+        if names is None or name in names:
+            selected_calls.append(call)
+
+    return selected_calls
+
+
+def _chained_parent(
+    calls: list[CSharpCall],
+    masked: str,
+    position: int,
+) -> CSharpCall | None:
+    """Return the immediately preceding call in a fluent chain."""
+    for call in reversed(calls):
+        if call.end > position:
+            continue
+
+        separator = masked[call.end : position]
+
+        if re.fullmatch(
+            r"\s*(?:\?\.|\.)\s*",
+            separator,
+        ):
+            return call
+
+    return None
 
 
 def parse_arguments(

--- a/nuguard/sbom/adapters/csharp/aspnet_core.py
+++ b/nuguard/sbom/adapters/csharp/aspnet_core.py
@@ -262,6 +262,13 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 continue
 
             http_method, action_route = http_attribute
+
+            if not action_route:
+                action_route = _route_attribute(
+                    method_attributes,
+                    constants,
+                )
+
             base_route = _route_attribute(
                 controller_attributes,
                 constants,
@@ -314,10 +321,11 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 request_type,
                 request_name,
             ) = _request_parameter(params)
-            request_schema = _schema_for_type(
+            request_schema = _request_schema(
                 content,
                 result,
                 request_type,
+                request_name,
             )
             chat_key = _chat_key(
                 request_schema,
@@ -398,10 +406,11 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 request_type,
                 request_name,
             ) = _request_parameter(params)
-            request_schema = _schema_for_type(
+            request_schema = _request_schema(
                 content,
                 result,
                 request_type,
+                request_name,
             )
             chat_key = _chat_key(
                 request_schema,
@@ -480,7 +489,12 @@ def _endpoint_node(
 
     if chat_key:
         metadata["chat_payload_key"] = chat_key
-        metadata["chat_payload_list"] = False
+        metadata["chat_payload_list"] = _is_collection_type(
+            request_schema.get(
+                chat_key,
+                "",
+            )
+        )
 
     if response_key:
         metadata["response_text_key"] = response_key
@@ -664,7 +678,14 @@ def _combine_routes(
     action_name: str,
 ) -> str:
     controller = controller_name.removesuffix("Controller")
-    combined = "/".join(part.strip("/") for part in (base, action) if part.strip("/"))
+    action_template = action.strip()
+
+    if action_template.startswith("~/"):
+        combined = action_template[1:]
+    elif action_template.startswith("/"):
+        combined = action_template
+    else:
+        combined = "/".join(part.strip("/") for part in (base, action_template) if part.strip("/"))
     combined = re.sub(
         r"\[controller\]",
         controller,
@@ -826,18 +847,80 @@ def _request_parameter(
         key=lambda item: not item[2],
     )
 
-    for type_name, name, _ in ordered:
+    for type_name, name, from_body in ordered:
         base = _base_type(type_name)
 
-        if base in _PRIMITIVE_TYPES or base in _INFRASTRUCTURE_TYPES:
+        if base in _INFRASTRUCTURE_TYPES:
             continue
 
-        if base.startswith("I") and len(base) > 1 and base[1].isupper():
+        if base in _PRIMITIVE_TYPES:
+            if from_body or name.casefold() in _PROMPT_FIELDS:
+                return type_name, name
+
             continue
 
-        return base, name
+        if (
+            base.startswith("I")
+            and len(base) > 1
+            and base[1].isupper()
+            and not _is_collection_type(type_name)
+        ):
+            continue
+
+        return type_name, name
 
     return "", None
+
+
+def _request_schema(
+    content: str,
+    result: Any,
+    type_name: str,
+    parameter_name: str | None,
+) -> dict[str, str]:
+    schema = _schema_for_type(
+        content,
+        result,
+        type_name,
+    )
+
+    if schema or not parameter_name:
+        return schema
+
+    base = _base_type(type_name)
+
+    if base in _PRIMITIVE_TYPES or _is_collection_type(type_name):
+        return {parameter_name: type_name}
+
+    return {}
+
+
+def _is_collection_type(
+    type_name: str,
+) -> bool:
+    clean = re.sub(
+        r"\s+",
+        "",
+        type_name,
+    ).rstrip("?")
+
+    if clean.endswith("[]"):
+        return True
+
+    root = clean.split("<", 1)[0].split(".")[-1]
+
+    return root in {
+        "Collection",
+        "HashSet",
+        "IAsyncEnumerable",
+        "ICollection",
+        "IEnumerable",
+        "IList",
+        "IReadOnlyCollection",
+        "IReadOnlyList",
+        "ImmutableArray",
+        "List",
+    }
 
 
 def _schema_for_type(

--- a/nuguard/sbom/adapters/csharp/llm_clients.py
+++ b/nuguard/sbom/adapters/csharp/llm_clients.py
@@ -300,7 +300,9 @@ def _provider_for_call(
 ) -> str | None:
     receiver_text = receiver or ""
 
-    if name == "OpenAIClient" and (imported == {"azure"} or "Azure.AI.OpenAI" in receiver_text):
+    if name == "OpenAIClient" and (
+        "Azure.AI.OpenAI" in receiver_text or ("azure" in imported and "openai" not in imported)
+    ):
         return "azure"
 
     if name in _CLIENT_CLASSES:

--- a/nuguard/sbom/adapters/csharp/mlnet.py
+++ b/nuguard/sbom/adapters/csharp/mlnet.py
@@ -126,7 +126,7 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 )
                 continue
 
-            if ".Trainers" in receiver:
+            if call.name != "Fit" and ".Trainers" in receiver:
                 if call.assigned_to:
                     estimator_variables.add(call.assigned_to)
 
@@ -165,7 +165,7 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 )
                 continue
 
-            if ".Transforms" in receiver:
+            if call.name != "Fit" and ".Transforms" in receiver:
                 pipeline_id = call.assigned_to or f"line:{call.line}"
 
                 if call.assigned_to:

--- a/nuguard/sbom/adapters/csharp/semantic_kernel.py
+++ b/nuguard/sbom/adapters/csharp/semantic_kernel.py
@@ -33,6 +33,15 @@ _PLUGIN_CALLS = {
     "ImportPluginFromPromptDirectory",
     "CreateFromType",
 }
+_PLUGIN_NAME_POSITIONS: dict[str, tuple[int, ...]] = {
+    "AddFromType": (0, 1),
+    "ImportPluginFromType": (0, 1),
+    "CreateFromType": (0, 1),
+    "AddFromObject": (1, 2),
+    "ImportPluginFromObject": (1, 2),
+    "AddFromPromptDirectory": (1, 2),
+    "ImportPluginFromPromptDirectory": (1, 2),
+}
 _PLANNER_CLASSES = {
     "ActionPlanner",
     "FunctionCallingStepwisePlanner",
@@ -129,7 +138,13 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
                 is_kernel_builder = (
                     (call.name == "CreateBuilder" and receiver.split(".")[-1] == "Kernel")
                     or (call.name == "KernelBuilder" and call.is_constructor)
-                    or (call.name == "Build" and receiver.split(".")[0] in builder_variables)
+                    or (
+                        call.name == "Build"
+                        and (
+                            receiver.split(".")[0] in builder_variables
+                            or call.assigned_to in builder_variables
+                        )
+                    )
                 )
 
                 if not is_kernel_builder:
@@ -193,7 +208,7 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
                 )
 
                 if not model_name:
-                    model_name = call.name.removeprefix("Add").removesuffix("ChatCompletion")
+                    continue
 
                 canonical = canonicalize_text(model_name.lower())
                 details = get_model_details(
@@ -235,14 +250,9 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
 
             if call.name in _PLUGIN_CALLS:
                 plugin_type = call.generic_arguments[0] if call.generic_arguments else ""
-                plugin_name = first_argument(
+                plugin_name = _plugin_name(
                     call,
-                    (
-                        "pluginName",
-                        "name",
-                    ),
                     constants,
-                    0,
                 )
                 display = plugin_name or plugin_type or call.assigned_to or f"plugin_{call.line}"
                 canonical = canonicalize_text(f"semantic_kernel:plugin:{display}")
@@ -410,6 +420,41 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
             )
 
         return _dedupe(detections)
+
+
+def _plugin_name(
+    call: Any,
+    constants: dict[str, str],
+) -> str:
+    """Resolve a plugin name according to the matched overload."""
+    named = first_argument(
+        call,
+        (
+            "pluginName",
+            "name",
+        ),
+        constants,
+        None,
+    )
+
+    if named:
+        return named
+
+    for position in _PLUGIN_NAME_POSITIONS.get(
+        call.name,
+        (),
+    ):
+        positional = first_argument(
+            call,
+            (),
+            constants,
+            position,
+        )
+
+        if positional:
+            return positional
+
+    return ""
 
 
 def _dedupe(

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -680,3 +680,237 @@ app.MapPost(
     assert endpoint.metadata["auth_required"] is False
     assert endpoint.metadata["response_body_schema"] == {"Answer": "string"}
     assert endpoint.metadata["response_text_key"] == "Answer"
+
+
+@pytest.mark.parametrize(
+    (
+        "source",
+        "name",
+        "expected_receiver",
+        "expected_assignment",
+    ),
+    [
+        (
+            "var model = ml.BinaryClassification.Trainers.Sdca().Fit(data);",
+            "Fit",
+            ("ml.BinaryClassification.Trainers.Sdca()"),
+            "model",
+        ),
+        (
+            "var kernel = Kernel.CreateBuilder().Services.AddLogging().Build();",
+            "Build",
+            ("Kernel.CreateBuilder().Services.AddLogging()"),
+            "kernel",
+        ),
+    ],
+)
+def test_call_parser_preserves_chained_receiver(
+    source: str,
+    name: str,
+    expected_receiver: str,
+    expected_assignment: str,
+) -> None:
+    call = find_calls(
+        source,
+        {name},
+    )[0]
+
+    assert call.receiver == expected_receiver
+    assert call.assigned_to == expected_assignment
+
+
+def test_mlnet_detects_fit_on_inline_trainer_chain() -> None:
+    source = """using Microsoft.ML;
+var ml = new MLContext();
+var model = ml.BinaryClassification.Trainers
+    .SdcaLogisticRegression()
+    .Fit(data);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+
+    assert any(
+        detection.metadata.get("trained_model") is True and detection.display_name == "model"
+        for detection in detections
+    )
+
+
+def test_aspnet_uses_separate_method_route_attribute() -> None:
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [Route("complete")]
+    [HttpPost]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}
+public record ChatRequest(string Message);
+"""
+
+    endpoint = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+        ),
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["endpoint"] == "/api/chat/complete"
+
+
+@pytest.mark.parametrize(
+    "action_route",
+    [
+        "/chat",
+        "~/chat",
+    ],
+)
+def test_aspnet_absolute_action_route_overrides_controller(
+    action_route: str,
+) -> None:
+    source = f"""using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/[controller]")]
+public class ChatController : ControllerBase
+{{
+    [HttpPost("{action_route}")]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Message);
+}}
+public record ChatRequest(string Message);
+"""
+
+    endpoint = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+        ),
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["endpoint"] == "/chat"
+
+
+def test_aspnet_marks_collection_chat_payloads_as_lists() -> None:
+    source = """using Microsoft.AspNetCore.Mvc;
+public record Message(string Content);
+public record ChatRequest(List<Message> Messages);
+[ApiController]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost]
+    public string Complete(ChatRequest request) =>
+        client.CompleteChat(request.Messages);
+}
+"""
+
+    endpoint = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+        ),
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["chat_payload_key"] == "Messages"
+    assert endpoint.metadata["chat_payload_list"] is True
+
+
+def test_aspnet_preserves_from_body_primitive_prompt() -> None:
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost("prompt")]
+    public string Complete([FromBody] string prompt) =>
+        client.CompleteChat(prompt);
+}
+"""
+
+    endpoint = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+        ),
+        ComponentType.API_ENDPOINT,
+    )[0]
+
+    assert endpoint.metadata["request_body_schema"] == {"prompt": "string"}
+    assert endpoint.metadata["chat_payload_key"] == "prompt"
+    assert endpoint.metadata["chat_payload_list"] is False
+
+
+def test_legacy_azure_client_with_anthropic_import_stays_azure() -> None:
+    source = """using Azure.AI.OpenAI;
+using Anthropic;
+var client = new OpenAIClient(endpoint, credential);
+"""
+
+    detections = _extract(
+        CSharpLLMClientsAdapter(),
+        source,
+    )
+    providers = {
+        detection.metadata["provider"]
+        for detection in _by_type(
+            detections,
+            ComponentType.FRAMEWORK,
+        )
+    }
+
+    assert providers == {"azure", "anthropic"}
+
+
+def test_semantic_kernel_skips_unresolved_model_registration() -> None:
+    source = """using Microsoft.SemanticKernel;
+var builder = Kernel.CreateBuilder();
+builder.AddAzureOpenAIChatCompletion(
+    deploymentName: deploymentName,
+    endpoint: endpoint,
+    apiKey: key);
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+
+    assert (
+        _by_type(
+            detections,
+            ComponentType.MODEL,
+        )
+        == []
+    )
+
+
+def test_semantic_kernel_uses_registration_specific_plugin_positions() -> None:
+    source = """using Microsoft.SemanticKernel;
+var builder = Kernel.CreateBuilder();
+builder.Plugins.AddFromObject(plugin, "Weather");
+builder.Plugins.AddFromPromptDirectory(
+    "prompts", options, "Prompts");
+builder.Plugins.AddFromType<SearchPlugin>(
+    options, "Search");
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+    tools = {
+        detection.display_name
+        for detection in _by_type(
+            detections,
+            ComponentType.TOOL,
+        )
+    }
+
+    assert {"Weather", "Prompts", "Search"} <= tools


### PR DESCRIPTION
Closes #260 

Follow-up to #222.  
Supports the C# pipeline integration tracked in #213.  
Part of #170.

## PR Type

- [ ] Bug fix
- [x] Feature

## What

This PR hardens the C# framework adapters against edge cases identified during the final review of #222.

It adds support for:

- preserving receivers and assignment targets across fluent invocation chains such as:
  - `Trainer().Fit(data)`
  - `Kernel.CreateBuilder().Build()`
- detecting ML.NET trained models created from inline trainer chains
- ASP.NET Core controller actions with separate method-level `[Route(...)]` attributes
- absolute ASP.NET Core action routes beginning with `/` or `~/`
- collection-valued conversational payloads such as:
  - `List<Message>`
  - `IReadOnlyList<Message>`
  - `string[]`
- body-bound primitive prompts such as `[FromBody] string prompt`
- legacy Azure `OpenAIClient` classification when Azure and unrelated provider namespaces are both imported
- unresolved Semantic Kernel model registrations
- registration-specific Semantic Kernel plugin-name argument positions

Focused regression tests were added for each reviewed case.

## Why

The C# adapters introduced in #222 are currently additive-only, but #213 will register them in the normal AI-SBOM extraction pipeline.

The final review of #222 identified several technically valid edge cases that could otherwise produce:

- missing ML.NET trained-model nodes
- incorrect ASP.NET Core routes
- incorrect chat request shapes
- missed primitive prompt inputs
- incorrect Azure/OpenAI provider metadata
- fabricated Semantic Kernel model identifiers
- incorrect Semantic Kernel plugin names

Addressing these cases before #213 lands keeps the pipeline-wiring PR focused on integration rather than adapter correctness.

## How

### Fluent call-chain handling

Updated the shared C# call-expression helper to:

- parse all call expressions before applying adapter-specific name filters
- link a call to the immediately preceding invocation when separated by `.` or `?.`
- preserve the full chained receiver expression
- inherit the assignment target from the beginning of the fluent chain
- retain accurate snippets and source locations

For example:

```csharp
var model = ml.BinaryClassification.Trainers
    .SdcaLogisticRegression()
    .Fit(data);