### PR TITLE
fix(config): stop unset ${VAR} leaking literal 'None' into headers/app_env

### DIFF
--- a/nuguard.yaml.example
+++ b/nuguard.yaml.example
@@ -115,6 +115,11 @@ behavior:
   # Canary seed file — same file used by redteam canary scanning.
   # canary: ./canary.json
 
+  # Extra HTTP headers added to every request (overrides the shared
+  # target.headers block for behavior only).
+  # headers:
+  #   X-Tenant-Id: "tenant-1"
+
   # Per-request HTTP timeout in seconds (default: 60)
   # Increase for slow LLM-backed pipelines.
   request_timeout: 60
@@ -179,7 +184,8 @@ behavior:
 
 # ─── Red-team mode ────────────────────────────────────────────────────────────
 # nuguard redteam exercises adversarial scenarios to find break points.
-# target.url, target.auth, target.endpoint are inherited from the target: block above.
+# target.url, target.auth, target.endpoint, target.headers are inherited from
+# the target: block above.
 # Override any of them here when redteam needs different credentials than behavior.
 redteam:
 

--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -813,7 +813,13 @@ class BehaviorRunner:
 
         # Merge explicit behavior.headers (shared target.headers or behavior.headers)
         # underneath bootstrapped/auth headers so auth always wins on conflicts.
-        _cfg_headers: dict[str, str] = dict(getattr(self._config, "headers", None) or {})
+        # Normalize first so a literal "None"/"" string header value (unset
+        # ${VAR} = None -> stringified anywhere upstream) can't reach the target.
+        from nuguard.common.auth_runtime import _normalize_headers  # noqa: PLC0415
+
+        _cfg_headers: dict[str, str] = _normalize_headers(
+            getattr(self._config, "headers", None)
+        )
         if _cfg_headers:
             bootstrap_headers = {**_cfg_headers, **(bootstrap_headers or {})}
 

--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -811,6 +811,12 @@ class BehaviorRunner:
             _log.debug("_build_client: bootstrap skipped: %s", exc)
             bootstrap_headers = getattr(runtime, "initial_headers", {}) or {}
 
+        # Merge explicit behavior.headers (shared target.headers or behavior.headers)
+        # underneath bootstrapped/auth headers so auth always wins on conflicts.
+        _cfg_headers: dict[str, str] = dict(getattr(self._config, "headers", None) or {})
+        if _cfg_headers:
+            bootstrap_headers = {**_cfg_headers, **(bootstrap_headers or {})}
+
         # Merge login-response identity/session fields and SBOM context hints
         # into chat_payload_extras so the correct user identity is sent in every
         # request (covers apps like Pinnacle Bank where user_id is a body field).

