### PR TITLE
Feat/go framework adapter base takeover

### DIFF
--- a/nuguard/sbom/adapters/go/__init__.py
+++ b/nuguard/sbom/adapters/go/__init__.py
@@ -1,0 +1,7 @@
+"""Golang SBOM framework adapters."""
+
+from __future__ import annotations
+
+from nuguard.sbom.adapters.go._go_base import GoFrameworkAdapter
+
+__all__ = ["GoFrameworkAdapter"]

--- a/nuguard/sbom/adapters/go/_go_base.py
+++ b/nuguard/sbom/adapters/go/_go_base.py
@@ -1,0 +1,103 @@
+"""Base class for all Golang framework adapters."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from nuguard.sbom.adapters.base import ComponentDetection, FrameworkAdapter
+from nuguard.sbom.types import ComponentType
+
+_TEMPLATE_VAR_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+
+class GoFrameworkAdapter(FrameworkAdapter):
+    """Base class for Go AI framework adapters.
+
+    Subclasses define `module_path` (e.g. "github.com/tmc/langchaingo") or
+    `module_paths` set, and override `extract()`.
+    """
+
+    name: str = "go_base"
+    priority: int = 100
+    module_path: str = ""
+    module_paths: set[str] = set()
+
+    def can_handle(self, imports: set[str] | list[str] | Any) -> bool:
+        """Return True if any import matches the target Go module path(s).
+
+        Supports passing a set/list of import strings, or a GoParseResult object.
+        Substring/prefix matching is used (e.g., "github.com/tmc/langchaingo/llms"
+        matches "github.com/tmc/langchaingo").
+        """
+        if hasattr(imports, "imports"):
+            raw_imports = getattr(imports, "imports", [])
+            import_set = {imp.path if hasattr(imp, "path") else str(imp) for imp in raw_imports}
+        elif isinstance(imports, (set, list)):
+            import_set = set(imports)
+        else:
+            return False
+
+        target_paths = self.module_paths or ({self.module_path} if self.module_path else set())
+        if not target_paths:
+            return False
+
+        for imp in import_set:
+            imp_lower = imp.lower()
+            for target in target_paths:
+                if target.lower() in imp_lower:
+                    return True
+        return False
+
+    # ---------------------------------------------------------------------------
+    # Shared Helper Utilities
+    # ---------------------------------------------------------------------------
+
+    def _clean(self, text: str) -> str:
+        """Strip enclosing quotes and clean whitespace."""
+        cleaned = text.strip()
+        if (cleaned.startswith('"') and cleaned.endswith('"')) or (
+            cleaned.startswith("`") and cleaned.endswith("`")
+        ):
+            return cleaned[1:-1].strip()
+        return cleaned
+
+    def _resolve(self, val: str, var_map: dict[str, str]) -> str:
+        """Resolve a variable reference or return the cleaned literal string."""
+        cleaned = self._clean(val)
+        return var_map.get(cleaned, cleaned)
+
+    def _fw_node(
+        self,
+        file_path: str,
+        confidence: float = 0.95,
+        display_name: str | None = None,
+    ) -> ComponentDetection:
+        """Emit a FRAMEWORK node for this Go adapter."""
+        canonical = f"framework:{self.name}"
+        name = display_name or self.name.replace("_", " ").title()
+        return ComponentDetection(
+            canonical_name=canonical,
+            display_name=name,
+            component_type=ComponentType.FRAMEWORK,
+            adapter_name=self.name,
+            priority=self.priority,
+            confidence=confidence,
+            file_path=file_path,
+            metadata={"language": "golang", "framework": self.name},
+        )
+
+    def _template_vars(self, text: str) -> list[str]:
+        """Extract {{ variable }} placeholder names from Go prompt templates."""
+        return _TEMPLATE_VAR_RE.findall(text)
+
+    def extract(
+        self,
+        code: str,
+        file_path: str,
+        parse_result: Any = None,
+    ) -> list[ComponentDetection]:
+        """Extract SBOM components from Go source code."""
+        if parse_result is None or not self.can_handle(parse_result):
+            return []
+        return [self._fw_node(file_path)]

--- a/nuguard/sbom/adapters/go/_go_base.py
+++ b/nuguard/sbom/adapters/go/_go_base.py
@@ -1,103 +1,162 @@
-"""Base class for all Golang framework adapters."""
+"""Base class for Golang framework adapters."""
 
 from __future__ import annotations
 
 import re
-from typing import Any
 
 from nuguard.sbom.adapters.base import ComponentDetection, FrameworkAdapter
+from nuguard.sbom.core.go_parser import (
+    GoFunctionCall,
+    GoImport,
+    GoInstantiation,
+    GoParseResult,
+)
 from nuguard.sbom.types import ComponentType
 
-_TEMPLATE_VAR_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+_TEMPLATE_VAR_RE = re.compile(
+    r"\$\{(?P<dollar>[A-Za-z_]\w*)\}"
+    r"|\{\{\s*(?:[.$])?(?P<go>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\}\}"
+    r"|(?<![$\{])\{(?P<brace>[A-Za-z_]\w*)\}(?!\})"
+)
 
 
 class GoFrameworkAdapter(FrameworkAdapter):
-    """Base class for Go AI framework adapters.
+    """Shared base for adapters that inspect :class:`GoParseResult` values.
 
-    Subclasses define `module_path` (e.g. "github.com/tmc/langchaingo") or
-    `module_paths` set, and override `extract()`.
+    Subclasses declare Go module roots through the inherited ``handles_imports``
+    field and implement ``extract()``. Module matching is case-sensitive and
+    accepts only an exact module root or a slash-delimited subpackage.
     """
 
