### PR TITLE
fix(sbom): classify unqualified legacy OpenAIClient as Azure across unrelated imports

### DIFF
--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from bisect import bisect_right
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Iterable
 
 from ...core.csharp_parser import CSharpMethodDeclaration, CSharpParseResult
@@ -84,7 +84,13 @@ def find_calls(
     source: str,
     names: set[str] | None = None,
 ) -> list[CSharpCall]:
-    """Return call expressions whose simple name is in *names*, if supplied."""
+    """Return call expressions whose simple name is in *names*, if supplied.
+
+    Fluent chains (``a.B(x).C(y)``) are resolved before the *names* filter is
+    applied: ``C`` inherits the full preceding invocation expression as its
+    receiver and, when it has no assignment target of its own, the chain's
+    assignment target.
+    """
     masked = mask_non_code(source)
     calls: list[CSharpCall] = []
 
@@ -103,9 +109,6 @@ def find_calls(
         name = name.removeprefix("@")
 
         if name in _CONTROL_NAMES:
-            continue
-
-        if names is not None and name not in names:
             continue
 
         open_paren = match.end() - 1
@@ -152,7 +155,72 @@ def find_calls(
             )
         )
 
-    return calls
+    linked = _link_fluent_chains(masked, calls)
+
+    if names is None:
+        return linked
+
+    return [call for call in linked if call.name in names]
+
+
+def _link_fluent_chains(
+    masked: str,
+    calls: list[CSharpCall],
+) -> list[CSharpCall]:
+    """Link invocations joined by ``.`` / ``?.`` to their preceding call.
+
+    A chained call inherits the full preceding invocation expression as its
+    receiver (so ``mlContext.Transforms.Text(x).Fit(d)`` gives ``Fit`` a
+    receiver containing ``.Transforms``) and, absent its own assignment, the
+    chain's final target.
+    """
+    linked: list[CSharpCall] = []
+    prev_call: CSharpCall | None = None
+    prev_expression = ""
+
+    for call in calls:
+        receiver = call.receiver
+        assigned_to = call.assigned_to
+
+        joined = (
+            prev_call is not None
+            and re.fullmatch(r"\s*(?:\?\.|\.)\s*", masked[prev_call.end : call.start])
+            is not None
+        )
+
+        if joined and prev_call is not None:
+            receiver = prev_expression
+            if not assigned_to:
+                assigned_to = prev_call.assigned_to
+            expression = f"{prev_expression}.{_callee_head(call)}"
+        else:
+            expression = _base_expression(call)
+
+        expression = expression[:240]
+        linked.append(
+            replace(
+                call,
+                receiver=receiver,
+                assigned_to=assigned_to,
+            )
+        )
+        prev_call = linked[-1]
+        prev_expression = expression
+
+    return linked
+
+
+def _callee_head(call: CSharpCall) -> str:
+    """Reconstruct ``Name<Generic>(args)`` without any receiver prefix."""
+    generics = "".join(f"<{arg}>" for arg in call.generic_arguments)
+    return f"{call.callee.rsplit('.', 1)[-1]}{generics}({call.arguments_text})"
+
+
+def _base_expression(call: CSharpCall) -> str:
+    """Reconstruct one un-chained call expression from parsed parts."""
+    new_prefix = "new " if call.is_constructor else ""
+    receiver = f"{call.receiver}." if call.receiver else ""
+    return f"{new_prefix}{receiver}{_callee_head(call)}"
 
 
 def parse_arguments(

--- a/nuguard/sbom/adapters/csharp/aspnet_core.py
+++ b/nuguard/sbom/adapters/csharp/aspnet_core.py
@@ -266,6 +266,13 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 controller_attributes,
                 constants,
             )
+            if not action_route:
+                # A separate method-level [Route(...)] supplies the action
+                # template when the HTTP attribute carries none.
+                action_route = _route_attribute(
+                    method_attributes,
+                    constants,
+                )
             route = _combine_routes(
                 base_route,
                 action_route,
@@ -319,6 +326,9 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 result,
                 request_type,
             )
+            if not request_schema and request_name and request_type in _PRIMITIVE_TYPES:
+                # Synthesize a schema for body-bound primitive prompts.
+                request_schema = {request_name: request_type}
             chat_key = _chat_key(
                 request_schema,
                 body,
@@ -347,6 +357,7 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                     request_schema=(request_schema),
                     response_schema=(response_schema),
                     chat_key=chat_key,
+                    chat_payload_list=_chat_payload_is_list(request_schema, chat_key),
                     response_key=response_key,
                 )
             )
