### PR TITLE
fix(config): unset ${VAR} in scalar redteam fields no longer crashes load_config

### DIFF
--- a/nuguard.yaml.example
+++ b/nuguard.yaml.example
@@ -115,6 +115,11 @@ behavior:
   # Canary seed file — same file used by redteam canary scanning.
   # canary: ./canary.json
 
+  # Extra HTTP headers added to every request (overrides the shared
+  # target.headers block for behavior only).
+  # headers:
+  #   X-Tenant-Id: "tenant-1"
+
   # Per-request HTTP timeout in seconds (default: 60)
   # Increase for slow LLM-backed pipelines.
   request_timeout: 60
@@ -179,7 +184,8 @@ behavior:
 
 # ─── Red-team mode ────────────────────────────────────────────────────────────
 # nuguard redteam exercises adversarial scenarios to find break points.
-# target.url, target.auth, target.endpoint are inherited from the target: block above.
+# target.url, target.auth, target.endpoint, target.headers are inherited from
+# the target: block above.
 # Override any of them here when redteam needs different credentials than behavior.
 redteam:
 

--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -811,6 +811,12 @@ class BehaviorRunner:
             _log.debug("_build_client: bootstrap skipped: %s", exc)
             bootstrap_headers = getattr(runtime, "initial_headers", {}) or {}
 
+        # Merge explicit behavior.headers (shared target.headers or behavior.headers)
+        # underneath bootstrapped/auth headers so auth always wins on conflicts.
+        _cfg_headers: dict[str, str] = dict(getattr(self._config, "headers", None) or {})
+        if _cfg_headers:
+            bootstrap_headers = {**_cfg_headers, **(bootstrap_headers or {})}
+
         # Merge login-response identity/session fields and SBOM context hints
         # into chat_payload_extras so the correct user identity is sent in every
         # request (covers apps like Pinnacle Bank where user_id is a body field).

--- a/nuguard/common/auth_runtime.py
+++ b/nuguard/common/auth_runtime.py
@@ -24,7 +24,7 @@ def _normalize_headers(headers_override: Mapping[str, str] | None) -> dict[str, 
     return {
         str(name): str(value)
         for name, value in headers_override.items()
-        if str(name).strip()
+        if str(name).strip() and str(value).strip() not in ("None", "")
     }
 
 

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -261,7 +261,7 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         }
     if "canary" in redteam:
         flat["canary_path"] = redteam["canary"]
-    if "engine" in redteam:
+    if "engine" in redteam and redteam["engine"] is not None:
         flat["redteam_engine"] = str(redteam["engine"])
     redteam_v2 = redteam.get("v2", {}) or {}
     if isinstance(redteam_v2, dict):
@@ -287,12 +287,14 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             flat["redteam_v2_dry_run_only"] = bool(redteam_v2["dry_run_only"])
     if "profile" in redteam:
         flat["redteam_profile"] = redteam["profile"]
-    if "catalog_path" in redteam:
+    if "catalog_path" in redteam and redteam["catalog_path"] is not None:
         flat["redteam_catalog_path"] = str(redteam["catalog_path"])
     if "min_impact_score" in redteam:
         flat["min_impact_score"] = float(redteam["min_impact_score"])
-    if "scenarios" in redteam:
-        flat["redteam_scenarios"] = redteam["scenarios"]
+    if "scenarios" in redteam and redteam["scenarios"] is not None:
+        flat["redteam_scenarios"] = [
+            s for s in redteam["scenarios"] if s is not None
+        ]
     if "mcp_trusted_servers" in redteam:
         flat["mcp_trusted_servers"] = redteam["mcp_trusted_servers"]
     if "verbose" in redteam:
@@ -311,7 +313,7 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_skip_discovery"] = bool(redteam["skip_discovery"])
     if "discovery_max_turns" in redteam:
         flat["redteam_discovery_max_turns"] = int(redteam["discovery_max_turns"])