-    name: str = "go_base"
-    priority: int = 100
-    module_path: str = ""
-    module_paths: set[str] = set()
+    @staticmethod
+    def _matches_module_path(import_path: str, module_path: str) -> bool:
+        """Return whether *import_path* belongs to *module_path*."""
+        return import_path == module_path or import_path.startswith(f"{module_path}/")
 
-    def can_handle(self, imports: set[str] | list[str] | Any) -> bool:
-        """Return True if any import matches the target Go module path(s).
+    @staticmethod
+    def _import_paths(imports_present: object) -> tuple[str, ...]:
+        """Normalize supported import containers into module-path strings."""
+        if isinstance(imports_present, GoParseResult):
+            return tuple(item.path for item in imports_present.imports)
 
-        Supports passing a set/list of import strings, or a GoParseResult object.
-        Substring/prefix matching is used (e.g., "github.com/tmc/langchaingo/llms"
-        matches "github.com/tmc/langchaingo").
-        """
-        if hasattr(imports, "imports"):
-            raw_imports = getattr(imports, "imports", [])
-            import_set = {imp.path if hasattr(imp, "path") else str(imp) for imp in raw_imports}
-        elif isinstance(imports, (set, list)):
-            import_set = set(imports)
-        else:
-            return False
+        if isinstance(imports_present, (set, frozenset, list, tuple)):
+            paths: list[str] = []
+            for item in imports_present:
+                if isinstance(item, GoImport):
+                    paths.append(item.path)
+                elif isinstance(item, str):
+                    paths.append(item)
+            return tuple(paths)
 
-        target_paths = self.module_paths or ({self.module_path} if self.module_path else set())
-        if not target_paths:
-            return False
+        return ()
 
-        for imp in import_set:
-            imp_lower = imp.lower()
-            for target in target_paths:
-                if target.lower() in imp_lower:
-                    return True
-        return False
+    def can_handle(self, imports_present: object) -> bool:
+        """Return whether any import is this adapter's module or a subpackage."""
+        return any(
+            self._matches_module_path(import_path, target)
+            for import_path in self._import_paths(imports_present)
+            for target in self.handles_imports
+            if target
+        )
 