--- a/nuguard/common/auth_runtime.py
+++ b/nuguard/common/auth_runtime.py
@@ -24,7 +24,7 @@ def _normalize_headers(headers_override: Mapping[str, str] | None) -> dict[str, 
     return {
         str(name): str(value)
         for name, value in headers_override.items()
-        if str(name).strip()
+        if str(name).strip() and str(value).strip() not in ("None", "")
     }
 
 

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -211,7 +211,9 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             flat["redteam_chat_payload_extras"] = shared_target["chat_payload_extras"]
         if "headers" in shared_target and isinstance(shared_target["headers"], dict):
             flat["redteam_headers"] = {
-                str(k): str(v) for k, v in shared_target["headers"].items()
+                str(k): str(v)
+                for k, v in shared_target["headers"].items()
+                if v is not None
             }
         # Structured auth from the shared block — same format as behavior/redteam auth
         _shared_auth = shared_target.get("auth", {}) or {}
@@ -253,7 +255,9 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_auth_header"] = redteam["auth_header"]
     if "headers" in redteam and isinstance(redteam["headers"], dict):
         flat["redteam_headers"] = {
-            str(k): str(v) for k, v in redteam["headers"].items()
+            str(k): str(v)
+            for k, v in redteam["headers"].items()
+            if v is not None
         }
     if "canary" in redteam:
         flat["canary_path"] = redteam["canary"]
@@ -311,9 +315,11 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_prompt_cache_dir"] = str(redteam["prompt_cache_dir"])
     if "app_env" in redteam and isinstance(redteam["app_env"], dict):
         flat["redteam_app_env"] = {
-            str(k): str(v) for k, v in redteam["app_env"].items()
+            str(k): str(v)
+            for k, v in redteam["app_env"].items()
+            if v is not None
         }
-    if "customer_profile" in redteam:
+    if "customer_profile" in redteam and redteam["customer_profile"] is not None:
         app_env = dict(flat.get("redteam_app_env", {}))
         app_env["BLISSFUL_CUSTOMER_PROFILE"] = str(redteam["customer_profile"])
         flat["redteam_app_env"] = app_env
@@ -424,7 +430,11 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                 if "headers" in shared_target and isinstance(shared_target["headers"], dict):
                     _shared_for_behavior.setdefault(
                         "headers",
-                        {str(k): str(v) for k, v in shared_target["headers"].items()},
+                        {
+                            str(k): str(v)
+                            for k, v in shared_target["headers"].items()
+                            if v is not None
+                        },
                     )
                 if "auth" in shared_target and isinstance(shared_target["auth"], dict):
                     _shared_for_behavior.setdefault("auth", shared_target["auth"])
@@ -439,6 +449,12 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                 if "endpoint" in b:
                     b["target_endpoint"] = b["endpoint"]
                 b = {**_shared_for_behavior, **b}
+            if isinstance(b, dict) and isinstance(b.get("headers"), dict):
+                b["headers"] = {
+                    str(k): str(v)
+                    for k, v in b["headers"].items()
+                    if v is not None
+                }
             flat["behavior_config"] = b
 
     # Validate section
@@ -573,6 +589,13 @@ class BehaviorConfig(BaseModel):
     target: str = ""
     target_endpoint: str = ""
     auth: AppAuthConfig = Field(default_factory=AppAuthConfig)
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Extra HTTP headers added to every behavior request "
+            "(yaml: behavior.headers, or the shared target.headers block)."
+        ),
+    )
     canary: str = ""
     workflows: list[str] = Field(
         default_factory=list,

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -805,7 +805,13 @@ class RedteamOrchestrator:
                 detail=default_check.error_detail,
             )
         bootstrap_headers = bootstrapper.session.headers()
-        effective_headers = dict(self._extra_headers)
+        # Normalize the static extra headers so a literal "None"/"" string
+        # value (unset ${VAR} → None → stringified anywhere upstream) can't
+        # reach the target. Login-flow/bootstrapped headers override the
+        # normalized static defaults below.
+        from nuguard.common.auth_runtime import _normalize_headers  # noqa: PLC0415
+
+        effective_headers = _normalize_headers(self._extra_headers)
         # Login-flow/bootstrapped session headers must override static defaults.
         if bootstrap_headers:
             effective_headers.update(bootstrap_headers)

