### PR TITLE
fix(validate): build agent_routing scenarios from component_type

### DIFF
--- a/nuguard/validate/runner.py
+++ b/nuguard/validate/runner.py
@@ -25,6 +25,7 @@ from nuguard.models.validate import (
 from nuguard.redteam.target.canary import CanaryConfig, CanaryScanner
 from nuguard.redteam.target.client import TargetAppClient
 from nuguard.redteam.target.session import AttackSession
+from nuguard.sbom.types import ComponentType
 from nuguard.validate.scenarios import build_scenarios
 
 if TYPE_CHECKING:
@@ -247,8 +248,8 @@ class ValidateRunner:
             try:
                 for node in self._sbom.nodes:
                     if (
-                        getattr(node, "node_type", None) == "AGENT"
-                        and getattr(node, "name", None)
+                        node.component_type == ComponentType.AGENT
+                        and node.name
                         and node.name not in cap_entries
                     ):
                         cap_entries[node.name] = CapabilityEntry(

--- a/nuguard/validate/scenarios.py
+++ b/nuguard/validate/scenarios.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from nuguard.common.logging import get_logger
 from nuguard.config import ValidateConfig
 from nuguard.models.validate import ValidateScenario, ValidateScenarioType
+from nuguard.sbom.types import ComponentType
 
 if TYPE_CHECKING:
     from nuguard.sbom.models import AiSbomDocument
@@ -63,7 +64,7 @@ def _agent_routing_scenarios_from_sbom(sbom: "AiSbomDocument") -> list[ValidateS
         agent_names = [
             node.name
             for node in sbom.nodes
-            if getattr(node, "node_type", None) == "AGENT" and getattr(node, "name", None)
+            if node.component_type == ComponentType.AGENT and node.name
         ]
     except Exception:
         agent_names = []

--- a/nuguard/validate/tests/test_scenarios.py
+++ b/nuguard/validate/tests/test_scenarios.py
@@ -120,3 +120,53 @@ def test_boundary_assertion_forbid_pattern():
     )
     scenarios = build_scenarios(cfg)
     assert scenarios[0].forbid_pattern == r"\d{3}-\d{2}-\d{4}"
+
+
+def test_agent_routing_builds_one_scenario_per_agent_node():
+    """Regression: agent_routing must build scenarios from SBOM AGENT nodes.
+
+    Pre-fix, the workflow read a nonexistent ``node_type`` attribute on
+    ``Node`` (the field is ``component_type``), so it always produced zero
+    scenarios and logged a misleading "no AGENT nodes found" warning even
+    when the SBOM contained AGENT nodes.
+    """
+    from nuguard.sbom.models import AiSbomDocument, Node
+    from nuguard.sbom.types import ComponentType
+
+    nodes = [
+        Node(name="medical_triage_agent", component_type=ComponentType.AGENT, confidence=0.9),
+        Node(name="billing_agent", component_type=ComponentType.AGENT, confidence=0.8),
+        Node(name="payment_tool", component_type=ComponentType.TOOL, confidence=0.7),
+    ]
+    sbom = AiSbomDocument(
+        target="test-app",
+        generated_at="2026-08-18T00:00:00Z",
+        schema_version="1.0",
+        nodes=nodes,
+    )
+    scenarios = build_scenarios(_config(workflows=["agent_routing"]), sbom=sbom)
+
+    assert len(scenarios) == 2
+    assert all(s.scenario_type == ValidateScenarioType.AGENT_ROUTING for s in scenarios)
+    assert {s.target_agents[0] for s in scenarios} == {"medical_triage_agent", "billing_agent"}
+
+
+def test_agent_routing_excludes_non_agent_nodes():
+    """TOOL / MODEL nodes must not produce agent-routing scenarios."""
+    from nuguard.sbom.models import AiSbomDocument, Node
+    from nuguard.sbom.types import ComponentType
+
+    nodes = [
+        Node(name="triage_agent", component_type=ComponentType.AGENT, confidence=0.9),
+        Node(name="llm_model", component_type=ComponentType.MODEL, confidence=0.8),
+    ]
+    sbom = AiSbomDocument(
+        target="test-app",
+        generated_at="2026-08-18T00:00:00Z",
+        schema_version="1.0",
+        nodes=nodes,
+    )
+    scenarios = build_scenarios(_config(workflows=["agent_routing"]), sbom=sbom)
+
+    assert len(scenarios) == 1
+    assert scenarios[0].target_agents == ["triage_agent"]


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

## What

Fixes `nuguard validate --workflows agent_routing` silently no-oping.

- `nuguard/validate/scenarios.py` — `_agent_routing_scenarios_from_sbom` now filters SBOM nodes by `node.component_type == ComponentType.AGENT` instead of the nonexistent `node_type` attribute.
- `nuguard/validate/runner.py` — the AGENT capability-entry initialisation uses the same corrected comparison.

## Why

Reported in issue #302. `Node` (`nuguard/sbom/models.py`) has a `component_type: ComponentType` field, **no** `node_type` attribute. The old `getattr(node, "node_type", None) == "AGENT"` filter always matched zero nodes, so:

- `agent_routing` workflows produced **zero** scenarios and logged a misleading `"workflow 'agent_routing' requested but no AGENT nodes found in SBOM. Skipping."` warning — even when the SBOM contained AGENT nodes.
- `ValidateRunner` never seeded AGENT capability entries, so capability reporting omitted agents.

This is a silent false negative for agent-based applications: the documented agent-routing validation never ran.

## Root Cause

Stale attribute name: the consumer code was written against a `node_type` field that does not exist on the `Node` model. Both call sites were affected.

## How

Compare against the actual field — `node.component_type == ComponentType.AGENT` (`ComponentType` is a `str` enum with `AGENT = "AGENT"`, `nuguard/sbom/types.py`). Imported at top level in both modules.

## Test Steps

- [x] Reproduce on `main`: build an SBOM with AGENT nodes, call `build_scenarios(ValidateConfig(workflows=["agent_routing"]), sbom=...)` → zero scenarios + misleading warning.
- [x] Confirm on this branch: exactly one `AGENT_ROUTING` scenario per AGENT node; TOOL/MODEL nodes excluded.
- [x] Two regression tests added to `nuguard/validate/tests/test_scenarios.py` (both fail pre-fix, pass post-fix — verified in a temporary worktree).

## Checks

- [x] `make test` passes — focused suites green (`nuguard/validate/tests/` + `tests/cli/test_validate_command.py`: 35 passed)
- [x] `make lint` passes (`ruff check` + `mypy`) — clean
- [x] No unrelated reformatting: only the 3 logical hunks + new tests
- [x] Added/updated tests covering this change (regression test for the bug)

Fixes #302