### PR TITLE
feat(sbom): add Go LLM client adapters

### DIFF
--- a/nuguard/sbom/adapters/go/__init__.py
+++ b/nuguard/sbom/adapters/go/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from nuguard.sbom.adapters.go._go_base import GoFrameworkAdapter
+from nuguard.sbom.adapters.go.llm_clients import GoLLMClientsAdapter
 
-__all__ = ["GoFrameworkAdapter"]
+__all__ = ["GoFrameworkAdapter", "GoLLMClientsAdapter"]

--- a/nuguard/sbom/adapters/go/llm_clients.py
+++ b/nuguard/sbom/adapters/go/llm_clients.py
@@ -7,13 +7,16 @@ Detects FRAMEWORK and MODEL components from:
 - ``github.com/google/generative-ai-go``
 - ``github.com/ollama/ollama/api``
 
-Matching is suffix-based after an SDK import is confirmed so explicit aliases
-and the go-openai import-path / package-name mismatch still work. Unresolved
-parser values (``$runtimeModel``, ``$openai.GPT4o``) are not turned into MODEL
-nodes. ``ClientConfig.BaseURL`` values emit a proxy FRAMEWORK node using the
-same OpenAI-compatible table as the Python adapter. The current parser has no
+Matching is qualifier-aware: request and config structs must use the matched
+import's alias, a dot import, or the SDK's known package identifier
+(``openai``, not the ``go-openai`` module path). Unresolved parser values
+(``$runtimeModel``, ``$openai.GPT4o``) are not turned into MODEL nodes.
+``ClientConfig.BaseURL`` values emit a proxy FRAMEWORK node using the same
+OpenAI-compatible table as the Python adapter. The current parser has no
 client→config→request dataflow, so those URLs do not remap unrelated MODEL
