### PR TITLE
fix(policy): build the LLM client from config in policy check --llm

### DIFF
--- a/nuguard/cli/commands/policy.py
+++ b/nuguard/cli/commands/policy.py
@@ -363,12 +363,24 @@ def check(
         fw_name = framework or "custom"
         _console.print(f"\n[bold]Running compliance assessment:[/bold] {fw_name} …")
 
+        llm_client = None
+        if enable_llm:
+            from nuguard.common.llm_client import LLMClient
+
+            _model = cfg.litellm_model or ""
+            llm_client = LLMClient(
+                model=cfg.litellm_model,
+                api_key=cfg.litellm_api_key,
+                api_base=cfg.litellm_api_base if _model.startswith("azure") else None,
+            )
+
         try:
             assessment = asyncio.run(
                 run_compliance_assessment(
                     doc,
                     framework=fw_name,
                     enable_llm=enable_llm,
+                    llm=llm_client,
                 )
             )
         except Exception as exc:

--- a/tests/cli/test_policy_cli.py
+++ b/tests/cli/test_policy_cli.py
@@ -340,6 +340,60 @@ def test_check_compliance_framework(sbom_file: Path) -> None:
     assert result.exit_code in (0, 1, 2), result.output
 
 
+def test_check_llm_builds_client_from_config(
+    sbom_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--llm`` must honour nuguard.yaml llm.model instead of the Gemini default (#325)."""
+    import nuguard.common.llm_client as llm_client_mod
+    import nuguard.policy.assessment as assessment_mod
+
+    captured: dict[str, object] = {}
+
+    class _RecordingClient:
+        def __init__(
+            self,
+            model: str | None = None,
+            api_key: str | None = None,
+            api_base: str | None = None,
+        ) -> None:
+            captured["model"] = model
+            captured["api_key"] = api_key
+
+    class _FakeAssessment:
+        evaluations: list = []
+
+    async def _fake_assessment(doc, framework="custom", enable_llm=False, llm=None):
+        captured["llm"] = llm
+        return _FakeAssessment()
+
+    monkeypatch.setattr(llm_client_mod, "LLMClient", _RecordingClient)
+    monkeypatch.setattr(assessment_mod, "run_compliance_assessment", _fake_assessment)
+
+    cfg_file = tmp_path / "nuguard.yaml"
+    cfg_file.write_text(
+        "llm:\n  model: openai/gpt-4o-mini\n  api_key: sk-test\n", encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "policy",
+            "check",
+            "--sbom",
+            str(sbom_file),
+            "--framework",
+            "owasp-llm-top10",
+            "--llm",
+            "--config",
+            str(cfg_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert isinstance(captured["llm"], _RecordingClient)
+    assert captured["model"] == "openai/gpt-4o-mini"
+    assert captured["api_key"] == "sk-test"
+
+
 def test_check_missing_sbom_exits(policy_file: Path, tmp_path: Path) -> None:
     result = runner.invoke(
         app,


### PR DESCRIPTION
## Summary

\
uguard policy check --llm\ (compliance-framework assessment path) ignored \llm.model\ from \
uguard.yaml\: it called \un_compliance_assessment(...)\ without an \llm\ client, so \llm_synthesize\ fell back to a bare \LLMClient()\ and silently used the hardcoded Gemini default.

## Fix

Build the \LLMClient\ from config in the \check\ command — the same pattern \policy compile --llm\ already uses — and pass it through via \un_compliance_assessment(..., llm=llm_client)\.

## Testing

New CLI regression test (\	est_check_llm_builds_client_from_config\) asserts the assessment receives a client constructed with the configured model and API key. All 20 tests in \	ests/cli/test_policy_cli.py\ pass; ruff + mypy clean.

Fixes #325