### PR TITLE
feat(analysis): extend Go AI-security rules to streaming, credential options, and WithHTTPClient TLS flows

### DIFF
--- a/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
+++ b/nuguard/analysis/plugins/semgrep_rules/ai-security.yaml
@@ -176,6 +176,9 @@ rules:
   # Go AI/LLM security rules (issues #180 / #223)
   # #223 adds qualified official non-streaming SDK sinks; TLS / credential
   # option flows remain unchanged (WithHTTPClient follow-up).
+  # #232 extends coverage to official streaming call shapes, credential
+  # options (option.WithAPIKey and friends), and insecure-TLS flows wired
+  # through option.WithHTTPClient.
   # -------------------------------------------------------------------------
 
   - id: nuguard-go-llm-prompt-injection-sprintf
@@ -219,7 +222,7 @@ rules:
           - pattern: $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
       - requires: FORMATTED
         patterns:
           - pattern: $CLIENT.Chat.Completions.New($CTX, $REQ, ...)
@@ -238,6 +241,25 @@ rules:
       - requires: FORMATTED
         patterns:
           - pattern: $CLIENT.Models.GenerateContent($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
+      # Official streaming variants (#232)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Chat.Completions.NewStreaming($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Responses.NewStreaming($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Messages.NewStreaming($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.ConverseStream($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.InvokeModelWithResponseStream($CTX, $REQ, ...)
+      - requires: FORMATTED
+        patterns:
+          - pattern: $CLIENT.Models.GenerateContentStream($CTX, $MODEL, $CONTENTS, $CONFIG, ...)
     message: >
       Potential prompt injection: untrusted string input is interpolated into an
       LLM prompt via fmt.Sprintf and passed to an AI/LLM API call. Validate and
@@ -276,6 +298,15 @@ rules:
               metavariable: $KEY
               regex: '"(sk-|AIza)'
           - pattern-not: $CFG.ApiKey = os.Getenv(...)
+      # Official SDK credential options (#232) — option.WithAPIKey("sk-…") etc.
+      - patterns:
+          - pattern-either:
+              - pattern: option.WithAPIKey($KEY)
+              - pattern: option.WithToken($KEY)
+              - pattern: option.WithAuthToken($KEY)
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: '"(sk-|AIza)'
     message: >
       Hardcoded AI service API key or auth token detected. Store secrets in
       environment variables or a secrets manager. Never commit API keys to
@@ -294,12 +325,12 @@ rules:
           - pattern: $CLIENT.$METHOD(context.Background(), $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
       - patterns:
           - pattern: $CLIENT.$METHOD(context.TODO(), $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
       - patterns:
           - pattern: |
               $CTX := context.Background()
@@ -307,7 +338,7 @@ rules:
               $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
           - pattern-not: |
               $CTX := context.Background()
               ...
@@ -339,7 +370,7 @@ rules:
               $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
           - pattern-not: |
               $CTX := context.TODO()
               ...
@@ -371,7 +402,7 @@ rules:
               $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
           - pattern-not: |
               $CTX = context.Background()
               ...
@@ -403,7 +434,7 @@ rules:
               $CLIENT.$METHOD($CTX, $REQ)
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
           - pattern-not: |
               $CTX = context.TODO()
               ...
@@ -452,6 +483,23 @@ rules:
           - pattern: $CLIENT.InvokeModel(context.TODO(), $REQ, ...)
       - patterns:
           - pattern: $CLIENT.Models.GenerateContent(context.TODO(), $MODEL, $CONTENTS, $CONFIG, ...)
+      # Official streaming variants (#232) — direct literal-context calls.
+      # Escaped-context (context.WithTimeout) handling for qualified streaming
+      # shapes is covered by the generic $METHOD patterns above for unqualified
+      # receivers; qualified receivers only match the direct forms here.
+      - pattern-either:
+          - pattern: $CLIENT.Chat.Completions.NewStreaming(context.Background(), $REQ, ...)
+          - pattern: $CLIENT.Chat.Completions.NewStreaming(context.TODO(), $REQ, ...)
+          - pattern: $CLIENT.Responses.NewStreaming(context.Background(), $REQ, ...)
+          - pattern: $CLIENT.Responses.NewStreaming(context.TODO(), $REQ, ...)
+          - pattern: $CLIENT.Messages.NewStreaming(context.Background(), $REQ, ...)
+          - pattern: $CLIENT.Messages.NewStreaming(context.TODO(), $REQ, ...)
+          - pattern: $CLIENT.ConverseStream(context.Background(), $REQ, ...)
+          - pattern: $CLIENT.ConverseStream(context.TODO(), $REQ, ...)
+          - pattern: $CLIENT.InvokeModelWithResponseStream(context.Background(), $REQ, ...)
+          - pattern: $CLIENT.InvokeModelWithResponseStream(context.TODO(), $REQ, ...)
+          - pattern: $CLIENT.Models.GenerateContentStream(context.Background(), $MODEL, $CONTENTS, $CONFIG, ...)
+          - pattern: $CLIENT.Models.GenerateContentStream(context.TODO(), $MODEL, $CONTENTS, $CONFIG, ...)
       - patterns:
           - pattern: |
               $CTX := context.Background()
@@ -1188,7 +1236,7 @@ rules:
               }
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
       - patterns:
           - pattern: |
               func $FN(...) {
@@ -1212,7 +1260,7 @@ rules:
               }
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
       - patterns:
           - pattern: |
               func $FN(...) {
@@ -1232,7 +1280,7 @@ rules:
               }
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
       - patterns:
           - pattern: |
               func $FN(...) {
@@ -1252,7 +1300,53 @@ rules:
               }
           - metavariable-regex:
               metavariable: $METHOD
-              regex: ^(CreateChatCompletion|CreateCompletion|GenerateContent|CreateMessage|SendMessage|GenerateText)$
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
+      # option.WithHTTPClient flows (#232) — insecure transport wired directly
+      # into the official SDK client constructor via client options. The sink
+      # call is matched separately so qualified receivers (e.g.
+      # client.Models.GenerateContent) still bind.
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $TRANSPORT := &http.Transport{
+                  TLSClientConfig: &tls.Config{
+                    InsecureSkipVerify: true,
+                  },
+                }
+                ...
+                $HTTP := &http.Client{
+                  Transport: $TRANSPORT,
+                }
+                ...
+                $CLIENT := $NEW(..., option.WithHTTPClient($HTTP), ...)
+                ...
+              }
+          - pattern-either:
+              - pattern: $SINK.$METHOD($CTX, ...)
+              - pattern: $SINK.Models.$METHOD($CTX, ...)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
+      - patterns:
+          - pattern: |
+              func $FN(...) {
+                ...
+                $CLIENT := $NEW(..., option.WithHTTPClient(&http.Client{
+                  Transport: &http.Transport{
+                    TLSClientConfig: &tls.Config{
+                      InsecureSkipVerify: true,
+                    },
+                  },
+                }), ...)
+                ...
+              }
+          - pattern-either:
+              - pattern: $SINK.$METHOD($CTX, ...)
+              - pattern: $SINK.Models.$METHOD($CTX, ...)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(CreateChatCompletion|CreateCompletion|CreateChatCompletionStream|ConverseStream|InvokeModelWithResponseStream|GenerateContent|GenerateContentStream|CreateMessage|SendMessage|GenerateText)$
     message: >
       HTTP client TLS configuration disables certificate verification
       (InsecureSkipVerify: true) on an HTTP client assigned to a config that is

--- a/nuguard/analysis/tests/fixtures/semgrep_go/credential_options_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/credential_options_negative.go
@@ -1,0 +1,34 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"os"
+
+	"google.golang.org/genai"
+	"openai"
+)
+
+// Credential options sourced from the environment or holding non-secret
+// literals must not be reported (#232).
+
+func EnvSourcedCredentialOptions() {
+	client, err := openai.NewClient(
+		"https://api.example.com",
+		option.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
+	)
+	if err != nil {
+		return
+	}
+	_ = client
+}
+
+func EnvSourcedAuthToken() {
+	client := genai.NewClient(context.Background(), nil, option.WithAuthToken(os.Getenv("GEMINI_API_KEY")))
+	_ = client
+}
+
+// Non-credential literals do not match the key-prefix gate.
+func UnrelatedOptionLiteral() {
+	opts := option.WithEndpoint("https://api.example.com")
+	_ = opts
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/credential_options_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/credential_options_positive.go
@@ -1,0 +1,31 @@
+package semgrepfixtures
+
+import (
+	"context"
+
+	"google.golang.org/genai"
+	"openai"
+)
+
+// Hardcoded credentials passed through official SDK client options (#232).
+
+func HardcodedKeyViaWithAPIKey() {
+	client, err := openai.NewClient(
+		"https://api.example.com",
+		option.WithAPIKey("sk-SYNTHETIC_TEST_KEY_005"),
+	)
+	if err != nil {
+		return
+	}
+	_ = client
+}
+
+func HardcodedKeyViaWithAuthToken() {
+	client := genai.NewClient(context.Background(), nil, option.WithAuthToken("sk-SYNTHETIC_TEST_KEY_006"))
+	_ = client
+}
+
+func HardcodedGoogleKeyViaWithToken() {
+	client := genai.NewClient(context.Background(), nil, option.WithToken("AIzaSYNTHETIC_TEST_KEY_007"))
+	_ = client
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/http_client_option_negative.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/http_client_option_negative.go
@@ -1,0 +1,41 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"google.golang.org/genai"
+)
+
+// Secure or AI-unrelated option.WithHTTPClient flows must not be reported (#232).
+
+func SecureTLSViaWithHTTPClient() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: false,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	client := genai.NewClient(
+		context.Background(),
+		nil,
+		option.WithHTTPClient(httpClient),
+	)
+	_ = client
+}
+
+// InsecureSkipVerify on a client that never reaches an AI provider is out of scope.
+func InsecureTLSOnNonAIHTTPClient() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	resp, err := httpClient.Get("https://internal.example.com")
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/http_client_option_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/http_client_option_positive.go
@@ -1,0 +1,41 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"google.golang.org/genai"
+)
+
+// option.WithHTTPClient flows carrying an insecure TLS transport (#232).
+
+func InsecureTLSViaWithHTTPClientVariable() {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient := &http.Client{Transport: transport}
+	client := genai.NewClient(
+		context.Background(),
+		nil,
+		option.WithHTTPClient(httpClient),
+	)
+	client.Models.GenerateContentStream(context.Background(), "gemini-2.0-flash", "hello", nil)
+}
+
+func InsecureTLSViaWithHTTPClientLiteral() {
+	client := genai.NewClient(
+		context.Background(),
+		nil,
+		option.WithHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}),
+	)
+	client.Models.GenerateContent(context.Background(), "gemini-2.0-flash", "hello", nil)
+}