-nodes. Field assignment after ``DefaultConfig`` is out of scope.
+nodes. Field assignment after ``DefaultConfig`` is out of scope. Google
+``GenerativeModel`` / ``EmbeddingModel`` calls are matched by method name
+only; the parser cannot prove receiver provenance.
 """
 
 from __future__ import annotations
@@ -67,6 +70,7 @@ def _resolve_provider_from_base_url(base_url: str) -> str | None:
 @dataclass(frozen=True)
 class _ProviderSpec:
     modules: tuple[str, ...]
+    package_ident: str
     request_types: tuple[str, ...]
     config_types: tuple[str, ...] = ()
     model_methods: tuple[str, ...] = ()
@@ -76,23 +80,27 @@ class _ProviderSpec:
 _PROVIDERS: dict[str, _ProviderSpec] = {
     "openai": _ProviderSpec(
         modules=("github.com/sashabaranov/go-openai",),
+        package_ident="openai",
         request_types=("ChatCompletionRequest", "CompletionRequest", "EmbeddingRequest"),
         config_types=("ClientConfig",),
         display_name="OpenAI",
     ),
     "anthropic": _ProviderSpec(
         modules=("github.com/anthropics/anthropic-sdk-go",),
+        package_ident="anthropic",
         request_types=("MessageNewParams", "MessageRequest"),
         display_name="Anthropic",
     ),
     "google": _ProviderSpec(
         modules=("github.com/google/generative-ai-go",),
+        package_ident="genai",
         request_types=(),
         model_methods=("GenerativeModel", "EmbeddingModel"),
         display_name="Google",
     ),
     "ollama": _ProviderSpec(
         modules=("github.com/ollama/ollama/api",),
+        package_ident="api",
         request_types=("ChatRequest", "GenerateRequest", "EmbedRequest"),
         display_name="Ollama",
     ),
@@ -115,10 +123,42 @@ _MODEL_METHOD_TO_PROVIDER: dict[str, str] = {
 }
 
 
-def _type_suffix(name: str) -> str:
-    """Return the identifier after the last package qualifier."""
+def _split_qualified_name(name: str) -> tuple[str, str]:
+    """Return ``(qualifier, type_suffix)`` for a Go type or constructor name."""
     cleaned = name.replace("*", "").replace("&", "").strip()
-    return cleaned.rsplit(".", 1)[-1] if cleaned else ""
+    if not cleaned:
+        return "", ""
+    if "." not in cleaned:
+        return "", cleaned
+    qualifier, suffix = cleaned.rsplit(".", 1)
+    return qualifier, suffix
+
+
+def _qualifier_matches(qualifier: str, matched_import: GoImport, package_ident: str) -> bool:
+    """Return whether *qualifier* is in scope for *matched_import*."""
+    alias = matched_import.alias
+    if alias == "_":
+        return False
+    if alias == ".":
+        return qualifier == ""
+    expected = alias if alias else package_ident
+    return qualifier == expected
+
+
+def _qualified_struct_provider(
+    class_name: str,
+    imported: dict[str, GoImport],
+    type_map: dict[str, str],
+) -> str | None:
+    """Return the SDK provider if *class_name* is a qualified known struct."""
+    qualifier, type_name = _split_qualified_name(class_name)
+    sdk_provider = type_map.get(type_name)
+    if sdk_provider is None or sdk_provider not in imported:
+        return None
+    spec = _PROVIDERS[sdk_provider]
+    if not _qualifier_matches(qualifier, imported[sdk_provider], spec.package_ident):
+        return None
+    return sdk_provider
 
 
 class GoLLMClientsAdapter(GoFrameworkAdapter):
@@ -161,16 +201,21 @@ class GoLLMClientsAdapter(GoFrameworkAdapter):
                     proxy_provider,
                     base_url,
                     result,
+                    imported,
                 )
             )
 
         for inst in result.instantiations:
             if inst.kind != "struct_literal":
                 continue
-            type_name = _type_suffix(inst.class_name)
-            sdk_provider = _REQUEST_TYPE_TO_PROVIDER.get(type_name)
-            if sdk_provider is None or sdk_provider not in imported:
+            sdk_provider = _qualified_struct_provider(
+                inst.class_name,
+                imported,
+                _REQUEST_TYPE_TO_PROVIDER,
+            )
+            if sdk_provider is None:
                 continue
+            type_name = _split_qualified_name(inst.class_name)[1]
             model_name = self._resolve(inst, "Model")
             if not model_name:
                 continue
@@ -236,7 +281,11 @@ class GoLLMClientsAdapter(GoFrameworkAdapter):
         for inst in parse_result.instantiations:
             if inst.kind != "struct_literal":
                 continue
-            if _CONFIG_TYPE_TO_PROVIDER.get(_type_suffix(inst.class_name)) != "openai":
+            if _qualified_struct_provider(
+                inst.class_name,
+                imported,
+                _CONFIG_TYPE_TO_PROVIDER,
+            ) != "openai":
                 continue
             url = self._resolve(inst, "BaseURL")
             proxy = _resolve_provider_from_base_url(url)
@@ -275,6 +324,7 @@ class GoLLMClientsAdapter(GoFrameworkAdapter):
         provider: str,
         base_url: str,
         parse_result: GoParseResult,
+        imported: dict[str, GoImport],
     ) -> ComponentDetection:
         """Emit a FRAMEWORK node for an OpenAI-compatible proxy BaseURL."""
         evidence = next(
@@ -282,7 +332,12 @@ class GoLLMClientsAdapter(GoFrameworkAdapter):
                 inst
                 for inst in parse_result.instantiations
                 if inst.kind == "struct_literal"
-                and _CONFIG_TYPE_TO_PROVIDER.get(_type_suffix(inst.class_name)) == "openai"
+                and _qualified_struct_provider(
+                    inst.class_name,
+                    imported,
+                    _CONFIG_TYPE_TO_PROVIDER,
+                )
+                == "openai"
                 and self._resolve(inst, "BaseURL") == base_url
             ),
             None,
@@ -333,7 +388,7 @@ class GoLLMClientsAdapter(GoFrameworkAdapter):
             priority=self.priority,
             confidence=0.90 if evidence_kind == "ast_instantiation" else 0.95,
             metadata={
-                "framework": provider,
+                "framework": sdk_provider,
                 "provider": provider,
                 "client_class": client_class,
                 "language": "golang",

--- a/nuguard/sbom/adapters/go/llm_clients.py
+++ b/nuguard/sbom/adapters/go/llm_clients.py
@@ -1,0 +1,361 @@
+"""Go adapters for direct LLM SDK client usage.
+
+Detects FRAMEWORK and MODEL components from:
+
+- ``github.com/sashabaranov/go-openai``
+- ``github.com/anthropics/anthropic-sdk-go``
+- ``github.com/google/generative-ai-go``
+- ``github.com/ollama/ollama/api``
+
+Matching is suffix-based after an SDK import is confirmed so explicit aliases
+and the go-openai import-path / package-name mismatch still work. Unresolved
+parser values (``$runtimeModel``, ``$openai.GPT4o``) are not turned into MODEL
+nodes. ``ClientConfig.BaseURL`` values emit a proxy FRAMEWORK node using the
+same OpenAI-compatible table as the Python adapter. The current parser has no
+client→config→request dataflow, so those URLs do not remap unrelated MODEL
+nodes. Field assignment after ``DefaultConfig`` is out of scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from nuguard.common.logging import get_logger
+
+from ...core.go_parser import GoImport, GoParseResult, parse_go
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection
+from ..models_kb import get_model_details, infer_provider
+from ._go_base import GoFrameworkAdapter
+
+_log = get_logger(__name__)
+
+# Kept in sync with the Python adapter's ``_BASE_URL_TO_PROVIDER`` table.
+_BASE_URL_TO_PROVIDER: list[tuple[str, str]] = [
+    ("api.groq.com", "groq"),
+    ("generativelanguage.googleapis.com", "google"),
+    ("aiplatform.googleapis.com", "google"),
+    ("localhost:11434", "ollama"),
+    ("127.0.0.1:11434", "ollama"),
+    ("0.0.0.0:11434", "ollama"),
+    ("api.anthropic.com", "anthropic"),
+    ("api.mistral.ai", "mistral"),
+    ("api.together.xyz", "togetherai"),
+    ("api.deepseek.com", "deepseek"),
+    ("openrouter.ai", "openrouter"),
+    ("api.cohere.ai", "cohere"),
+    ("inference.cerebras.ai", "cerebras"),
+    ("api.fireworks.ai", "fireworks"),
+    ("api.perplexity.ai", "perplexity"),
+]
+
+
+def _resolve_provider_from_base_url(base_url: str) -> str | None:
+    """Resolve a provider string from an OpenAI-compatible ``BaseURL`` value."""
+    if not base_url:
+        return None
+    url_lower = base_url.lower()
+    for substring, provider in _BASE_URL_TO_PROVIDER:
+        if substring in url_lower:
+            _log.debug("Go BaseURL %r → provider %r", base_url, provider)
+            return provider
+    return None
+
+
+@dataclass(frozen=True)
+class _ProviderSpec:
+    modules: tuple[str, ...]
+    request_types: tuple[str, ...]
+    config_types: tuple[str, ...] = ()
+    model_methods: tuple[str, ...] = ()
+    display_name: str = ""
+
+
+_PROVIDERS: dict[str, _ProviderSpec] = {
+    "openai": _ProviderSpec(
+        modules=("github.com/sashabaranov/go-openai",),
+        request_types=("ChatCompletionRequest", "CompletionRequest", "EmbeddingRequest"),
+        config_types=("ClientConfig",),
+        display_name="OpenAI",
+    ),
+    "anthropic": _ProviderSpec(
+        modules=("github.com/anthropics/anthropic-sdk-go",),
+        request_types=("MessageNewParams", "MessageRequest"),
+        display_name="Anthropic",
+    ),
+    "google": _ProviderSpec(
+        modules=("github.com/google/generative-ai-go",),
+        request_types=(),
+        model_methods=("GenerativeModel", "EmbeddingModel"),
+        display_name="Google",
+    ),
+    "ollama": _ProviderSpec(
+        modules=("github.com/ollama/ollama/api",),
+        request_types=("ChatRequest", "GenerateRequest", "EmbedRequest"),
+        display_name="Ollama",
+    ),
+}
+
+_REQUEST_TYPE_TO_PROVIDER: dict[str, str] = {
+    type_name: provider
+    for provider, spec in _PROVIDERS.items()
+    for type_name in spec.request_types
+}
+_CONFIG_TYPE_TO_PROVIDER: dict[str, str] = {
+    type_name: provider
+    for provider, spec in _PROVIDERS.items()
+    for type_name in spec.config_types
+}
+_MODEL_METHOD_TO_PROVIDER: dict[str, str] = {
+    method: provider
+    for provider, spec in _PROVIDERS.items()
+    for method in spec.model_methods
+}
+
+
+def _type_suffix(name: str) -> str:
+    """Return the identifier after the last package qualifier."""
+    cleaned = name.replace("*", "").replace("&", "").strip()
+    return cleaned.rsplit(".", 1)[-1] if cleaned else ""
+
+
+class GoLLMClientsAdapter(GoFrameworkAdapter):
+    """Detect direct Go usage of supported LLM client libraries."""
+
+    name = "llm_clients_go"
+    priority = 90
+    handles_imports = [
+        "github.com/sashabaranov/go-openai",
+        "github.com/anthropics/anthropic-sdk-go",
+        "github.com/google/generative-ai-go",
+        "github.com/ollama/ollama/api",
+    ]
+
+    def extract(
+        self,
+        content: str,
+        file_path: str,
+        parse_result: Any,
+    ) -> list[ComponentDetection]:
+        result = (
+            parse_result
+            if isinstance(parse_result, GoParseResult)
+            else parse_go(content, file_path)
+        )
+        imported = self._imported_providers(result)
+        if not imported:
+            return []
+
+        detections: list[ComponentDetection] = []
+        for provider, matched_import in imported.items():
+            detections.append(
+                self._provider_framework_node(file_path, matched_import, provider)
+            )
+
+        for base_url, proxy_provider in self._openai_proxy_configs(result, imported):
+            detections.append(
+                self._proxy_framework_node(
+                    file_path,
+                    proxy_provider,
+                    base_url,
+                    result,
+                )
+            )
+
+        for inst in result.instantiations:
+            if inst.kind != "struct_literal":
+                continue
+            type_name = _type_suffix(inst.class_name)
+            sdk_provider = _REQUEST_TYPE_TO_PROVIDER.get(type_name)
+            if sdk_provider is None or sdk_provider not in imported:
+                continue
+            model_name = self._resolve(inst, "Model")
+            if not model_name:
+                continue
+            detections.append(
+                self._model_node(
+                    file_path=file_path,
+                    model_name=model_name,
+                    sdk_provider=sdk_provider,
+                    client_class=type_name,
+                    line=inst.line,
+                    snippet=inst.source_snippet or f"{inst.class_name}{{Model: {model_name!r}}}",
+                    evidence_kind="ast_instantiation",
+                )
+            )
+
+        for call in result.function_calls:
+            sdk_provider = _MODEL_METHOD_TO_PROVIDER.get(call.function_name)
+            if sdk_provider is None or sdk_provider not in imported:
+                continue
+            model_name = self._resolve(call, 0)
+            if not model_name:
+                continue
+            detections.append(
+                self._model_node(
+                    file_path=file_path,
+                    model_name=model_name,
+                    sdk_provider=sdk_provider,
+                    client_class=call.function_name,
+                    line=call.line,
+                    snippet=call.source_snippet or f"{call.full_name}({model_name!r})",
+                    evidence_kind="ast_call",
+                )
+            )
+
+        return detections
+
+    def _imported_providers(self, parse_result: GoParseResult) -> dict[str, GoImport]:
+        """Return the first matching import for each supported SDK provider."""
+        imported: dict[str, GoImport] = {}
+        for item in parse_result.imports:
+            for provider, spec in _PROVIDERS.items():
+                if provider in imported:
+                    continue
+                if any(self._matches_module_path(item.path, module) for module in spec.modules):
+                    imported[provider] = item
+        return imported
+
+    def _openai_proxy_configs(
+        self,
+        parse_result: GoParseResult,
+        imported: dict[str, GoImport],
+    ) -> list[tuple[str, str]]:
+        """Return unique ``(BaseURL, proxy provider)`` pairs from ClientConfig literals.
+
+        The parser does not link a config to a later request, so these values
+        are used only for proxy FRAMEWORK nodes.
+        """
+        if "openai" not in imported:
+            return []
+
+        found: list[tuple[str, str]] = []
+        seen_providers: set[str] = set()
+        for inst in parse_result.instantiations:
+            if inst.kind != "struct_literal":
+                continue
+            if _CONFIG_TYPE_TO_PROVIDER.get(_type_suffix(inst.class_name)) != "openai":
+                continue
+            url = self._resolve(inst, "BaseURL")
+            proxy = _resolve_provider_from_base_url(url)
+            if not proxy or proxy in seen_providers:
+                continue
+            seen_providers.add(proxy)
+            found.append((url, proxy))
+        return found
+
+    def _provider_framework_node(
+        self,
+        file_path: str,
+        matched_import: GoImport,
+        provider: str,
+    ) -> ComponentDetection:
+        """Emit a per-SDK FRAMEWORK node using import provenance from ``_fw_node``."""
+        spec = _PROVIDERS[provider]
+        node = self._fw_node(
+            file_path,
+            matched_import,
+            display_name=spec.display_name or provider,
+        )
+        node.canonical_name = f"framework:{provider}"
+        node.metadata.update(
+            {
+                "framework": provider,
+                "provider": provider,
+                "client_kind": "llm_sdk",
+            }
+        )
+        return node
+
+    def _proxy_framework_node(
+        self,
+        file_path: str,
+        provider: str,
+        base_url: str,
+        parse_result: GoParseResult,
+    ) -> ComponentDetection:
+        """Emit a FRAMEWORK node for an OpenAI-compatible proxy BaseURL."""
+        evidence = next(
+            (
+                inst
+                for inst in parse_result.instantiations
+                if inst.kind == "struct_literal"
+                and _CONFIG_TYPE_TO_PROVIDER.get(_type_suffix(inst.class_name)) == "openai"
+                and self._resolve(inst, "BaseURL") == base_url
+            ),
+            None,
+        )
+        return ComponentDetection(
+            component_type=ComponentType.FRAMEWORK,
+            canonical_name=f"framework:{provider}",
+            display_name=provider,
+            adapter_name=self.name,
+            priority=self.priority,
+            confidence=0.88,
+            metadata={
+                "framework": provider,
+                "provider": provider,
+                "language": "golang",
+                "via_openai_proxy": True,
+                "base_url": base_url,
+            },
+            file_path=file_path,
+            line=evidence.line if evidence is not None else 0,
+            snippet=(
+                evidence.source_snippet
+                if evidence is not None and evidence.source_snippet
+                else f"ClientConfig{{BaseURL: {base_url!r}}}"
+            ),
+            evidence_kind="ast_instantiation",
+        )
+
+    def _model_node(
+        self,
+        *,
+        file_path: str,
+        model_name: str,
+        sdk_provider: str,
+        client_class: str,
+        line: int,
+        snippet: str,
+        evidence_kind: str,
+    ) -> ComponentDetection:
+        provider = self._effective_provider(model_name, sdk_provider)
+        details = get_model_details(model_name, provider)
+        canonical = canonicalize_text(model_name.lower())
+        return ComponentDetection(
+            component_type=ComponentType.MODEL,
+            canonical_name=canonical,
+            display_name=model_name,
+            adapter_name=self.name,
+            priority=self.priority,
+            confidence=0.90 if evidence_kind == "ast_instantiation" else 0.95,
+            metadata={
+                "framework": provider,
+                "provider": provider,
+                "client_class": client_class,
+                "language": "golang",
+                **{key: value for key, value in details.items() if value is not None},
+            },
+            file_path=file_path,
+            line=line,
+            snippet=snippet,
+            evidence_kind=evidence_kind,
+        )
+
+    @staticmethod
+    def _effective_provider(
+        model_name: str,
+        sdk_provider: str,
+    ) -> str:
+        if sdk_provider == "ollama":
+            return "ollama"
+        inferred = infer_provider(model_name)
+        if inferred != "unknown":
+            return inferred
+        return sdk_provider
+
+
+__all__ = ["GoLLMClientsAdapter"]