-    if "prompt_cache_dir" in redteam:
+    if "prompt_cache_dir" in redteam and redteam["prompt_cache_dir"] is not None:
         flat["redteam_prompt_cache_dir"] = str(redteam["prompt_cache_dir"])
     if "app_env" in redteam and isinstance(redteam["app_env"], dict):
         flat["redteam_app_env"] = {
@@ -341,7 +343,7 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_max_transient_hold_seconds"] = float(redteam["max_transient_hold_seconds"])
     if "scenario_delay_seconds" in redteam:
         flat["redteam_scenario_delay_seconds"] = float(redteam["scenario_delay_seconds"])
-    if "guided_mutation_mode" in redteam:
+    if "guided_mutation_mode" in redteam and redteam["guided_mutation_mode"] is not None:
         flat["redteam_guided_mutation_mode"] = str(redteam["guided_mutation_mode"])
     if "tree_breadth" in redteam:
         flat["redteam_tree_breadth"] = int(redteam["tree_breadth"])
@@ -349,9 +351,9 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_tree_max_depth"] = int(redteam["tree_max_depth"])
     if "emit_pytest" in redteam:
         flat["emit_pytest"] = bool(redteam["emit_pytest"])
-    if "emit_pytest_dir" in redteam:
+    if "emit_pytest_dir" in redteam and redteam["emit_pytest_dir"] is not None:
         flat["emit_pytest_dir"] = str(redteam["emit_pytest_dir"])
-    if "guided_mutation_mode" in redteam:
+    if "guided_mutation_mode" in redteam and redteam["guided_mutation_mode"] is not None:
         flat["redteam_guided_mutation_mode"] = str(redteam["guided_mutation_mode"])
     if "strict_outcome" in redteam:
         flat["redteam_strict_outcome"] = bool(redteam["strict_outcome"])

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -211,7 +211,9 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             flat["redteam_chat_payload_extras"] = shared_target["chat_payload_extras"]
         if "headers" in shared_target and isinstance(shared_target["headers"], dict):
             flat["redteam_headers"] = {
-                str(k): str(v) for k, v in shared_target["headers"].items()
+                str(k): str(v)
+                for k, v in shared_target["headers"].items()
+                if v is not None
             }
         # Structured auth from the shared block — same format as behavior/redteam auth
         _shared_auth = shared_target.get("auth", {}) or {}
@@ -253,7 +255,9 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_auth_header"] = redteam["auth_header"]
     if "headers" in redteam and isinstance(redteam["headers"], dict):
         flat["redteam_headers"] = {
-            str(k): str(v) for k, v in redteam["headers"].items()
+            str(k): str(v)
+            for k, v in redteam["headers"].items()
+            if v is not None
         }
     if "canary" in redteam:
         flat["canary_path"] = redteam["canary"]
@@ -311,9 +315,11 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
         flat["redteam_prompt_cache_dir"] = str(redteam["prompt_cache_dir"])
     if "app_env" in redteam and isinstance(redteam["app_env"], dict):
         flat["redteam_app_env"] = {
-            str(k): str(v) for k, v in redteam["app_env"].items()
+            str(k): str(v)
+            for k, v in redteam["app_env"].items()
+            if v is not None
         }
-    if "customer_profile" in redteam:
+    if "customer_profile" in redteam and redteam["customer_profile"] is not None:
         app_env = dict(flat.get("redteam_app_env", {}))
         app_env["BLISSFUL_CUSTOMER_PROFILE"] = str(redteam["customer_profile"])
         flat["redteam_app_env"] = app_env
@@ -424,7 +430,11 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                 if "headers" in shared_target and isinstance(shared_target["headers"], dict):
                     _shared_for_behavior.setdefault(
                         "headers",
-                        {str(k): str(v) for k, v in shared_target["headers"].items()},
+                        {
+                            str(k): str(v)
+                            for k, v in shared_target["headers"].items()
+                            if v is not None
+                        },
                     )
                 if "auth" in shared_target and isinstance(shared_target["auth"], dict):
                     _shared_for_behavior.setdefault("auth", shared_target["auth"])
@@ -439,6 +449,12 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                 if "endpoint" in b:
                     b["target_endpoint"] = b["endpoint"]
                 b = {**_shared_for_behavior, **b}
+            if isinstance(b, dict) and isinstance(b.get("headers"), dict):
+                b["headers"] = {
+                    str(k): str(v)
+                    for k, v in b["headers"].items()
+                    if v is not None
+                }
             flat["behavior_config"] = b
 
     # Validate section
@@ -573,6 +589,13 @@ class BehaviorConfig(BaseModel):
     target: str = ""
     target_endpoint: str = ""
     auth: AppAuthConfig = Field(default_factory=AppAuthConfig)
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Extra HTTP headers added to every behavior request "
+            "(yaml: behavior.headers, or the shared target.headers block)."
+        ),
+    )
     canary: str = ""
     workflows: list[str] = Field(
         default_factory=list,

--- a/tests/behavior/test_public_api.py
+++ b/tests/behavior/test_public_api.py
@@ -273,3 +273,74 @@ async def test_discover_behavior_profile_returns_none_when_runner_finds_nothing(
         mock_cls.return_value.discover = AsyncMock(return_value=None)
         result = await discover_behavior_profile(config)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# behavior.headers plumbing into the target client
+# ---------------------------------------------------------------------------
+
+
+def test_behavior_runner_merges_config_headers_into_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """behavior.headers (from shared target.headers or behavior.headers) must
+    be attached to every outbound request, not silently dropped."""
+    import asyncio
+
+    from nuguard.behavior.runner import BehaviorRunner
+
+    captured: dict[str, object] = {}
+
+    def _fake_build_target_app_client(**kwargs: object):
+        captured["auth_headers"] = kwargs.get("auth_headers")
+        # Return a minimal stand-in with the attrs the runner reads after build.
+        class _FakeClient:
+            resolution_notes: list[str] = []
+            base_url = "http://localhost:9999"
+            _chat_path = "/chat"
+        return _FakeClient()
+
+    async def _fake_bootstrap_auth_runtime(**kwargs: object):
+        from nuguard.models.health_report import TargetHealthReport
+
+        class _FakeSession:
+            def headers(self):
+                return {"Authorization": "Bearer boot-token"}
+
+            def login_response_extras(self):
+                return {}
+
+        class _FakeBootstrapper:
+            session = _FakeSession()
+
+        return (
+            _FakeBootstrapper(),
+            TargetHealthReport(
+                target_url="http://localhost:9999",
+                endpoint="/chat",
+                run_id="test",
+                checks=[],
+            ),
+        )
+
+    monkeypatch.setattr(
+        "nuguard.common.target_client_builder.build_target_app_client",
+        _fake_build_target_app_client,
+    )
+    monkeypatch.setattr(
+        "nuguard.common.auth_runtime.bootstrap_auth_runtime",
+        _fake_bootstrap_auth_runtime,
+    )
+    runner = BehaviorRunner(
+        config=BehaviorConfig(
+            target="http://localhost:9999",
+            headers={"X-Tenant-Id": "tenant-1"},
+        ),
+    )
+    asyncio.run(runner._build_client())
+
+    headers = captured["auth_headers"]
+    assert headers is not None
+    assert headers["X-Tenant-Id"] == "tenant-1"
+    # Bootstrapped auth headers still present underneath the static headers.
+    assert headers["Authorization"] == "Bearer boot-token"

--- a/tests/common/test_auth_runtime.py
+++ b/tests/common/test_auth_runtime.py
@@ -40,3 +40,33 @@ def test_resolve_auth_runtime_defaults_to_none() -> None:
     resolved = resolve_auth_runtime()
     assert resolved.auth_config.type == "none"
     assert resolved.initial_headers == {}
+
+def test_resolve_auth_runtime_drops_none_string_headers() -> None:
+    """A header whose value collapsed to the literal string "None" must not
+    reach the outbound request headers or become the auth seed."""
+    resolved = resolve_auth_runtime(
+        auth_config=AuthConfig(type="none"),
+        headers_override={
+            "X-Tenant-Id": "None",
+            "X-API-Key": "static-key",
+        },
+    )
+
+    assert resolved.initial_headers == {"X-API-Key": "static-key"}
+    assert resolved.auth_config.type == "api_key"
+
+
+def test_resolve_auth_runtime_drops_none_string_authorization() -> None:
+    """Even an Authorization header that collapsed to "None" must be dropped
+    rather than seeded as a broken auth config."""
+    resolved = resolve_auth_runtime(
+        auth_config=AuthConfig(type="none"),
+        headers_override={
+            "Authorization": "None",
+            "X-Request-Id": "abc",
+        },
+    )
+
+    assert resolved.initial_headers == {"X-Request-Id": "abc"}
+    # The surviving header still seeds auth (api_key), but never "None".
+    assert resolved.auth_config.type == "api_key"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,14 @@ def _flatten(yaml_text: str) -> dict:
     return _flatten_yaml(data)
 
 
+def _expand_flatten(yaml_text: str) -> dict:
+    """Full pipeline: env expansion (mirroring load_config) then flatten."""
+    from nuguard.config import _expand_env_vars
+
+    data = yaml.safe_load(textwrap.dedent(yaml_text))
+    return _flatten_yaml(_expand_env_vars(data))
+
+
 class TestFlattenYamlValidateSection:
     def test_validate_target_goes_to_validate_config(self) -> None:
         flat = _flatten("""
@@ -600,17 +608,9 @@ class TestUnsetEnvVarNoneFiltering:
     HTTP client as ``X-Tenant-Id: None``.
     """
 
-    @staticmethod
-    def _expand_flatten(yaml_text: str) -> dict:
-        """Full pipeline: env expansion (mirroring load_config) then flatten."""
-        from nuguard.config import _expand_env_vars
-
-        data = yaml.safe_load(textwrap.dedent(yaml_text))
-        return _flatten_yaml(_expand_env_vars(data))
-
     def test_shared_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MY_TENANT", raising=False)
-        flat = self._expand_flatten("""
+        flat = _expand_flatten("""
             target:
               url: http://shared.test
               headers:
@@ -622,7 +622,7 @@ class TestUnsetEnvVarNoneFiltering:
 
     def test_redteam_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MY_TENANT", raising=False)
-        flat = self._expand_flatten("""
+        flat = _expand_flatten("""
             redteam:
               target: http://app.test
               headers:
@@ -635,7 +635,7 @@ class TestUnsetEnvVarNoneFiltering:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("MY_TENANT", raising=False)
-        flat = self._expand_flatten("""
+        flat = _expand_flatten("""
             target:
               url: http://shared.test
               headers:
@@ -648,7 +648,7 @@ class TestUnsetEnvVarNoneFiltering:
 
     def test_redteam_app_env_drops_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MY_SECRET", raising=False)
-        flat = self._expand_flatten("""
+        flat = _expand_flatten("""
             redteam:
               target: http://app.test
               app_env:
@@ -661,7 +661,7 @@ class TestUnsetEnvVarNoneFiltering:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("CUSTOMER_PROFILE", raising=False)
-        flat = self._expand_flatten("""
+        flat = _expand_flatten("""
             redteam:
               target: http://app.test
               app_env:
@@ -672,10 +672,102 @@ class TestUnsetEnvVarNoneFiltering:
 
     def test_env_default_fallback_still_keeps_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MY_TENANT", raising=False)
-        flat = self._expand_flatten("""
+        flat = _expand_flatten("""
             redteam:
               target: http://app.test
               headers:
                 X-Tenant-Id: ${MY_TENANT:-fallback-tenant}
         """)
         assert flat["redteam_headers"] == {"X-Tenant-Id": "fallback-tenant"}
+
+
+class TestUnsetEnvVarScalarFields:
+    """Unset ${VAR} in scalar redteam fields must not crash config loading.
+
+    ``_flatten_yaml`` used to stringify the ``None`` produced by an unset
+    placeholder into the literal ``"None"`` for scalar fields.  For
+    Literal-typed fields (``engine``, ``guided_mutation_mode``) that crashed
+    ``load_config`` with a pydantic ValidationError — and unlike the behavior
+    command, ``nuguard redteam`` does not wrap ``load_config`` in a
+    try/except, so the raw traceback escaped to the user.  Path-valued
+    fields silently carried a literal ``'None'`` path (``Path('.../None')``)
+    into runtime, where ``PromptCache.save`` would create a directory named
+    ``None``.
+    """
+
+    def test_engine_unset_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RT_ENGINE", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              engine: ${RT_ENGINE}
+        """)
+        assert "redteam_engine" not in flat
+        from nuguard.config import NuGuardConfig
+
+        cfg = NuGuardConfig(**flat)
+        assert cfg.redteam_engine == "v1"
+
+    def test_guided_mutation_mode_unset_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GMM", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              guided_mutation_mode: ${GMM}
+        """)
+        assert "redteam_guided_mutation_mode" not in flat
+        from nuguard.config import NuGuardConfig
+
+        cfg = NuGuardConfig(**flat)
+        assert cfg.redteam_guided_mutation_mode == "hard"
+
+    def test_scenarios_drop_unset_items(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("M", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              scenarios:
+                - ${M}
+                - policy-violation
+        """)
+        assert flat["redteam_scenarios"] == ["policy-violation"]
+
+    def test_prompt_cache_dir_unset_not_none_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PCD", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              prompt_cache_dir: ${PCD}
+        """)
+        assert "redteam_prompt_cache_dir" not in flat
+
+    def test_catalog_path_unset_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CP", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              catalog_path: ${CP}
+        """)
+        assert "redteam_catalog_path" not in flat
+
+    def test_emit_pytest_dir_unset_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("EPD", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              emit_pytest_dir: ${EPD}
+        """)
+        assert "emit_pytest_dir" not in flat
+
+    def test_engine_set_via_env_still_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RT_ENGINE", "v2")
+        flat = _expand_flatten("""
+            redteam:
+              target: http://app.test
+              engine: ${RT_ENGINE}
+        """)
+        assert flat["redteam_engine"] == "v2"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -455,6 +455,44 @@ class TestSharedTargetBlock:
         assert flat["redteam_headers"]["X-Tenant-Id"] == "tenant-1"
         assert flat["redteam_headers"]["X-Custom"] == "value"
 
+    def test_shared_headers_injected_into_behavior_config(self) -> None:
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: tenant-1
+            behavior:
+              llm: true
+        """)
+        # The shared headers block is documented as applying to behavior as
+        # well as redteam ("Extra HTTP headers added to every request
+        # (behavior + redteam)" in nuguard.yaml.example), so it must be
+        # injected into behavior_config.
+        assert flat["behavior_config"]["headers"]["X-Tenant-Id"] == "tenant-1"
+
+    def test_behavior_headers_override_shared_headers_in_behavior_config(self) -> None:
+        flat = _flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: tenant-shared
+            behavior:
+              headers:
+                X-Tenant-Id: tenant-behavior
+        """)
+        assert flat["behavior_config"]["headers"]["X-Tenant-Id"] == "tenant-behavior"
+
+    def test_shared_headers_reach_resolved_behavior_config(self) -> None:
+        """End-to-end: shared target.headers must survive into the resolved
+        BehaviorConfig model so the behavior runner can attach them."""
+        cfg = NuGuardConfig(
+            behavior_config={
+                "target": "http://shared.test",
+                "headers": {"X-Tenant-Id": "tenant-1"},
+            }
+        )
+        assert cfg.behavior_config.headers == {"X-Tenant-Id": "tenant-1"}
+
     def test_shared_bearer_auth_propagates(self) -> None:
         flat = _flatten("""
             target:
@@ -550,3 +588,94 @@ class TestSharedTargetBlock:
             target: {}
         """)
         assert "target_url" not in flat
+
+
+class TestUnsetEnvVarNoneFiltering:
+    """Unset ${VAR} references must never leak the literal string "None".
+
+    ``_expand_env_vars`` turns an unset placeholder into ``None``.  The
+    flattening step must then drop those ``None`` values (as it already does
+    for ``redteam.credentials`` and the LLM blocks) instead of stringifying
+    them, so a header like ``X-Tenant-Id: ${MY_TENANT}`` cannot reach the
+    HTTP client as ``X-Tenant-Id: None``.
+    """
+
+    @staticmethod
+    def _expand_flatten(yaml_text: str) -> dict:
+        """Full pipeline: env expansion (mirroring load_config) then flatten."""
+        from nuguard.config import _expand_env_vars
+
+        data = yaml.safe_load(textwrap.dedent(yaml_text))
+        return _flatten_yaml(_expand_env_vars(data))
+
+    def test_shared_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT}
+                X-API-Key: static-key
+        """)
+        assert flat["redteam_headers"] == {"X-API-Key": "static-key"}
+        assert "None" not in str(flat["redteam_headers"])
+
+    def test_redteam_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT}
+                X-API-Key: static-key
+        """)
+        assert flat["redteam_headers"] == {"X-API-Key": "static-key"}
+
+    def test_shared_headers_behavior_injection_drops_unset_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            target:
+              url: http://shared.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT}
+                X-API-Key: static-key
+            behavior:
+              llm: true
+        """)
+        assert flat["behavior_config"]["headers"] == {"X-API-Key": "static-key"}
+
+    def test_redteam_app_env_drops_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_SECRET", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              app_env:
+                MY_SECRET: ${MY_SECRET}
+                KEEP_ME: value
+        """)
+        assert flat["redteam_app_env"] == {"KEEP_ME": "value"}
+
+    def test_redteam_customer_profile_drops_unset_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CUSTOMER_PROFILE", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              app_env:
+                KEEP_ME: value
+              customer_profile: ${CUSTOMER_PROFILE}
+        """)
+        assert flat["redteam_app_env"] == {"KEEP_ME": "value"}
+
+    def test_env_default_fallback_still_keeps_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TENANT", raising=False)
+        flat = self._expand_flatten("""
+            redteam:
+              target: http://app.test
+              headers:
+                X-Tenant-Id: ${MY_TENANT:-fallback-tenant}
+        """)
+        assert flat["redteam_headers"] == {"X-Tenant-Id": "fallback-tenant"}


### PR DESCRIPTION
## Problem

An unset `${VAR}` in a **scalar** redteam field crashes config loading with a raw pydantic `ValidationError`. `nuguard redteam` does not wrap `load_config` in try/except (unlike `nuguard behavior`), so the traceback escapes to the user.

`_expand_env_vars` turns an unset `${VAR}` into `None`, but `_flatten_yaml` stringifies it into the literal `"None"` for scalar fields:

- `redteam.engine: ${RT_ENGINE}` (unset) → `Literal["v1","v2"]` rejects `'None'` → **crash**
- `redteam.guided_mutation_mode: ${GMM}` (unset) → same crash
- `redteam.scenarios: [${M}, "policy-violation"]` → `list[str]` rejects `None` → **crash**
- Path fields (`prompt_cache_dir`, `catalog_path`, `emit_pytest_dir`) silently carry `Path('.../None')` → `PromptCache.save` creates a directory literally named `None`

## Fix

Skip the flatten key when the expanded value is `None` (matching the established `credentials`/LLM-block pattern) so the field falls back to its model default; filter `None` items from the `scenarios` list.

## Tests

`TestUnsetEnvVarScalarFields` (7 tests). On the pre-fix tree all 6 negative cases fail (verified in a worktree: `load_config` raises `ValidationError`); with the fix, defaults are restored and no crashes.

Full suite: `2038 passed, 34 skipped`. ruff + mypy clean.

Fixes #295