-    # ---------------------------------------------------------------------------
-    # Shared Helper Utilities
-    # ---------------------------------------------------------------------------
+    def _matching_import(self, parse_result: GoParseResult) -> GoImport | None:
+        """Return the first import that activates this adapter."""
+        for imported in parse_result.imports:
+            if any(
+                self._matches_module_path(imported.path, target)
+                for target in self.handles_imports
+                if target
+            ):
+                return imported
+        return None
 
-    def _clean(self, text: str) -> str:
-        """Strip enclosing quotes and clean whitespace."""
-        cleaned = text.strip()
-        if (cleaned.startswith('"') and cleaned.endswith('"')) or (
-            cleaned.startswith("`") and cleaned.endswith("`")
-        ):
-            return cleaned[1:-1].strip()
+    @staticmethod
+    def _clean(value: object) -> str:
+        """Normalize textual parser values and reject unresolved/structured values."""
+        if not isinstance(value, str):
+            return ""
+
+        cleaned = value.strip()
+        if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {'"', "'", "`"}:
+            cleaned = cleaned[1:-1].strip()
+
+        if not cleaned or cleaned.startswith("$"):
+            return ""
+        if cleaned in {"<complex>", "<lambda>", "<dict>", "<list>"}:
+            return ""
         return cleaned
 
-    def _resolve(self, val: str, var_map: dict[str, str]) -> str:
-        """Resolve a variable reference or return the cleaned literal string."""
-        cleaned = self._clean(val)
-        return var_map.get(cleaned, cleaned)
+    @classmethod
+    def _resolve(
+        cls,
+        inst_or_call: GoInstantiation | GoFunctionCall,
+        *keys: str | int,
+    ) -> str:
+        """Return the first usable named or positional parser argument.
+
+        String keys read ``args``; non-negative integer keys read
+        ``positional_args``. Values have already been symbol-resolved by
+        ``parse_go()``.
+        """
+        named = inst_or_call.args
+        positional = inst_or_call.positional_args
+
+        for key in keys:
+            if isinstance(key, int):
+                if key < 0 or key >= len(positional):
+                    continue
+                value = positional[key]
+            else:
+                if key not in named:
+                    continue
+                value = named[key]
+
+            cleaned = cls._clean(value)
+            if cleaned:
+                return cleaned
+
+        return ""
 
     def _fw_node(
         self,
         file_path: str,
+        matched_import: GoImport,
         confidence: float = 0.95,
         display_name: str | None = None,
     ) -> ComponentDetection:
-        """Emit a FRAMEWORK node for this Go adapter."""
-        canonical = f"framework:{self.name}"
-        name = display_name or self.name.replace("_", " ").title()
+        """Emit a framework node using provenance from *matched_import*."""
+        alias = f"{matched_import.alias} " if matched_import.alias else ""
         return ComponentDetection(
-            canonical_name=canonical,
-            display_name=name,
             component_type=ComponentType.FRAMEWORK,
+            canonical_name=f"framework:{self.name}",
+            display_name=display_name or self.name.replace("_", " ").title(),
             adapter_name=self.name,
             priority=self.priority,
             confidence=confidence,
+            metadata={"framework": self.name, "language": "golang"},
             file_path=file_path,
-            metadata={"language": "golang", "framework": self.name},
+            line=matched_import.line,
+            snippet=f'import {alias}"{matched_import.path}"',
+            evidence_kind="ast_import",
         )
 