--- a/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_streaming_positive.go
+++ b/nuguard/analysis/tests/fixtures/semgrep_go/official_sdk_streaming_positive.go
@@ -1,0 +1,103 @@
+package semgrepfixtures
+
+import (
+	"context"
+	"fmt"
+)
+
+// Official SDK *streaming* call shapes (issue #232). Structural stand-ins,
+// not runnable and not vendored upstream source.
+
+type streamChatCompletions struct{}
+
+func (streamChatCompletions) New(ctx context.Context, req any, _ ...any) {}
+
+func (streamChatCompletions) NewStreaming(ctx context.Context, req any, _ ...any) {}
+
+type streamChatService struct {
+	Completions streamChatCompletions
+}
+
+type streamResponsesService struct{}
+
+func (streamResponsesService) NewStreaming(ctx context.Context, req any, _ ...any) {}
+
+type streamMessagesService struct{}
+
+func (streamMessagesService) New(ctx context.Context, req any, _ ...any) {}
+
+func (streamMessagesService) NewStreaming(ctx context.Context, req any, _ ...any) {}
+
+type streamModelsService struct{}
+
+func (streamModelsService) GenerateContent(ctx context.Context, model string, contents any, config any, _ ...any) {
+}
+
+func (streamModelsService) GenerateContentStream(ctx context.Context, model string, contents any, config any, _ ...any) {
+}
+
+type streamOpenAIClient struct {
+	Chat      streamChatService
+	Responses streamResponsesService
+}
+
+type streamAnthropicClient struct {
+	Messages streamMessagesService
+}
+
+type streamBedrockClient struct{}
+
+func (streamBedrockClient) ConverseStream(ctx context.Context, req any, _ ...any) {}
+
+func (streamBedrockClient) InvokeModelWithResponseStream(ctx context.Context, req any, _ ...any) {}
+
+type streamGeminiClient struct {
+	Models streamModelsService
+}
+
+// StreamingPromptInjectionOpenAI: user input -> fmt.Sprintf -> official
+// streaming sink = prompt-injection MATCH (#232).
+func StreamingPromptInjectionOpenAI(userInput string) {
+	client := streamOpenAIClient{}
+	prompt := fmt.Sprintf("Answer: %s", userInput)
+	stream := client.Chat.Completions.NewStreaming(context.Background(), prompt)
+	_ = stream
+}
+
+// StreamingMissingTimeoutAnthropic: context.Background() straight into an
+// official streaming sink = missing-timeout MATCH (#232).
+func StreamingMissingTimeoutAnthropic() {
+	client := streamAnthropicClient{}
+	client.Messages.NewStreaming(context.Background(), "hello")
+}
+
+// StreamingMissingTimeoutBedrockConverseStream = missing-timeout MATCH.
+func StreamingMissingTimeoutBedrockConverseStream() {
+	client := streamBedrockClient{}
+	client.ConverseStream(context.Background(), "hello")
+}
+
+// StreamingMissingTimeoutBedrockInvokeModelWithResponseStream = MATCH.
+func StreamingMissingTimeoutBedrockInvokeModelWithResponseStream() {
+	client := streamBedrockClient{}
+	client.InvokeModelWithResponseStream(context.Background(), "hello")
+}
+
+// StreamingPromptInjectionGemini: user input -> fmt.Sprintf ->
+// Models.GenerateContentStream = prompt-injection MATCH (#232).
+func StreamingPromptInjectionGemini(userInput string) {
+	client := streamGeminiClient{}
+	prompt := fmt.Sprintf("Summarize: %s", userInput)
+	it := client.Models.GenerateContentStream(context.Background(), "gemini-2.0-flash", prompt, nil)
+	_ = it
+}
+
+// StreamingBoundedContextIsNotReported: a timeout-bounded streaming call with
+// trusted input must not trip either rule.
+func StreamingBoundedContextIsNotReported(userInput string) {
+	client := streamOpenAIClient{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30)
+	defer cancel()
+	resp := client.Responses.NewStreaming(ctx, userInput)
+	_ = resp
+}

