### PR TITLE
fix(config): fall back to model defaults for scalar redteam fields with unset env vars

### DIFF
--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -251,6 +251,10 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                 flat["redteam_auth_login_flow"] = _shared_auth["login_flow"]
 
     # Redteam section — overrides shared target block when keys are present.
+    # Drop keys whose env-var interpolation resolved to None (unset ${VAR}
+    # without a ``:-default``) so scalar fields keep their model defaults
+    # instead of crashing validation as the literal string 'None' — matching
+    # the established credentials/LLM-block handling below.
     # Both `endpoint:` and `target_endpoint:` are accepted as aliases, mirroring
     # the shared ``target:`` block (which accepts both names). The shared block
     # already does this on lines 199-203; the override must accept the same
@@ -258,7 +262,7 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
     # in nuguard.yaml.example line 47) see their override take effect.
     # Precedence matches the shared block: ``endpoint`` wins over
     # ``target_endpoint`` when both are set in the same block.
-    redteam = data.get("redteam", {}) or {}
+    redteam = {k: v for k, v in (data.get("redteam", {}) or {}).items() if v is not None}
     if "target" in redteam:
         flat["target_url"] = redteam["target"]
     if "endpoint" in redteam:
@@ -293,7 +297,12 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
     if "min_impact_score" in redteam:
         flat["min_impact_score"] = float(redteam["min_impact_score"])
     if "scenarios" in redteam:
-        flat["redteam_scenarios"] = redteam["scenarios"]
+        scenarios = redteam["scenarios"]
+        if isinstance(scenarios, list):
+            # Unset ${VAR} entries resolve to None — drop them so the
+            # remaining explicit goals still run instead of failing validation.
+            scenarios = [s for s in scenarios if s is not None]
+        flat["redteam_scenarios"] = scenarios
     if "mcp_trusted_servers" in redteam:
         flat["mcp_trusted_servers"] = redteam["mcp_trusted_servers"]
     if "verbose" in redteam:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,14 @@ def _flatten(yaml_text: str) -> dict:
     return _flatten_yaml(data)
 
 
+def _expand_flatten(yaml_text: str) -> dict:
+    """Full pipeline: env expansion (mirroring load_config) then flatten."""
+    from nuguard.config import _expand_env_vars
+
+    data = yaml.safe_load(textwrap.dedent(yaml_text))
+    return _flatten_yaml(_expand_env_vars(data))
+
+
 class TestFlattenYamlValidateSection:
     def test_validate_target_goes_to_validate_config(self) -> None:
         flat = _flatten("""
@@ -702,11 +710,7 @@ class TestUnsetEnvVarNoneFiltering:
 
     @staticmethod
     def _expand_flatten(yaml_text: str) -> dict:
-        """Full pipeline: env expansion (mirroring load_config) then flatten."""
-        from nuguard.config import _expand_env_vars
-
-        data = yaml.safe_load(textwrap.dedent(yaml_text))
-        return _flatten_yaml(_expand_env_vars(data))
+        return _expand_flatten(yaml_text)
 
     def test_shared_headers_drop_unset_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MY_TENANT", raising=False)
@@ -779,3 +783,77 @@ class TestUnsetEnvVarNoneFiltering:
                 X-Tenant-Id: ${MY_TENANT:-fallback-tenant}
         """)
         assert flat["redteam_headers"] == {"X-Tenant-Id": "fallback-tenant"}
+
+
+class TestUnsetEnvVarScalarFields:
+    """Unset ${VAR} in scalar redteam fields must fall back to model defaults.
+
+    ``_flatten_yaml`` used to stringify the expanded ``None`` into the literal
+    'None', which Literal-typed fields rejected with a raw ValidationError and
+    path-valued fields carried into runtime as a directory literally named
+    ``None``.
+    """
+
+    def test_unset_guided_mutation_mode_keeps_model_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GMM", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              guided_mutation_mode: ${GMM}
+        """)
+        assert "redteam_guided_mutation_mode" not in flat
+        assert NuGuardConfig().redteam_guided_mutation_mode == "hard"
+
+    def test_set_env_var_still_applies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GMM", "soft")
+        flat = _expand_flatten("""
+            redteam:
+              guided_mutation_mode: ${GMM}
+        """)
+        assert flat["redteam_guided_mutation_mode"] == "soft"
+
+    def test_unset_scenario_entry_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_SCENARIO", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              scenarios:
+                - ${MY_SCENARIO}
+                - policy-violation
+        """)
+        assert flat["redteam_scenarios"] == ["policy-violation"]
+
+    def test_all_unset_scenario_entries_leave_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("MY_SCENARIO", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              scenarios:
+                - ${MY_SCENARIO}
+        """)
+        assert flat["redteam_scenarios"] == []
+
+    def test_unset_catalog_path_not_stringified(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CATALOG_PATH", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              catalog_path: ${CATALOG_PATH}
+        """)
+        assert "redteam_catalog_path" not in flat
+
+    def test_unset_prompt_cache_dir_not_stringified(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PCD", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              prompt_cache_dir: ${PCD}
+        """)
+        assert "redteam_prompt_cache_dir" not in flat
+
+    def test_unset_emit_pytest_dir_not_stringified(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EPD", raising=False)
+        flat = _expand_flatten("""
+            redteam:
+              emit_pytest_dir: ${EPD}
+        """)
+        assert "emit_pytest_dir" not in flat


### PR DESCRIPTION
## Summary

Re-applies #332's fix onto `develop` (that PR targets `main`, which has drifted
significantly from `develop`; cherry-picked here as a clean, verified apply).

An unset `${VAR}` in a scalar redteam field was stringified to the literal
`'None'` by `_flatten_yaml`, so `Literal`-typed fields (e.g.
`redteam.guided_mutation_mode`) rejected it with a raw `ValidationError`, and
path-valued fields (`catalog_path`, `prompt_cache_dir`, `emit_pytest_dir`)
carried the literal string `'None'` into runtime — e.g. `PromptCache.save`
would create a directory literally named `None`.

Fix: drop top-level `None` values from the `redteam` section before any
per-field handling runs (matching the established `credentials`/LLM-block
pattern), and filter `None` entries out of the `scenarios` list.

Fixes #295

## Testing

- Reproduced the crash against current `develop` before applying the fix
  (`redteam.guided_mutation_mode: ${GMM}` with `GMM` unset → raw
  `pydantic.ValidationError`).
- Confirmed the fix resolves it — falls back to the model default instead.
- `uv run ruff check nuguard/config.py` — clean.
- `uv run mypy nuguard/config.py` — clean.
- `uv run pytest tests/test_config.py` — 61 passed (includes the 7 new
  `TestUnsetEnvVarScalarFields` cases from #332).
- Full suite: `uv run pytest nuguard/ tests/` — 4065 passed, 71 skipped, 0
  failures.