-    def _template_vars(self, text: str) -> list[str]:
-        """Extract {{ variable }} placeholder names from Go prompt templates."""
-        return _TEMPLATE_VAR_RE.findall(text)
+    @staticmethod
+    def _template_vars(text: str) -> list[str]:
+        """Extract unique simple variables from Go and prompt-template forms.
 
-    def extract(
-        self,
-        code: str,
-        file_path: str,
-        parse_result: Any = None,
-    ) -> list[ComponentDetection]:
-        """Extract SBOM components from Go source code."""
-        if parse_result is None or not self.can_handle(parse_result):
-            return []
-        return [self._fw_node(file_path)]
+        Supported forms are ``{{ .Name }}``, ``{{ $name }}``, ``{{ name }}``,
+        ``${name}``, and ``{name}``. Dotted Go fields are returned without the
+        leading dot, for example ``{{ .User.Name }}`` becomes ``User.Name``.
+        """
+        variables: list[str] = []
+        seen: set[str] = set()
+
+        for match in _TEMPLATE_VAR_RE.finditer(text):
+            value = match.group("dollar") or match.group("go") or match.group("brace")
+            if value is None:
+                continue
+            if value not in seen:
+                seen.add(value)
+                variables.append(value)
+
+        return variables

--- a/nuguard/sbom/tests/test_go_adapter_base.py
+++ b/nuguard/sbom/tests/test_go_adapter_base.py
@@ -2,91 +2,183 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
 import pytest
 
 from nuguard.sbom.adapters.go._go_base import GoFrameworkAdapter
+from nuguard.sbom.core.go_parser import parse_go
 from nuguard.sbom.types import ComponentType
-
-
-@dataclass
-class DummyGoImport:
-    path: str
-
-
-@dataclass
-class DummyGoParseResult:
-    imports: list[DummyGoImport]
 
 
 class SampleGoAdapter(GoFrameworkAdapter):
     name = "langchaingo"
-    module_path = "github.com/tmc/langchaingo"
+    handles_imports = ["github.com/tmc/langchaingo"]
 
 
-class TestGoFrameworkAdapterBase:
-    """Unit tests for GoFrameworkAdapter base functionality."""
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "github.com/tmc/langchaingo",
+        "github.com/tmc/langchaingo/llms",
+    ],
+)
+def test_can_handle_real_parse_result_for_exact_module_and_subpackage(
+    module_path: str,
+) -> None:
+    adapter = SampleGoAdapter()
+    result = parse_go(f'package main\nimport "{module_path}"\n', "main.go")
 
-    def test_can_handle_matching_set(self) -> None:
-        adapter = SampleGoAdapter()
-        imports = {"github.com/tmc/langchaingo/llms", "fmt", "os"}
-        assert adapter.can_handle(imports) is True
+    assert adapter.can_handle(result) is True
 
-    def test_can_handle_non_matching_set(self) -> None:
-        adapter = SampleGoAdapter()
-        imports = {"github.com/gin-gonic/gin", "fmt"}
-        assert adapter.can_handle(imports) is False
 
-    def test_can_handle_parse_result_object(self) -> None:
-        adapter = SampleGoAdapter()
-        parse_res = DummyGoParseResult(
-            imports=[DummyGoImport(path="github.com/tmc/langchaingo/vectorstores")]
-        )
-        assert adapter.can_handle(parse_res) is True
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "github.com/tmc/langchaingo-malicious",
+        "github.com/tmc/langchaingo2",
+        "evilgithub.com/tmc/langchaingo",
+        "github.com/TMC/langchaingo",
+    ],
+)
+def test_can_handle_rejects_lookalikes_and_case_changes(module_path: str) -> None:
+    adapter = SampleGoAdapter()
 
-    def test_can_handle_invalid_input(self) -> None:
-        adapter = SampleGoAdapter()
-        assert adapter.can_handle(12345) is False  # type: ignore[arg-type]
+    assert adapter.can_handle({module_path}) is False
 
-    def test_clean_string_literals(self) -> None:
-        adapter = SampleGoAdapter()
-        assert adapter._clean('"hello world"') == "hello world"
-        assert adapter._clean("`raw string`") == "raw string"
-        assert adapter._clean(" plain text ") == "plain text"
 
-    def test_resolve_variables(self) -> None:
-        adapter = SampleGoAdapter()
-        var_map = {"myVar": "gpt-4o"}
-        assert adapter._resolve("myVar", var_map) == "gpt-4o"
-        assert adapter._resolve('"literal"', var_map) == "literal"
+def test_can_handle_accepts_raw_import_collections() -> None:
+    adapter = SampleGoAdapter()
 