@@ -403,6 +414,9 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                 result,
                 request_type,
             )
+            if not request_schema and request_name and request_type in _PRIMITIVE_TYPES:
+                # Synthesize a schema for body-bound primitive prompts.
+                request_schema = {request_name: request_type}
             chat_key = _chat_key(
                 request_schema,
                 handler,
@@ -440,11 +454,32 @@ class CSharpAspNetCoreAdapter(CSharpFrameworkAdapter):
                     request_schema=(request_schema),
                     response_schema=(response_schema),
                     chat_key=chat_key,
+                    chat_payload_list=_chat_payload_is_list(request_schema, chat_key),
                     response_key=response_key,
                 )
             )
 
         return detections
+
+
+def _chat_payload_is_list(
+    schema: dict[str, str],
+    chat_key: str | None,
+) -> bool:
+    """Return True when the conversational payload field is collection-typed."""
+    if not chat_key:
+        return False
+
+    field_type = schema.get(chat_key, "")
+    return bool(
+        field_type.endswith("[]")
+        or re.search(
+            r"\b(?:List|IList|ICollection|IEnumerable|IReadOnlyCollection"
+            r"|IReadOnlyList|ReadOnlyCollection|ImmutableArray|ImmutableList"
+            r"|HashSet|ISet)<",
+            field_type,
+        )
+    )
 
 
 def _endpoint_node(
@@ -462,6 +497,7 @@ def _endpoint_node(
     response_schema: dict[str, str],
     chat_key: str | None,
     response_key: str | None,
+    chat_payload_list: bool = False,
 ) -> ComponentDetection:
     canonical = canonicalize_text(f"aspnet:endpoint:{http_method}:{route}")
     metadata: dict[str, Any] = {
@@ -480,7 +516,7 @@ def _endpoint_node(
 
     if chat_key:
         metadata["chat_payload_key"] = chat_key
-        metadata["chat_payload_list"] = False
+        metadata["chat_payload_list"] = chat_payload_list
 
     if response_key:
         metadata["response_text_key"] = response_key
@@ -664,7 +700,14 @@ def _combine_routes(
     action_name: str,
 ) -> str:
     controller = controller_name.removesuffix("Controller")
-    combined = "/".join(part.strip("/") for part in (base, action) if part.strip("/"))
+    # An absolute action template ("/x" or "~/x") overrides the
+    # controller-level route instead of concatenating with it.
+    if action.startswith("~"):
+        combined = action.lstrip("~")
+    elif action.startswith("/"):
+        combined = action
+    else:
+        combined = "/".join(part.strip("/") for part in (base, action) if part.strip("/"))
     combined = re.sub(
         r"\[controller\]",
         controller,
@@ -826,6 +869,22 @@ def _request_parameter(
         key=lambda item: not item[2],
     )
 
+    # An explicitly body-bound parameter defines the request shape even when
+    # primitive (e.g. [FromBody] string prompt).
+    for type_name, name, from_body in ordered:
+        if not from_body:
+            break
+
+        base = _base_type(type_name)
+
+        if base in _INFRASTRUCTURE_TYPES:
+            continue
+
+        if base.startswith("I") and len(base) > 1 and base[1].isupper():
+            continue
+
+        return base, name
+
     for type_name, name, _ in ordered:
         base = _base_type(type_name)
 
@@ -855,7 +914,6 @@ def _schema_for_type(
 
     if declaration is None:
         return {}
-
     schema: dict[str, str] = {}
     record_match = re.search(
         r"\((?P<params>[^()]*)\)",

--- a/nuguard/sbom/adapters/csharp/llm_clients.py
+++ b/nuguard/sbom/adapters/csharp/llm_clients.py
@@ -300,7 +300,13 @@ def _provider_for_call(
 ) -> str | None:
     receiver_text = receiver or ""
 
-    if name == "OpenAIClient" and (imported == {"azure"} or "Azure.AI.OpenAI" in receiver_text):
+    # An unqualified legacy OpenAIClient belongs to Azure.AI.OpenAI when that
+    # namespace is imported and the newer OpenAI namespace is not — unrelated
+    # providers (e.g. Anthropic) do not change the classification (#260).
+    if name == "OpenAIClient" and (
+        "Azure.AI.OpenAI" in receiver_text
+        or ("azure" in imported and "openai" not in imported)
+    ):
         return "azure"
 
     if name in _CLIENT_CLASSES:

--- a/nuguard/sbom/adapters/csharp/mlnet.py
+++ b/nuguard/sbom/adapters/csharp/mlnet.py
@@ -126,7 +126,10 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 )
                 continue
 
-            if ".Trainers" in receiver:
+            # Fluent chaining gives ``Fit`` a receiver containing the full
+            # preceding expression (e.g. "...Transforms.Text(x)"); ``Fit``
+            # must reach its own handler below, not be treated as a stage.
+            if ".Trainers" in receiver and call.name != "Fit":
                 if call.assigned_to:
                     estimator_variables.add(call.assigned_to)
 
@@ -165,7 +168,7 @@ class CSharpMLNetAdapter(CSharpFrameworkAdapter):
                 )
                 continue
 
-            if ".Transforms" in receiver:
+            if ".Transforms" in receiver and call.name != "Fit":
                 pipeline_id = call.assigned_to or f"line:{call.line}"
 
                 if call.assigned_to:

--- a/nuguard/sbom/adapters/csharp/semantic_kernel.py
+++ b/nuguard/sbom/adapters/csharp/semantic_kernel.py
@@ -24,6 +24,16 @@ _SERVICE_CALLS: dict[str, str] = {
     "AddOllamaChatCompletion": "ollama",
     "AddMistralChatCompletion": "mistral",
 }
+# Positional index of the plugin-name argument per registration method.
+# Type registrations take the name first; object and prompt-directory
+# registrations place it after the instance/path argument.
+_PLUGIN_NAME_POSITION: dict[str, int] = {
+    "AddFromObject": 1,
+    "ImportPluginFromObject": 1,
+    "AddFromPromptDirectory": 1,
+    "ImportPluginFromPromptDirectory": 1,
+}
+
 _PLUGIN_CALLS = {
     "AddFromType",
     "ImportPluginFromType",
@@ -193,7 +203,10 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
                 )
 
                 if not model_name:
-                    model_name = call.name.removeprefix("Add").removesuffix("ChatCompletion")
+                    # An unresolved model/deployment expression is not a model
+                    # identifier — deriving one from the registration method
+                    # would fabricate names like "AzureOpenAI" (#260).
+                    continue
 
                 canonical = canonicalize_text(model_name.lower())
                 details = get_model_details(
@@ -242,7 +255,9 @@ class CSharpSemanticKernelAdapter(CSharpFrameworkAdapter):
                         "name",
                     ),
                     constants,
-                    0,
+                    # Object and prompt-directory registrations place the
+                    # plugin name in positional argument one.
+                    _PLUGIN_NAME_POSITION.get(call.name, 0),
                 )
                 display = plugin_name or plugin_type or call.assigned_to or f"plugin_{call.line}"
                 canonical = canonicalize_text(f"semantic_kernel:plugin:{display}")

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -176,6 +176,49 @@ var direct = new ChatClient(
     assert models["gpt-4o"].relationships[0].relationship_type == "USES"
 
 
+def test_legacy_openaiclient_is_azure_when_azure_namespace_imported() -> None:
+    """Unqualified OpenAIClient classifies as Azure even with other providers (#260)."""
+    source = """using Azure.AI.OpenAI;
+using System.ClientModel;
+var client = new OpenAIClient(new Uri(endpoint), credential);
+var chat = client.GetChatClient("gpt-35-turbo");
+"""
+
+    models = _by_type(
+        _extract(
+            CSharpLLMClientsAdapter(),
+            source,
+        ),
+        ComponentType.MODEL,
+    )
+
+    assert any(
+        model.display_name == "gpt-35-turbo"
+        and model.metadata["framework"] == "azure_openai"
+        for model in models
+    )
+
+
+def test_legacy_openaiclient_stays_openai_when_openai_namespace_imported() -> None:
+    """Importing the newer OpenAI namespace keeps the openai classification."""
+    source = """using Azure.AI.OpenAI;
+using OpenAI.Chat;
+var client = new OpenAIClient(new Uri(endpoint), credential);
+var chat = client.GetChatClient("gpt-35-turbo");
+"""
+
+    models = _by_type(
+        _extract(
+            CSharpLLMClientsAdapter(),
+            source,
+        ),
+        ComponentType.MODEL,
+    )
+    target = next(model for model in models if model.display_name == "gpt-35-turbo")
+
+    assert target.metadata["framework"] == "openai"
+
+
 def test_llm_clients_detect_anthropic_model_constants() -> None:
     source = """using Anthropic;
 var client = new AnthropicClient(apiKey);

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -83,6 +83,57 @@ var actual = client.GetChatClient("gpt-4o");
     assert calls[0].name == "GetChatClient"
 
 
+def test_fluent_chain_preserves_receiver_and_assignment() -> None:
+    """A chained call inherits the preceding expression and chain target (#260)."""
+    source = (
+        'var pipeline = mlContext.Transforms.Text("x").Fit(data);\n'
+        "var model = new MyTrainer().Fit(data);\n"
+    )
+
+    fits = find_calls(source, {"Fit"})
+
+    assert len(fits) == 2
+
+    chained = next(call for call in fits if ".Transforms" in (call.receiver or ""))
+    assert chained.receiver == 'mlContext.Transforms.Text("x")'
+    assert chained.assigned_to == "pipeline"
+
+    constructed = next(call for call in fits if (call.receiver or "").startswith("new "))
+    assert constructed.receiver == "new MyTrainer()"
+    assert constructed.assigned_to == "model"
+
+
+def test_fluent_chain_links_across_name_filter() -> None:
+    """Chain linking works when intermediate calls are filtered out (#260)."""
+    source = 'var estimator = ml.Transforms.Text("x").Fit(data);\n'
+
+    fit = find_calls(source, {"Fit"})[0]
+
+    assert fit.receiver == 'ml.Transforms.Text("x")'
+    assert fit.assigned_to == "estimator"
+
+
+def test_mlnet_fits_trained_pipeline_model_from_fluent_chain() -> None:
+    """ML.NET emits a trained MODEL node for ``pipeline.Fit(...)`` chains."""
+    source = """using Microsoft.ML;
+var mlContext = new MLContext();
+var pipeline = mlContext.Transforms.Text("Features", "Text").Fit(data);
+"""
+
+    detections = _extract(
+        CSharpMLNetAdapter(),
+        source,
+    )
+    models = [
+        detection
+        for detection in detections
+        if detection.component_type == ComponentType.MODEL and detection.metadata.get("trained_model")
+    ]
+
+    assert len(models) == 1
+    assert models[0].display_name == "pipeline"
+
+
 def test_llm_clients_detect_azure_and_openai_models() -> None:
     source = """using Azure.AI.OpenAI;
 using OpenAI.Chat;

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -294,6 +294,63 @@ public class SearchPlugin
     )
 
 
+def test_semantic_kernel_skips_unresolved_model_registration() -> None:
+    """An unresolved model expression must not fabricate a model node (#260)."""
+    source = """using Microsoft.SemanticKernel;
+public class Svc
+{
+    public void Register(KernelBuilder builder)
+    {
+        builder.AddOpenAIChatCompletion(modelId, apiKey);
+    }
+}
+"""
+
+    detections = _extract(
+        CSharpSemanticKernelAdapter(),
+        source,
+    )
+    models = _by_type(
+        detections,
+        ComponentType.MODEL,
+    )
+
+    assert models == []
+    assert not any(
+        detection.display_name in {"OpenAI", "AzureOpenAI"}
+        for detection in detections
+    )
+
+
+def test_semantic_kernel_resolves_plugin_name_by_registration_overload() -> None:
+    """Object and prompt-directory registrations take the name from arg one (#260)."""
+    source = """using Microsoft.SemanticKernel;
+public class Svc
+{
+    public void Register(KernelBuilder builder, MyPlugin plugin)
+    {
+        builder.Plugins.AddFromType<MyPlugin>();
+        builder.Plugins.AddFromObject(plugin, "custom-name");
+        builder.Plugins.AddFromPromptDirectory("/prompts", "prompt-plugin");
+    }
+}
+class MyPlugin {}
+"""
+
+    tools = {
+        detection.display_name
+        for detection in _extract(
+            CSharpSemanticKernelAdapter(),
+            source,
+        )
+        if detection.component_type == ComponentType.TOOL
+    }
+
+    assert "MyPlugin" in tools
+    assert "custom-name" in tools
+    assert "prompt-plugin" in tools
+
+
 def test_semantic_kernel_ignores_unrelated_build_calls() -> None:
     source = """using Microsoft.SemanticKernel;
 var result = unrelated.Build();

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -680,3 +680,129 @@ app.MapPost(
     assert endpoint.metadata["auth_required"] is False
     assert endpoint.metadata["response_body_schema"] == {"Answer": "string"}
     assert endpoint.metadata["response_text_key"] == "Answer"
+
+
+def test_method_level_route_combined_with_http_attribute() -> None:
+    """A separate method-level [Route(...)] supplies the action template (#260)."""
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/[controller]")]
+public class ChatController : ControllerBase
+{
+    [Route("complete")]
+    [HttpPost]
+    public IActionResult Complete([FromBody] ChatRequest request)
+    {
+        return Ok(request);
+    }
+}
+"""
+
+    endpoints = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+            "ChatController.cs",
+        ),
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    assert endpoints[0].metadata["method"] == "POST"
+    assert endpoints[0].metadata["endpoint"] == "/api/Chat/complete"
+
+
+def test_absolute_action_route_overrides_controller_route() -> None:
+    """Action templates beginning with '/' or '~/' replace the base route (#260)."""
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/[controller]")]
+public class ChatController : ControllerBase
+{
+    [HttpGet("/complete")]
+    public IActionResult Complete()
+    {
+        return Ok("ok");
+    }
+
+    [HttpGet("~/prompt-status")]
+    public IActionResult PromptStatus()
+    {
+        return Ok("ok");
+    }
+}
+"""
+
+    endpoints = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+            "ChatController.cs",
+        ),
+        ComponentType.API_ENDPOINT,
+    )
+    routes = {endpoint.metadata["method"] + " " + endpoint.metadata["endpoint"] for endpoint in endpoints}
+
+    assert routes == {"GET /complete", "GET /prompt-status"}
+
+
+def test_chat_payload_list_reflects_collection_field() -> None:
+    """Collection-valued conversational fields emit chat_payload_list=true (#260)."""
+    source = """using Microsoft.AspNetCore.Mvc;
+public record Turn(string Role, string Content);
+public record ChatRequest(List<Message> Messages);
+public class Message {}
+[ApiController]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Chat(ChatRequest request)
+    {
+        return Ok(request);
+    }
+}
+"""
+
+    endpoints = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+            "ChatController.cs",
+        ),
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    assert endpoints[0].metadata["chat_payload_key"] == "Messages"
+    assert endpoints[0].metadata["chat_payload_list"] is True
+
+
+def test_from_body_primitive_prompt_is_preserved() -> None:
+    """[FromBody] string prompt defines the request shape and chat key (#260)."""
+    source = """using Microsoft.AspNetCore.Mvc;
+[ApiController]
+[Route("api/chat")]
+public class ChatController : ControllerBase
+{
+    [HttpPost("ask")]
+    public IActionResult Ask([FromBody] string prompt)
+    {
+        return Ok(prompt);
+    }
+}
+"""
+
+    endpoints = _by_type(
+        _extract(
+            CSharpAspNetCoreAdapter(),
+            source,
+            "ChatController.cs",
+        ),
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+    assert endpoints[0].metadata["request_body_schema"] == {"prompt": "string"}
+    assert endpoints[0].metadata["chat_payload_key"] == "prompt"
+    assert endpoints[0].metadata["chat_payload_list"] is False


### PR DESCRIPTION
## Summary

Part 4 (final) of the #260 hardening series: legacy `OpenAIClient` provider classification.

`_provider_for_call` required `Azure.AI.OpenAI` to be the **sole** imported AI provider before treating an unqualified legacy `OpenAIClient` as Azure. A file importing `Azure.AI.OpenAI` alongside any other AI provider fell through to the generic `OpenAIClient -> openai` mapping, misclassifying the client and every model resolved through it.

Now: classify as **azure** when `Azure.AI.OpenAI` is imported and the newer `OpenAI` namespace is not — unrelated providers (e.g. `Anthropic`, or plain framework imports) do not change the classification. When both namespaces are imported the ambiguity resolves to `openai` as before.

## Testing

2 new regression tests: azure classification with an unrelated import present (via a `GetChatClient` model node carrying `framework == "azure_openai"`), and the openai fallback when both namespaces are imported. All 41 adapter tests pass; full sbom suite green except two pre-existing unrelated csproj failures on main.

Part of #260