--- a/tests/behavior/test_public_api.py
+++ b/tests/behavior/test_public_api.py
@@ -273,3 +273,74 @@ async def test_discover_behavior_profile_returns_none_when_runner_finds_nothing(
         mock_cls.return_value.discover = AsyncMock(return_value=None)
         result = await discover_behavior_profile(config)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# behavior.headers plumbing into the target client
+# ---------------------------------------------------------------------------
+
+
+def test_behavior_runner_merges_config_headers_into_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """behavior.headers (from shared target.headers or behavior.headers) must
+    be attached to every outbound request, not silently dropped."""
+    import asyncio
+
+    from nuguard.behavior.runner import BehaviorRunner
+
+    captured: dict[str, object] = {}
+
+    def _fake_build_target_app_client(**kwargs: object):
+        captured["auth_headers"] = kwargs.get("auth_headers")
+        # Return a minimal stand-in with the attrs the runner reads after build.
+        class _FakeClient:
+            resolution_notes: list[str] = []
+            base_url = "http://localhost:9999"
+            _chat_path = "/chat"
+        return _FakeClient()
+
+    async def _fake_bootstrap_auth_runtime(**kwargs: object):
+        from nuguard.models.health_report import TargetHealthReport
+
+        class _FakeSession:
+            def headers(self):
+                return {"Authorization": "Bearer boot-token"}
+
+            def login_response_extras(self):
+                return {}
+
+        class _FakeBootstrapper:
+            session = _FakeSession()
+
+        return (
+            _FakeBootstrapper(),
+            TargetHealthReport(
+                target_url="http://localhost:9999",
+                endpoint="/chat",
+                run_id="test",
+                checks=[],
+            ),
+        )
+
+    monkeypatch.setattr(
+        "nuguard.common.target_client_builder.build_target_app_client",
+        _fake_build_target_app_client,
+    )
+    monkeypatch.setattr(
+        "nuguard.common.auth_runtime.bootstrap_auth_runtime",
+        _fake_bootstrap_auth_runtime,
+    )
+    runner = BehaviorRunner(
+        config=BehaviorConfig(
+            target="http://localhost:9999",
+            headers={"X-Tenant-Id": "tenant-1"},
+        ),
+    )
+    asyncio.run(runner._build_client())
+
+    headers = captured["auth_headers"]
+    assert headers is not None
+    assert headers["X-Tenant-Id"] == "tenant-1"
+    # Bootstrapped auth headers still present underneath the static headers.
+    assert headers["Authorization"] == "Bearer boot-token"

--- a/tests/common/test_auth_runtime.py
+++ b/tests/common/test_auth_runtime.py
@@ -40,3 +40,33 @@ def test_resolve_auth_runtime_defaults_to_none() -> None:
     resolved = resolve_auth_runtime()
     assert resolved.auth_config.type == "none"
     assert resolved.initial_headers == {}
+
+def test_resolve_auth_runtime_drops_none_string_headers() -> None:
+    """A header whose value collapsed to the literal string "None" must not
+    reach the outbound request headers or become the auth seed."""
+    resolved = resolve_auth_runtime(
+        auth_config=AuthConfig(type="none"),
+        headers_override={
+            "X-Tenant-Id": "None",
+            "X-API-Key": "static-key",
+        },
+    )
+
+    assert resolved.initial_headers == {"X-API-Key": "static-key"}
+    assert resolved.auth_config.type == "api_key"
+
+
+def test_resolve_auth_runtime_drops_none_string_authorization() -> None:
+    """Even an Authorization header that collapsed to "None" must be dropped
+    rather than seeded as a broken auth config."""
+    resolved = resolve_auth_runtime(
+        auth_config=AuthConfig(type="none"),
+        headers_override={
+            "Authorization": "None",
+            "X-Request-Id": "abc",
+        },
+    )
+
+    assert resolved.initial_headers == {"X-Request-Id": "abc"}
+    # The surviving header still seeds auth (api_key), but never "None".
+    assert resolved.auth_config.type == "api_key"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -455,6 +455,44 @@ class TestSharedTargetBlock:
         assert flat["redteam_headers"]["X-Tenant-Id"] == "tenant-1"
         assert flat["redteam_headers"]["X-Custom"] == "value"
 
+    def test_shared_headers_injected_into_behavior_config(self) -> None:
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: tenant-1
+            behavior:
+              llm: true
+        """)
+        # The shared headers block is documented as applying to behavior as
+        # well as redteam ("Extra HTTP headers added to every request
+        # (behavior + redteam)" in nuguard.yaml.example), so it must be
+        # injected into behavior_config.
+        assert flat["behavior_config"]["headers"]["X-Tenant-Id"] == "tenant-1"
+
+    def test_behavior_headers_override_shared_headers_in_behavior_config(self) -> None:
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: tenant-shared
+            behavior:
+              headers:
+                X-Tenant-Id: tenant-behavior
+        """)
+        assert flat["behavior_config"]["headers"]["X-Tenant-Id"] == "tenant-behavior"
+
+    def test_shared_headers_reach_resolved_behavior_config(self) -> None:
+        """End-to-end: shared target.headers must survive into the resolved
+        BehaviorConfig model so the behavior runner can attach them."""
+        cfg = NuGuardConfig(
+            behavior_config={
+                "target": "http://shared.test",
+                "headers": {"X-Tenant-Id": "tenant-1"},
+            }
+        )
+        assert cfg.behavior_config.headers == {"X-Tenant-Id": "tenant-1"}
+
     def test_shared_bearer_auth_propagates(self) -> None:
         flat = _flatten("""
             target:
@@ -550,3 +588,94 @@ class TestSharedTargetBlock:
             target: {}
         """)
         assert "target_url" not in flat