-    def test_template_vars_extraction(self) -> None:
-        adapter = SampleGoAdapter()
-        prompt = "Hello {{ name }}, welcome to {{ location }}!"
-        vars_found = adapter._template_vars(prompt)
-        assert vars_found == ["name", "location"]
+    assert adapter.can_handle(["fmt", "github.com/tmc/langchaingo/chains"]) is True
+    assert adapter.can_handle(1234) is False
 
-    def test_framework_node_generation(self) -> None:
-        adapter = SampleGoAdapter()
-        node = adapter._fw_node("main.go")
-        assert node.component_type == ComponentType.FRAMEWORK
-        assert node.canonical_name == "framework:langchaingo"
-        assert node.display_name == "Langchaingo"
-        assert node.metadata["language"] == "golang"
 
-    def test_extract_returns_framework_node_when_handled(self) -> None:
-        adapter = SampleGoAdapter()
-        parse_res = DummyGoParseResult(
-            imports=[DummyGoImport(path="github.com/tmc/langchaingo")]
-        )
-        nodes = adapter.extract("package main", "main.go", parse_res)
-        assert len(nodes) == 1
-        assert nodes[0].component_type == ComponentType.FRAMEWORK
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ('"gpt-4o"', "gpt-4o"),
+        ("`gpt-4o-mini`", "gpt-4o-mini"),
+        (" 'claude-sonnet' ", "claude-sonnet"),
+        (" plain ", "plain"),
+        (None, ""),
+        (42, ""),
+        (True, ""),
+        (["gpt-4o"], ""),
+        ({"model": "gpt-4o"}, ""),
+        ("$runtimeModel", ""),
+    ],
+)
+def test_clean_handles_parser_value_types(value: object, expected: str) -> None:
+    assert SampleGoAdapter._clean(value) == expected
 