--- a/nuguard/sbom/adapters/registry.py
+++ b/nuguard/sbom/adapters/registry.py
@@ -36,11 +36,12 @@ def intake_candidates() -> tuple[IntakeCandidate, ...]:
 def default_framework_adapters() -> tuple[FrameworkAdapter, ...]:
     """Return all AST-aware framework adapters in priority order.
 
-    Includes both Python adapters (run against ``.py`` and ``.ipynb`` files)
-    and TypeScript adapters (run against ``.ts``, ``.tsx``, ``.js``, ``.jsx``
-    files).
+    Includes Python adapters (run against ``.py`` and ``.ipynb`` files),
+    TypeScript adapters (run against ``.ts``, ``.tsx``, ``.js``, ``.jsx``
+    files), and Go adapters (run against ``.go`` files).
     """
     from .data_classification import DataClassificationPythonAdapter
+    from .go import GoLLMClientsAdapter
     from .python import (
         AgnoAdapter,
         AutoGenAdapter,
@@ -105,6 +106,8 @@ def default_framework_adapters() -> tuple[FrameworkAdapter, ...]:
         PromptTSAdapter(),
         AgnoTSAdapter(),
         AzureAIAgentsTSAdapter(),
+        # Go adapters
+        GoLLMClientsAdapter(),
     ]
     return tuple(sorted(adapters, key=lambda a: (a.priority, canonicalize_text(a.name))))
 

