### PR TITLE
fix(cli): auto-create --output parent dirs in validate and policy

### DIFF
--- a/nuguard/cli/commands/policy.py
+++ b/nuguard/cli/commands/policy.py
@@ -429,6 +429,9 @@ def check(
                 all_formats=formats,
                 extension_map=extension_map,
             )
+            # Auto-create the parent directory, consistent with analyze /
+            # behavior / redteam (issue #233) and scan / sbom generate.
+            out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(_render(fmt), encoding="utf-8")
             _console.print(f"Output written to {out_path}")
     else:

--- a/nuguard/cli/commands/validate.py
+++ b/nuguard/cli/commands/validate.py
@@ -207,6 +207,9 @@ def _do_validate(
                 all_formats=formats,
                 extension_map=extension_map,
             )
+            # Auto-create the parent directory, consistent with analyze /
+            # behavior / redteam (issue #233) and scan / sbom generate.
+            out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(_render(fmt), encoding="utf-8")
             _console.print(f"[green]Results written to[/green] {out_path}")
     else:

--- a/nuguard/policy/loader.py
+++ b/nuguard/policy/loader.py
@@ -22,6 +22,9 @@ def save_controls(controls: list[PolicyControl], path: Path) -> None:
         controls: Compiled policy controls.
         path:     Destination file path (typically ``cognitive_policy.json``).
     """
+    # Auto-create the parent directory, consistent with analyze / behavior /
+    # redteam (issue #233) and scan / sbom generate.
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
             [c.model_dump() for c in controls],

--- a/tests/cli/test_output_parent_dir.py
+++ b/tests/cli/test_output_parent_dir.py
@@ -259,3 +259,76 @@ def test_redteam_creates_missing_parent_dir_for_output(fresh_tmp: Path) -> None:
     # The output file must be valid JSON — proves the dispatch loop ran
     # through the JSON-format branch, not the text-format branch.
     _json.loads(out_path.read_text(encoding="utf-8"))
+
+
+def test_policy_check_creates_missing_parent_dir_for_output(tmp_path: Path) -> None:
+    """``nuguard policy check --output <nested>/report.json`` must auto-create parents.
+
+    Regression: policy check wrote the output file with a bare ``write_text``,
+    so a missing parent directory raised an uncaught FileNotFoundError
+    traceback, unlike analyze / behavior / redteam / scan / sbom which all
+    auto-create the parent (issue #233 unified behaviour).
+    """
+    from nuguard.sbom.extractor import AiSbomExtractor
+    from nuguard.sbom.extractor.config import AiSbomConfig
+    from nuguard.sbom.extractor.serializer import AiSbomSerializer
+
+    app_dir = (
+        Path(__file__).parent.parent.parent
+        / "nuguard"
+        / "sbom"
+        / "tests"
+        / "fixtures"
+        / "apps"
+        / "customer_service_bot"
+    )
+    doc = AiSbomExtractor().extract_from_path(
+        app_dir, AiSbomConfig(include_extensions={".py"}, enable_llm=False)
+    )
+    sbom = tmp_path / "app.sbom.json"
+    sbom.write_text(AiSbomSerializer.to_json(doc), encoding="utf-8")
+    pol = tmp_path / "policy.md"
+    pol.write_text(
+        "## Restricted Topics\n- medical\n## Rate Limits\n- requests_per_minute: 60\n",
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "a" / "b" / "c" / "report.json"
+    assert not out_path.parent.exists()
+    result = runner.invoke(
+        app,
+        [
+            "policy", "check",
+            "--policy", str(pol),
+            "--sbom", str(sbom),
+            "--output", str(out_path),
+            "--format", "json",
+        ],
+        catch_exceptions=False,
+    )
+    # exit 0 (no gaps) or 1 (gap findings) are both fine — the contract is
+    # that the parent dir is created and the file is written.
+    assert result.exit_code in (0, 1), result.output
+    assert out_path.exists(), (
+        f"Expected policy check report at {out_path}; stdout:\n{result.output}"
+    )
+
+
+def test_policy_compile_creates_missing_parent_dir_for_output(tmp_path: Path) -> None:
+    """``nuguard policy compile --output <nested>/controls.json`` must auto-create parents."""
+    pol = tmp_path / "policy.md"
+    pol.write_text(
+        "## Restricted Topics\n- medical\n## Rate Limits\n- requests_per_minute: 60\n",
+        encoding="utf-8",
+    )
+    out_path = tmp_path / "a" / "b" / "c" / "controls.json"
+    assert not out_path.parent.exists()
+    result = runner.invoke(
+        app,
+        ["policy", "compile", "--policy", str(pol), "--output", str(out_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out_path.exists(), (
+        f"Expected compiled controls at {out_path}; stdout:\n{result.output}"
+    )

--- a/tests/cli/test_validate_command.py
+++ b/tests/cli/test_validate_command.py
@@ -109,6 +109,7 @@ def test_validate_json_includes_verbose_flag_and_diagnostics_when_verbose(
     tmp_path: Path,
 ) -> None:
     import json as _json
+
     import nuguard.cli.commands.validate as validate_cmd
 
     monkeypatch.setattr(validate_cmd, "_run_validate", _fake_run_validate)
@@ -140,6 +141,7 @@ def test_validate_json_omits_diagnostics_when_not_verbose(
     tmp_path: Path,
 ) -> None:
     import json as _json
+
     import nuguard.cli.commands.validate as validate_cmd
 
     monkeypatch.setattr(validate_cmd, "_run_validate", _fake_run_validate)
@@ -170,6 +172,7 @@ def test_validate_json_uses_resolved_endpoint_metadata(
     tmp_path: Path,
 ) -> None:
     import json as _json
+
     import nuguard.cli.commands.validate as validate_cmd
 
     monkeypatch.setattr(validate_cmd, "_run_validate", _fake_run_validate)
@@ -193,3 +196,37 @@ def test_validate_json_uses_resolved_endpoint_metadata(
     payload = _json.loads(out_base.read_text(encoding="utf-8"))
     assert payload["_meta"]["effective_endpoint"] == "/api/agent/chat"
     assert payload["_meta"]["target_endpoint_source"] == "probe"
+
+
+def test_validate_creates_missing_parent_dir_for_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``nuguard validate --output <nested>/out.json`` must auto-create parents.
+
+    Regression: validate wrote the output file with a bare ``write_text``, so
+    a missing parent directory raised an uncaught FileNotFoundError traceback,
+    unlike analyze / behavior / redteam / scan / sbom which all auto-create
+    the parent (issue #233 unified behaviour).
+    """
+    import nuguard.cli.commands.validate as validate_cmd
+
+    monkeypatch.setattr(validate_cmd, "_run_validate", _fake_run_validate)
+    cfg = _write_validate_config(tmp_path)
+    out_path = tmp_path / "a" / "b" / "c" / "results.json"
+    assert not out_path.parent.exists()
+
+    result = runner.invoke(
+        app,
+        [
+            "validate",
+            "--config", str(cfg),
+            "--format", "json",
+            "--output", str(out_path),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out_path.exists(), (
+        f"Expected validate report at {out_path}; stdout:\n{result.output}"
+    )


### PR DESCRIPTION
## Summary
Extends the established `--output` parent-directory auto-creation contract (issue #233) to `nuguard validate`, `nuguard policy check`, and `nuguard policy compile`.

## Bug fix
- [x] Yes

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Root Cause
`analyze`, `behavior`, `redteam`, `scan`, and `sbom generate` all auto-create the parent directory of an `--output` path (issue #233 unified this behaviour across analyze/behavior/redteam). `validate`, `policy check`, and `policy compile` were not included: they wrote output with a bare `write_text`, so `nuguard validate --output reports/nested/out.json` (with a missing parent) raised an **uncaught FileNotFoundError traceback** instead of creating the directory.

## Expected vs Actual Behaviour
- **Expected:** `--output` into a missing parent directory creates the parent and writes the file (consistent with analyze/behavior/redteam/scan/sbom).
- **Actual:** validate/policy check/policy compile crash with `FileNotFoundError: [Errno 2] No such file or directory`.

## Implementation
Add `out_path.parent.mkdir(parents=True, exist_ok=True)` before the output write in:
- `nuguard/cli/commands/validate.py` (`validate --output`)
- `nuguard/cli/commands/policy.py` (`policy check --output`)
- `nuguard/policy/loader.py` `save_controls` (`policy compile --output`)

## Tests
Three regression tests (all **fail against the pre-fix implementation** with the FileNotFoundError traceback — verified via a temporary worktree — and pass with the fix):
- `test_validate_creates_missing_parent_dir_for_output`
- `test_policy_check_creates_missing_parent_dir_for_output`
- `test_policy_compile_creates_missing_parent_dir_for_output`

Also fixed a pre-existing import-sort lint issue in `tests/cli/test_validate_command.py` (ruff I001) that CI would otherwise flag on this file.

## Validation
- `tests/cli/` — 89 passed
- `tests/policy/` + `tests/cli/test_policy_cli.py` — 26 passed
- `ruff check` clean
- `mypy` clean

Fixes #292

Also addresses #233