-    def test_extract_returns_empty_when_not_handled(self) -> None:
-        adapter = SampleGoAdapter()
-        parse_res = DummyGoParseResult(imports=[DummyGoImport(path="net/http")])
-        nodes = adapter.extract("package main", "main.go", parse_res)
-        assert nodes == []
+
+def test_resolve_uses_real_named_and_positional_parser_arguments() -> None:
+    result = parse_go(
+        """package main
+
+const modelName = "gpt-4o-mini"
+
+func build() {
+    request := openai.ChatCompletionRequest{
+        Model: modelName,
+        Temperature: 1,
+        Stream: true,
+        Metadata: map[string]string{"team": "security"},
+        Optional: nil,
+    }
+    client := openai.NewClient(modelName, true, 5)
+    unresolved := openai.ChatCompletionRequest{Model: runtimeModel}
+    _, _, _ = request, client, unresolved
+}
+""",
+        "main.go",
+    )
+    adapter = SampleGoAdapter()
+    requests = [
+        item for item in result.instantiations if item.class_name == "openai.ChatCompletionRequest"
+    ]
+    resolved_request = next(item for item in requests if item.args["Model"] == "gpt-4o-mini")
+    unresolved_request = next(item for item in requests if item.args["Model"] == "$runtimeModel")
+    constructor = next(
+        item for item in result.instantiations if item.class_name == "openai.NewClient"
+    )
+    call = next(item for item in result.function_calls if item.full_name == "openai.NewClient")
+
+    assert adapter._resolve(resolved_request, "Missing", "Model") == "gpt-4o-mini"
+    assert adapter._resolve(constructor, 0) == "gpt-4o-mini"
+    assert adapter._resolve(call, 0) == "gpt-4o-mini"
+    assert adapter._resolve(resolved_request, "Temperature") == ""
+    assert adapter._resolve(resolved_request, "Stream") == ""
+    assert adapter._resolve(resolved_request, "Metadata") == ""
+    assert adapter._resolve(resolved_request, "Optional") == ""
+    assert adapter._resolve(unresolved_request, "Model") == ""
+    assert adapter._resolve(constructor, -1) == ""
+    assert adapter._resolve(constructor, 99) == ""
+
+
+def test_framework_node_preserves_import_provenance() -> None:
+    source = """package main
+
+import (
+    "github.com/tmc/langchaingo/llms"
+)
+"""
+    adapter = SampleGoAdapter()
+    result = parse_go(source, "main.go")
+    matched_import = adapter._matching_import(result)
+
+    assert matched_import is not None
+
+    node = adapter._fw_node("main.go", matched_import)
+
+    assert node.component_type == ComponentType.FRAMEWORK
+    assert node.canonical_name == "framework:langchaingo"
+    assert node.display_name == "Langchaingo"
+    assert node.adapter_name == "langchaingo"
+    assert node.file_path == "main.go"
+    assert node.line == 4
+    assert node.snippet == 'import "github.com/tmc/langchaingo/llms"'
+    assert node.evidence_kind == "ast_import"
+    assert node.metadata["framework"] == "langchaingo"
+    assert node.metadata["language"] == "golang"
+
+
+def test_framework_node_preserves_import_alias() -> None:
+    adapter = SampleGoAdapter()
+    result = parse_go(
+        'package main\nimport lc "github.com/tmc/langchaingo"\n',
+        "main.go",
+    )
+    matched_import = adapter._matching_import(result)
+
+    assert matched_import is not None
+
+    node = adapter._fw_node("main.go", matched_import)
+
+    assert node.line == 2
+    assert node.snippet == 'import lc "github.com/tmc/langchaingo"'
+
+
+def test_template_vars_support_common_go_and_prompt_forms() -> None:
+    template = (
+        "Hello {{ .Name }} from ${region}; input={input}; "
+        "owner={{ $owner }}; nested={{ .User.Name }}; again={{ .Name }}"
+    )
+
+    assert SampleGoAdapter._template_vars(template) == [
+        "Name",
+        "region",
+        "input",
+        "owner",
+        "User.Name",
+    ]
+
+
+def test_extract_remains_unimplemented() -> None:
+    adapter = SampleGoAdapter()
+    result = parse_go(
+        'package main\nimport "github.com/tmc/langchaingo"\n',
+        "main.go",
+    )
+
+    with pytest.raises(NotImplementedError):
+        adapter.extract(result.source, result.file_path, result)