--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -45,6 +45,7 @@ from ..adapters.base import (
 )
 from ..adapters.data_classification import DataClassificationSQLAdapter
 from ..adapters.dockerfile import DockerfileAdapter
+from ..adapters.go._go_base import GoFrameworkAdapter
 from ..adapters.iac import (
     BicepAdapter,
     CloudFormationAdapter,
@@ -72,6 +73,8 @@ from ..adapters.yaml_adapters import (
 )
 from ..config import AiSbomConfig
 from ..core.application_summary import build_scan_summary
+from ..core.go_parser import GoParseResult
+from ..core.go_parser import parse_go as _parse_go_impl
 from ..core.ts_parser import TSParseResult
 from ..core.ts_parser import parse_typescript as _parse_ts_impl
 from ..deps import DependencyScanner
@@ -100,6 +103,8 @@ _SQL_EXTENSIONS = {".sql"}
 _NOTEBOOK_EXTENSIONS = {".ipynb"}
 # TypeScript/JavaScript: tree-sitter (or regex fallback) via core/ts_parser
 _TYPESCRIPT_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx"}
+# Go: tree-sitter (or regex fallback) via core/go_parser
+_GO_EXTENSIONS = {".go"}
 # Dockerfile: extensionless file named "Dockerfile" or suffixed ".dockerfile"
 _DOCKERFILE_EXTENSIONS = {".dockerfile"}
 _DOCKERFILE_NAMES = {"dockerfile"}  # lower-cased stem match
@@ -740,6 +745,7 @@ class AiSbomExtractor:
             is_python = suffix in _PYTHON_EXTENSIONS
             is_notebook = suffix in _NOTEBOOK_EXTENSIONS
             is_typescript = suffix in _TYPESCRIPT_EXTENSIONS
+            is_go = suffix in _GO_EXTENSIONS
             is_sql = suffix in _SQL_EXTENSIONS
             is_dockerfile = (
                 suffix in _DOCKERFILE_EXTENSIONS or file_path.name.lower() in _DOCKERFILE_NAMES
@@ -781,8 +787,8 @@ class AiSbomExtractor:
                             if imp.module
                         }
                         for adapter in self.framework_adapters:
-                            # Skip TypeScript adapters for Python/notebook files
-                            if isinstance(adapter, TSFrameworkAdapter):
+                            # Skip TypeScript and Go adapters for Python/notebook files
+                            if isinstance(adapter, (TSFrameworkAdapter, GoFrameworkAdapter)):
                                 continue
                             if not adapter.can_handle(imported_modules):
                                 continue
@@ -852,6 +858,28 @@ class AiSbomExtractor:
                     except Exception as exc:
                         _log.warning(
                             "TS adapter %r failed on %s: %s",
+                            adapter.name,
+                            rel_path,
+                            exc,
+                        )
+                        continue
+                    for det in detections:
+                        self._merge_detection(node_map, det)
+
+            # Phase 1c-go: Go AST-aware framework adapters
+            elif is_go:
+                go_hints = self._parse_go(content, rel_path)
+                for adapter in self.framework_adapters:
+                    if not isinstance(adapter, GoFrameworkAdapter):
+                        continue
+                    if not adapter.can_handle(go_hints):
+                        continue
+                    _log.debug("running Go adapter %r on %s", adapter.name, rel_path)
+                    try:
+                        detections = adapter.extract(content, rel_path, go_hints)
+                    except Exception as exc:
+                        _log.warning(
+                            "Go adapter %r failed on %s: %s",
                             adapter.name,
                             rel_path,
                             exc,
@@ -1678,6 +1706,11 @@ class AiSbomExtractor:
     def _parse_typescript(content: str, file_path: str = "") -> TSParseResult:
         """Parse TypeScript/JavaScript via tree-sitter (or regex fallback)."""
         return _parse_ts_impl(content, file_path or None)
+
+    @staticmethod
+    def _parse_go(content: str, file_path: str = "") -> GoParseResult:
+        """Parse Go via tree-sitter (or regex fallback)."""
+        return _parse_go_impl(content, file_path)
 
     @staticmethod
     def _extract_notebook_python(content: str) -> str:

--- a/nuguard/sbom/tests/test_extraction.py
+++ b/nuguard/sbom/tests/test_extraction.py
@@ -486,6 +486,7 @@ class TestQuality:
             "crewai",
             "llamaindex",
             "llm_clients",
+            "llm_clients_go",
         } <= adapter_names
         assert {
             "langgraph_ts",

--- a/nuguard/sbom/tests/test_go_llm_clients.py
+++ b/nuguard/sbom/tests/test_go_llm_clients.py
@@ -1,0 +1,422 @@
+"""Tests for the Go LLM client adapter and extractor wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nuguard.sbom.adapters.base import ComponentDetection
+from nuguard.sbom.adapters.go.llm_clients import GoLLMClientsAdapter
+from nuguard.sbom.adapters.registry import default_framework_adapters
+from nuguard.sbom.config import AiSbomConfig
+from nuguard.sbom.core.go_parser import parse_go
+from nuguard.sbom.extractor import AiSbomExtractor
+from nuguard.sbom.types import ComponentType
+
+_ADAPTER = GoLLMClientsAdapter()
+
+
+def _extract(source: str, path: str = "main.go") -> list[ComponentDetection]:
+    return _ADAPTER.extract(source, path, parse_go(source, path))
+
+
+def _by_type(
+    detections: list[ComponentDetection],
+    component_type: ComponentType,
+) -> list[ComponentDetection]:
+    return [item for item in detections if item.component_type == component_type]
+
+
+def _frameworks(detections: list[ComponentDetection]) -> dict[str, ComponentDetection]:
+    return {
+        item.metadata["provider"]: item
+        for item in _by_type(detections, ComponentType.FRAMEWORK)
+    }
+
+
+def _models(detections: list[ComponentDetection]) -> dict[str, ComponentDetection]:
+    return {item.display_name: item for item in _by_type(detections, ComponentType.MODEL)}
+
+
+def test_adapter_is_registered() -> None:
+    names = {adapter.name for adapter in default_framework_adapters()}
+
+    assert "llm_clients_go" in names
+    assert _ADAPTER.priority == 90
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "github.com/sashabaranov/go-openai",
+        "github.com/anthropics/anthropic-sdk-go",
+        "github.com/google/generative-ai-go/genai",
+        "github.com/ollama/ollama/api",
+    ],
+)
+def test_can_handle_supported_modules(module_path: str) -> None:
+    result = parse_go(f'package main\nimport "{module_path}"\n', "main.go")
+
+    assert _ADAPTER.can_handle(result) is True
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "github.com/sashabaranov/go-openai2",
+        "github.com/tmc/langchaingo",
+        "github.com/ollama/ollama",
+        "github.com/openai/openai-go",
+        "google.golang.org/genai",
+    ],
+)
+def test_can_handle_rejects_unrelated_and_lookalike_modules(module_path: str) -> None:
+    result = parse_go(f'package main\nimport "{module_path}"\n', "main.go")
+
+    assert _ADAPTER.can_handle(result) is False
+
+
+def test_go_openai_chat_completion_string_model() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    detections = _extract(source)
+    frameworks = _frameworks(detections)
+    models = _models(detections)
+
+    assert "openai" in frameworks
+    assert frameworks["openai"].canonical_name == "framework:openai"
+    assert frameworks["openai"].metadata["language"] == "golang"
+    assert frameworks["openai"].metadata["framework"] == "openai"
+    assert frameworks["openai"].metadata["provider"] == "openai"
+    assert frameworks["openai"].metadata["client_kind"] == "llm_sdk"
+    assert frameworks["openai"].evidence_kind == "ast_import"
+    assert "gpt-4o" in models
+    assert models["gpt-4o"].metadata["provider"] == "openai"
+    assert models["gpt-4o"].metadata["framework"] == "openai"
+    assert models["gpt-4o"].metadata["language"] == "golang"
+    assert models["gpt-4o"].metadata["client_class"] == "ChatCompletionRequest"
+    assert models["gpt-4o"].evidence_kind == "ast_instantiation"
+    assert [item.canonical_name for item in _by_type(detections, ComponentType.FRAMEWORK)] == [
+        "framework:openai"
+    ]
+
+
+def test_go_openai_bare_new_client_is_framework_only() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    client := openai.NewClient("sk-test")
+    _ = client
+}
+"""
+    detections = _extract(source)
+
+    assert "openai" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_explicit_go_openai_alias_import() -> None:
+    source = """package main
+
+import oai "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = oai.ChatCompletionRequest{Model: "gpt-4o-mini"}
+}
+"""
+    detections = _extract(source)
+    frameworks = _frameworks(detections)
+
+    assert "gpt-4o-mini" in _models(detections)
+    assert frameworks["openai"].snippet == 'import oai "github.com/sashabaranov/go-openai"'
+
+
+def test_const_resolved_string_model() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+const modelName = "gpt-4o-mini"
+
+func main() {
+    _ = openai.ChatCompletionRequest{Model: modelName}
+}
+"""
+    detections = _extract(source)
+
+    assert "gpt-4o-mini" in _models(detections)
+
+
+def test_dynamic_model_does_not_emit_model_node() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.ChatCompletionRequest{Model: runtimeModel}
+}
+"""
+    detections = _extract(source)
+
+    assert "openai" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_sdk_constant_model_does_not_emit_model_node() -> None:
+    """Parser limitation: selector constants stay unresolved (``$openai.GPT4o``)."""
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.ChatCompletionRequest{Model: openai.GPT4o}
+}
+"""
+    detections = _extract(source)
+
+    assert "openai" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_anthropic_string_model() -> None:
+    source = """package main
+
+import "github.com/anthropics/anthropic-sdk-go"
+
+func main() {
+    _ = anthropic.MessageNewParams{Model: "claude-3-5-sonnet"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "anthropic" in _frameworks(detections)
+    assert "claude-3-5-sonnet" in models
+    assert models["claude-3-5-sonnet"].metadata["provider"] == "anthropic"
+
+
+def test_anthropic_message_request_string_model() -> None:
+    source = """package main
+
+import "github.com/anthropics/anthropic-sdk-go"
+
+func main() {
+    _ = anthropic.MessageRequest{Model: "claude-3-haiku"}
+}
+"""
+    detections = _extract(source)
+
+    assert "claude-3-haiku" in _models(detections)
+
+
+def test_google_generative_model_call() -> None:
+    source = """package main
+
+import "github.com/google/generative-ai-go/genai"
+
+func main() {
+    model := client.GenerativeModel("gemini-1.5-flash")
+    _ = model
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "google" in _frameworks(detections)
+    assert "gemini-1.5-flash" in models
+    assert models["gemini-1.5-flash"].metadata["provider"] == "google"
+    assert models["gemini-1.5-flash"].evidence_kind == "ast_call"
+    assert models["gemini-1.5-flash"].metadata["client_class"] == "GenerativeModel"
+
+
+def test_google_embedding_model_call() -> None:
+    source = """package main
+
+import "github.com/google/generative-ai-go/genai"
+
+func main() {
+    _ = client.EmbeddingModel("text-embedding-004")
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "text-embedding-004" in models
+    assert models["text-embedding-004"].metadata["provider"] == "google"
+
+
+def test_ollama_requests_keep_ollama_provider() -> None:
+    source = """package main
+
+import "github.com/ollama/ollama/api"
+
+func main() {
+    _ = api.ChatRequest{Model: "llama3.2"}
+    _ = api.GenerateRequest{Model: "llama3.2"}
+    _ = api.EmbedRequest{Model: "nomic-embed-text"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "ollama" in _frameworks(detections)
+    assert models["llama3.2"].metadata["provider"] == "ollama"
+    assert models["nomic-embed-text"].metadata["provider"] == "ollama"
+
+
+def test_client_config_base_url_emits_proxy_framework() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    cfg := openai.ClientConfig{
+        BaseURL: "https://api.groq.com/openai/v1",
+    }
+    _ = openai.NewClientWithConfig(cfg)
+}
+"""
+    detections = _extract(source)
+    frameworks = _frameworks(detections)
+
+    assert "openai" in frameworks
+    assert "groq" in frameworks
+    assert frameworks["groq"].metadata["via_openai_proxy"] is True
+    assert frameworks["groq"].metadata["base_url"] == "https://api.groq.com/openai/v1"
+    assert frameworks["groq"].metadata["language"] == "golang"
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_nested_client_config_emits_proxy_framework_without_remapping_model() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.NewClientWithConfig(openai.ClientConfig{
+        BaseURL: "https://api.groq.com/openai/v1",
+    })
+    _ = openai.ChatCompletionRequest{Model: "llama-3.3-70b-versatile"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "groq" in _frameworks(detections)
+    assert "llama-3.3-70b-versatile" in models
+    assert models["llama-3.3-70b-versatile"].metadata["provider"] != "groq"
+    assert "api.groq.com" not in (models["llama-3.3-70b-versatile"].metadata.get("api_endpoint") or "")
+
+
+def test_proxy_client_config_does_not_remap_unrelated_openai_model() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    cfg := openai.ClientConfig{
+        BaseURL: "https://api.groq.com/openai/v1",
+    }
+    _ = openai.NewClientWithConfig(cfg)
+    _ = openai.NewClient("sk-test")
+    _ = openai.ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+    frameworks = _frameworks(detections)
+
+    assert "openai" in frameworks
+    assert "groq" in frameworks
+    assert frameworks["groq"].metadata["via_openai_proxy"] is True
+    assert "gpt-4o" in models
+    assert models["gpt-4o"].metadata["provider"] == "openai"
+    assert models["gpt-4o"].metadata["framework"] == "openai"
+    assert "api.groq.com" not in (models["gpt-4o"].metadata.get("api_endpoint") or "")
+
+
+def test_localhost_ollama_base_url_mapping() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.ClientConfig{BaseURL: "http://localhost:11434/v1"}
+}
+"""
+    detections = _extract(source)
+    frameworks = _frameworks(detections)
+
+    assert "ollama" in frameworks
+    assert frameworks["ollama"].metadata["via_openai_proxy"] is True
+
+
+def test_default_config_field_assignment_is_not_invented() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    cfg := openai.DefaultConfig("sk-test")
+    cfg.BaseURL = "https://api.groq.com/openai/v1"
+    _ = openai.NewClientWithConfig(cfg)
+}
+"""
+    detections = _extract(source)
+
+    assert "openai" in _frameworks(detections)
+    assert "groq" not in _frameworks(detections)
+
+
+def test_local_type_without_sdk_import_is_ignored() -> None:
+    source = """package main
+
+type ChatCompletionRequest struct {
+    Model string
+}
+
+func main() {
+    _ = ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    detections = _extract(source)
+
+    assert detections == []
+    assert _ADAPTER.can_handle(parse_go(source, "main.go")) is False
+
+
+def test_extractor_go_file_emits_framework_and_model(tmp_path: Path) -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    (tmp_path / "main.go").write_text(source)
+    doc = AiSbomExtractor().extract_from_path(
+        tmp_path,
+        AiSbomConfig(include_extensions={".go"}, enable_llm=False),
+    )
+
+    adapters = {node.metadata.extras.get("adapter") for node in doc.nodes}
+    models = [node for node in doc.nodes if node.component_type == ComponentType.MODEL]
+    frameworks = [
+        node for node in doc.nodes if node.component_type == ComponentType.FRAMEWORK
+    ]
+
+    assert "llm_clients_go" in adapters
+    assert any(node.metadata.extras.get("provider") == "openai" for node in frameworks)
+    assert any(node.metadata.extras.get("language") == "golang" for node in frameworks)
+    assert any("gpt-4o" in node.name.lower() for node in models)
+    assert any(node.metadata.extras.get("provider") == "openai" for node in models)

--- a/nuguard/sbom/tests/test_go_llm_clients.py
+++ b/nuguard/sbom/tests/test_go_llm_clients.py
@@ -202,6 +202,7 @@ func main() {
     assert "anthropic" in _frameworks(detections)
     assert "claude-3-5-sonnet" in models
     assert models["claude-3-5-sonnet"].metadata["provider"] == "anthropic"
+    assert models["claude-3-5-sonnet"].metadata["framework"] == "anthropic"
 
 
 def test_anthropic_message_request_string_model() -> None:
@@ -234,6 +235,7 @@ func main() {
     assert "google" in _frameworks(detections)
     assert "gemini-1.5-flash" in models
     assert models["gemini-1.5-flash"].metadata["provider"] == "google"
+    assert models["gemini-1.5-flash"].metadata["framework"] == "google"
     assert models["gemini-1.5-flash"].evidence_kind == "ast_call"
     assert models["gemini-1.5-flash"].metadata["client_class"] == "GenerativeModel"
 
@@ -270,7 +272,9 @@ func main() {
 
     assert "ollama" in _frameworks(detections)
     assert models["llama3.2"].metadata["provider"] == "ollama"
+    assert models["llama3.2"].metadata["framework"] == "ollama"
     assert models["nomic-embed-text"].metadata["provider"] == "ollama"
+    assert models["nomic-embed-text"].metadata["framework"] == "ollama"
 
 
 def test_client_config_base_url_emits_proxy_framework() -> None:
@@ -313,6 +317,8 @@ func main() {
 
     assert "groq" in _frameworks(detections)
     assert "llama-3.3-70b-versatile" in models
+    assert models["llama-3.3-70b-versatile"].metadata["framework"] == "openai"
+    assert models["llama-3.3-70b-versatile"].metadata["provider"] == "meta"
     assert models["llama-3.3-70b-versatile"].metadata["provider"] != "groq"
     assert "api.groq.com" not in (models["llama-3.3-70b-versatile"].metadata.get("api_endpoint") or "")
 
@@ -392,6 +398,146 @@ func main() {
 
     assert detections == []
     assert _ADAPTER.can_handle(parse_go(source, "main.go")) is False
+
+
+def test_local_unqualified_chat_request_is_not_ollama_model() -> None:
+    source = """package main
+
+import "github.com/ollama/ollama/api"
+
+type ChatRequest struct {
+    Model string
+}
+
+func main() {
+    _ = ChatRequest{Model: "local-model"}
+}
+"""
+    detections = _extract(source)
+
+    assert "ollama" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_local_unqualified_chat_completion_request_is_not_openai_model() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+type ChatCompletionRequest struct {
+    Model string
+}
+
+func main() {
+    _ = ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    detections = _extract(source)
+
+    assert "openai" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_aliased_openai_request_is_detected() -> None:
+    source = """package main
+
+import oai "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = oai.ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "gpt-4o" in models
+    assert models["gpt-4o"].metadata["framework"] == "openai"
+    assert models["gpt-4o"].metadata["provider"] == "openai"
+
+
+def test_dot_imported_openai_request_is_detected() -> None:
+    source = """package main
+
+import . "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = ChatCompletionRequest{Model: "gpt-4o"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "gpt-4o" in models
+    assert models["gpt-4o"].metadata["framework"] == "openai"
+    assert models["gpt-4o"].metadata["provider"] == "openai"
+
+
+def test_wrong_qualifier_is_not_attributed_to_imported_sdk() -> None:
+    source = """package main
+
+import "github.com/ollama/ollama/api"
+
+func main() {
+    _ = local.ChatRequest{Model: "local-model"}
+}
+"""
+    detections = _extract(source)
+
+    assert "ollama" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_blank_import_does_not_match_unqualified_request() -> None:
+    source = """package main
+
+import _ "github.com/ollama/ollama/api"
+
+func main() {
+    _ = ChatRequest{Model: "local-model"}
+}
+"""
+    detections = _extract(source)
+
+    assert "ollama" in _frameworks(detections)
+    assert _by_type(detections, ComponentType.MODEL) == []
+
+
+def test_openai_sdk_llama_model_keeps_openai_framework() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+func main() {
+    _ = openai.ChatCompletionRequest{Model: "llama3.2"}
+}
+"""
+    detections = _extract(source)
+    models = _models(detections)
+
+    assert "llama3.2" in models
+    assert models["llama3.2"].metadata["framework"] == "openai"
+    assert models["llama3.2"].metadata["provider"] == "meta"
+    assert len(_by_type(detections, ComponentType.MODEL)) == 1
+
+
+def test_local_unqualified_client_config_is_not_proxy_framework() -> None:
+    source = """package main
+
+import "github.com/sashabaranov/go-openai"
+
+type ClientConfig struct {
+    BaseURL string
+}
+
+func main() {
+    _ = ClientConfig{BaseURL: "https://api.groq.com/openai/v1"}
+}
+"""
+    detections = _extract(source)
+    frameworks = _frameworks(detections)
+
+    assert "openai" in frameworks
+    assert "groq" not in frameworks
 
 
 def test_extractor_go_file_emits_framework_and_model(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add Go LLM client SBOM detection for go-openai, Anthropic, Google Generative AI, and Ollama
- emit provider-attributed FRAMEWORK and MODEL nodes using the shared model knowledge base
- detect supported go-openai ClientConfig BaseURL proxy usage without inventing unsupported dataflow
- wire GoFrameworkAdapter implementations into AiSbomExtractor for real `.go` scans
- add focused provider, proxy, negative, registry, and end-to-end extraction coverage

## Validation

- `uv run pytest nuguard/sbom/tests/test_go_llm_clients.py -v` — 28 passed
- Go parser/base/extraction tests — 92 passed
- `uv run ruff check ...` — passed
- `uv run mypy ...` — passed
- `make test` — 2062 passed, 34 skipped, 7 warnings
- `git diff --check` — clean

## Known parser limitations

- SDK selector constants such as `openai.GPT4o` remain unresolved and do not emit MODEL nodes
- selector assignments such as `cfg.BaseURL = ...` are not represented by the current Go parser
- dynamic/non-const model values are not invented

Closes #176