--- a/nuguard/analysis/tests/test_semgrep_go_rules.py
+++ b/nuguard/analysis/tests/test_semgrep_go_rules.py
@@ -253,6 +253,91 @@ class TestGoOfficialSdkSinks:
             _assert_no_rule(semgrep_findings, "official_sdk_negative.go", rule_id)
 
 
+class TestGoOfficialStreamingSinks:
+    """Issue #232: official SDK streaming call shapes."""
+
+    def test_streaming_prompt_injection(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "official_sdk_streaming_positive.go",
+            "nuguard-go-llm-prompt-injection-sprintf",
+        )
+        # Chat.Completions.NewStreaming and Models.GenerateContentStream.
+        assert lines == [63, 91]
+
+    def test_streaming_missing_timeout(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "official_sdk_streaming_positive.go",
+            "nuguard-go-llm-missing-context-timeout",
+        )
+        # NewStreaming x3, ConverseStream, InvokeModelWithResponseStream,
+        # GenerateContentStream.
+        assert lines == [63, 71, 77, 83, 91]
+
+    def test_bounded_context_streaming_not_reported(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        """A timeout-bounded streaming call with trusted input stays clean."""
+        for rule_id in (
+            "nuguard-go-llm-prompt-injection-sprintf",
+            "nuguard-go-llm-missing-context-timeout",
+        ):
+            hits = _rule_lines(semgrep_findings, "official_sdk_streaming_positive.go", rule_id)
+            assert 99 not in hits
+
+
+class TestGoCredentialOptions:
+    """Issue #232: hardcoded credentials via official client options."""
+
+    def test_positive_literal_options(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "credential_options_positive.go",
+            "nuguard-go-hardcoded-api-key",
+        )
+        # WithAPIKey("sk-…"), WithAuthToken("sk-…"), WithToken("AIza…").
+        assert lines == [15, 24, 29]
+
+    def test_negative_env_and_non_secret(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "credential_options_negative.go",
+            "nuguard-go-hardcoded-api-key",
+        )
+
+
+class TestGoInsecureTLSViaHTTPClientOption:
+    """Issue #232: InsecureSkipVerify wired through option.WithHTTPClient."""
+
+    def test_positive_variable_and_literal_transport(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        lines = _rule_lines(
+            semgrep_findings,
+            "http_client_option_positive.go",
+            "nuguard-go-llm-insecure-tls",
+        )
+        assert lines == [25, 40]
+
+    def test_negative_secure_and_non_ai(
+        self, semgrep_findings: dict[str, list[dict[str, object]]]
+    ) -> None:
+        _assert_no_rule(
+            semgrep_findings,
+            "http_client_option_negative.go",
+            "nuguard-go-llm-insecure-tls",
+        )
+
+
 class TestGoRuleInventory:
     def test_only_expected_go_rules_fire_on_fixtures(
         self, semgrep_findings: dict[str, list[dict[str, object]]]


### PR DESCRIPTION
## Summary

Extends the bundled Go Semgrep coverage per #232, keeping all existing rule IDs and the current community/provider-neutral + non-streaming official SDK behavior intact:

1. **Official streaming sinks** — prompt-injection taint rule and missing-context-timeout rule now cover \Chat.Completions.NewStreaming\, \Responses.NewStreaming\, \Messages.NewStreaming\, \ConverseStream\, \InvokeModelWithResponseStream\, and \Models.GenerateContentStream\ (plus \CreateChatCompletionStream\ in the generic METHOD patterns).
2. **Credential options** — \
uguard-go-hardcoded-api-key\ flags literal keys passed via \option.WithAPIKey(...)\, \option.WithToken(...)\, \option.WithAuthToken(...)\; env-sourced values remain clean.
3. **Insecure TLS via client options** — \
uguard-go-llm-insecure-tls\ detects \option.WithHTTPClient(...)\ carrying a transport with \InsecureSkipVerify: true\ into an AI provider client (variable and inline-literal forms). Provider-qualified patterns avoid overly broad matches.

## Testing

- New fixtures: \official_sdk_streaming_positive.go\, \credential_options_{positive,negative}.go\, \http_client_option_{positive,negative}.go\.
- New test classes pin exact match lines for each shape, including negatives (bounded context streaming, env-sourced creds, secure/non-AI HTTP clients).
- All 22 rule tests pass; every pre-existing fixture expectation is unchanged; ruff clean.

Fixes #232