--- a/nuguard/sbom/tests/test_go_adapter_base.py
+++ b/nuguard/sbom/tests/test_go_adapter_base.py
@@ -1,0 +1,92 @@
+"""Tests for the GoFrameworkAdapter base class."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from nuguard.sbom.adapters.go._go_base import GoFrameworkAdapter
+from nuguard.sbom.types import ComponentType
+
+
+@dataclass
+class DummyGoImport:
+    path: str
+
+
+@dataclass
+class DummyGoParseResult:
+    imports: list[DummyGoImport]
+
+
+class SampleGoAdapter(GoFrameworkAdapter):
+    name = "langchaingo"
+    module_path = "github.com/tmc/langchaingo"
+
+
+class TestGoFrameworkAdapterBase:
+    """Unit tests for GoFrameworkAdapter base functionality."""
+
+    def test_can_handle_matching_set(self) -> None:
+        adapter = SampleGoAdapter()
+        imports = {"github.com/tmc/langchaingo/llms", "fmt", "os"}
+        assert adapter.can_handle(imports) is True
+
+    def test_can_handle_non_matching_set(self) -> None:
+        adapter = SampleGoAdapter()
+        imports = {"github.com/gin-gonic/gin", "fmt"}
+        assert adapter.can_handle(imports) is False
+
+    def test_can_handle_parse_result_object(self) -> None:
+        adapter = SampleGoAdapter()
+        parse_res = DummyGoParseResult(
+            imports=[DummyGoImport(path="github.com/tmc/langchaingo/vectorstores")]
+        )
+        assert adapter.can_handle(parse_res) is True
+
+    def test_can_handle_invalid_input(self) -> None:
+        adapter = SampleGoAdapter()
+        assert adapter.can_handle(12345) is False  # type: ignore[arg-type]
+
+    def test_clean_string_literals(self) -> None:
+        adapter = SampleGoAdapter()
+        assert adapter._clean('"hello world"') == "hello world"
+        assert adapter._clean("`raw string`") == "raw string"
+        assert adapter._clean(" plain text ") == "plain text"
+
+    def test_resolve_variables(self) -> None:
+        adapter = SampleGoAdapter()
+        var_map = {"myVar": "gpt-4o"}
+        assert adapter._resolve("myVar", var_map) == "gpt-4o"
+        assert adapter._resolve('"literal"', var_map) == "literal"
+
+    def test_template_vars_extraction(self) -> None:
+        adapter = SampleGoAdapter()
+        prompt = "Hello {{ name }}, welcome to {{ location }}!"
+        vars_found = adapter._template_vars(prompt)
+        assert vars_found == ["name", "location"]
+
+    def test_framework_node_generation(self) -> None:
+        adapter = SampleGoAdapter()
+        node = adapter._fw_node("main.go")
+        assert node.component_type == ComponentType.FRAMEWORK
+        assert node.canonical_name == "framework:langchaingo"
+        assert node.display_name == "Langchaingo"
+        assert node.metadata["language"] == "golang"
+
+    def test_extract_returns_framework_node_when_handled(self) -> None:
+        adapter = SampleGoAdapter()
+        parse_res = DummyGoParseResult(
+            imports=[DummyGoImport(path="github.com/tmc/langchaingo")]
+        )
+        nodes = adapter.extract("package main", "main.go", parse_res)
+        assert len(nodes) == 1
+        assert nodes[0].component_type == ComponentType.FRAMEWORK
+
+    def test_extract_returns_empty_when_not_handled(self) -> None:
+        adapter = SampleGoAdapter()
+        parse_res = DummyGoParseResult(imports=[DummyGoImport(path="net/http")])
+        nodes = adapter.extract("package main", "main.go", parse_res)
+        assert nodes == []


### PR DESCRIPTION
## Summary

Supersedes #247 following a maintainer-approved handoff of #175.

This PR carries forward the original `GoFrameworkAdapter` implementation from commit `f2c747606ce36fea9dcca6b0cf735d87d69adcb2`, with the original authorship and attribution preserved. It addresses the outstanding review findings and adds integration coverage against the real `parse_go()` contract.

Thank you @luqmanbooso for the initial implementation.

## Changes

- Reuses the inherited `handles_imports` adapter convention.
- Uses case-sensitive exact-or-subpackage matching for Go module paths.
- Aligns `_resolve()` and `_clean()` with values produced by the Go parser.
- Rejects unresolved identifiers and unsupported structured values.
- Preserves import line, snippet, and `ast_import` evidence provenance.
- Keeps `extract()` unimplemented in the base class so incomplete adapters fail explicitly.
- Documents and tests the supported Go and prompt-template variable forms.
- Adds integration-style tests using `parse_go()`.

## Testing

- [x] `uv run ruff format --check nuguard/sbom/adapters/go/_go_base.py nuguard/sbom/tests/test_go_adapter_base.py`
- [x] `uv run ruff check nuguard/sbom/adapters/go/_go_base.py nuguard/sbom/tests/test_go_adapter_base.py`
- [x] `uv run mypy nuguard/sbom/adapters/go/_go_base.py`
- [x] `uv run pytest -q nuguard/sbom/tests/test_go_adapter_base.py`
- [x] `uv run pytest -q nuguard/sbom/tests/test_go_parser.py`
- [x] `uv run pytest -q nuguard/sbom/tests`
- [x] `make lint`
- [x] `uv run pytest`
- [x] `make precommit-run`

## Related issues

- Closes #175
- Supersedes #247
- Unblocks #176
- Unblocks #177