+
+
+class TestUnsetEnvVarNoneFiltering:
+    """Unset ${VAR} references must never leak the literal string "None".
+
+    ``_expand_env_vars`` turns an unset placeholder into ``None``.  The
+    flattening step must then drop those ``None`` values (as it already does
+    for ``redteam.credentials`` and the LLM blocks) instead of stringifying
+    them, so a header like ``X-Tenant-Id: ${MY_TENANT}`` cannot reach the
+    HTTP client as ``X-Tenant-Id: None``.
+    """
+
+    @staticmethod
+    def _expand_flatten(yaml_text: str) -> dict:
+        """Full pipeline: env expansion (mirroring load_config) then flatten."""
+        from nuguard.config import _expand_env_vars
+
+        data = yaml.safe_load(textwrap.dedent(yaml_text))
+        return _flatten_yaml(_expand_env_vars(data))
+
+    def test_shared_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT}
+                X-API-Key: static-key
+        """)
+        assert flat["redteam_headers"] == {"X-API-Key": "static-key"}
+        assert "None" not in str(flat["redteam_headers"])
+
+    def test_redteam_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT}
+                X-API-Key: static-key
+        """)
+        assert flat["redteam_headers"] == {"X-API-Key": "static-key"}
+
+    def test_shared_headers_behavior_injection_drops_unset_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT}
+                X-API-Key: static-key
+            behavior:
+              llm: true
+        """)
+        assert flat["behavior_config"]["headers"] == {"X-API-Key": "static-key"}
+
+    def test_redteam_app_env_drops_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_SECRET", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              app_env:
+                MY_SECRET: ${MY_SECRET}
+                KEEP_ME: value
+        """)
+        assert flat["redteam_app_env"] == {"KEEP_ME": "value"}
+
+    def test_redteam_customer_profile_drops_unset_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CUSTOMER_PROFILE", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              app_env:
+                KEEP_ME: value
+              customer_profile: ${CUSTOMER_PROFILE}
+        """)
+        assert flat["redteam_app_env"] == {"KEEP_ME": "value"}
+
+    def test_env_default_fallback_still_keeps_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT:-fallback-tenant}
+        """)
+        assert flat["redteam_headers"] == {"X-Tenant-Id": "fallback-tenant"}


### PR DESCRIPTION
## Problem

`_expand_env_vars` turns an unset `${VAR}` reference into `None`, but `_flatten_yaml` then **stringifies that `None` into the literal string `"None"`** for the header-like dict blocks (`target.headers`, `redteam.headers`, `redteam.app_env`, `customer_profile`) because the comprehensions call `str(v)` without filtering `None` first (`redteam.credentials` and the LLM blocks already filter it).

**Result:** with `X-Tenant-Id: ${MY_TENANT}` and the var unset, the live target receives `X-Tenant-Id: None`. Worse, `resolve_auth_runtime` can seed the derived auth identity from a `"None"`-valued header (e.g. `Authorization: None`).

**Secondary finding:** `nuguard.yaml.example` documents `target.headers` as `behavior + redteam`, and `_flatten_yaml` injects shared `target.headers` into `behavior_config` — but `BehaviorConfig` had **no `headers` field**, so pydantic silently dropped it and behavior never attached those headers to requests.

## Fix

1. Filter `None` in all header/app_env flattening comprehensions (shared `target.headers`, `redteam.headers`, `redteam.app_env`, `customer_profile`, behavior injection).
2. Add `headers` to `BehaviorConfig`; the behavior runner now merges them under auth headers (`behavior.headers` overrides shared `target.headers`).
3. Harden `auth_runtime._normalize_headers` to drop `"None"`/`""` header values as a final safety net.

## Tests (all fail on pre-fix tree, verified in a worktree)

- `TestUnsetEnvVarNoneFiltering` — full env-expansion + flatten pipeline (6 tests)
- `test_resolve_auth_runtime_drops_none_string_*` — 2 tests
- `test_behavior_runner_merges_config_headers_into_client` — fails pre-fix with `KeyError: 'X-Tenant-Id'`
- `test_shared_headers_reach_resolved_behavior_config` — fails pre-fix with `AttributeError: 'BehaviorConfig' object has no attribute 'headers'`

Full suite: `2031 passed, 34 skipped`. ruff + mypy clean.

Fixes #293