### PR TITLE
MAIN - fix(sbom): preserve new prefix on chained C# constructor receivers

### DIFF
--- a/nuguard/sbom/adapters/csharp/_source.py
+++ b/nuguard/sbom/adapters/csharp/_source.py
@@ -133,6 +133,11 @@ def find_calls(
                 r"\1",
                 " ".join(source[chain_parent.start : chain_parent.end].strip().split()),
             )
+            # A constructor receiver keeps its ``new `` prefix so the
+            # reconstructed expression reads as a fresh instance even when
+            # it becomes a chained receiver (e.g. ``new MyTrainer().Fit``).
+            if chain_parent.is_constructor and not parent_expression.startswith("new "):
+                parent_expression = f"new {parent_expression}"
             receiver = f"{parent_expression}.{receiver}" if receiver else parent_expression
             snippet_start = chain_parent.start
 

--- a/nuguard/sbom/tests/test_csharp_framework_adapters.py
+++ b/nuguard/sbom/tests/test_csharp_framework_adapters.py
@@ -914,3 +914,31 @@ builder.Plugins.AddFromType<SearchPlugin>(
     }
 
     assert {"Weather", "Prompts", "Search"} <= tools
+
+
+def test_call_parser_preserves_new_prefix_on_chained_constructor() -> None:
+    """A constructor receiver keeps its ``new `` prefix when chained.
+
+    ``new MyTrainer().Fit(data)`` is a fluent chain whose ``Fit`` call
+    inherits the full preceding constructor invocation as its receiver;
+    the reconstructed receiver must stay ``new MyTrainer()`` (not drop the
+    ``new`` keyword), so downstream consumers can tell the receiver is a
+    fresh instance rather than an existing variable.
+    """
+    source = (
+        'var pipeline = mlContext.Transforms.Text("x").Fit(data);\n'
+        "var model = new MyTrainer().Fit(data);\n"
+    )
+
+    fits = find_calls(
+        source,
+        {"Fit"},
+    )
+
+    assert len(fits) == 2
+
+    constructed = next(
+        call for call in fits if (call.receiver or "").startswith("new ")
+    )
+    assert constructed.receiver == "new MyTrainer()"
+    assert constructed.assigned_to == "model"


### PR DESCRIPTION
## PR Type

<!--
Check exactly ONE box below. This is the single source of truth automation
reads to classify the PR (e.g. a GitHub Action looking for "[x] Bug fix" vs
"[x] Feature") — do not remove or rephrase these two lines.
-->
- [x] Bug fix
- [ ] Feature

## What

Preserve the ``new`` prefix when a C# fluent chain is reconstructed as a
receiver. For a chained constructor call such as ``new MyTrainer().Fit(data)``,
current ``find_calls`` links ``Fit`` to the reconstructed receiver
``"MyTrainer()"`` (the ``new`` keyword is dropped); it now yields
``"new MyTrainer()"``.

## Why

`find_calls` reconstructs a fluent-chain receiver from the source slice of the
parent call. For constructor-based chains that slice starts at the callee
identifier, so the ``new`` keyword is lost: a fresh constructor instance
becomes indistinguishable from a pre-existing variable to downstream adapter
consumers (e.g. ML.NET's ``Fit`` handling). This is a focused replacement for
the one genuinely missing behavior found while auditing #338 against current
main — a chained-constructor receiver keeps ``new``. It does not sync or
repair #338, which remains closed as superseded.

## Root Cause

In `find_calls`, the chained-receiver reconstruction
`source[chain_parent.start : chain_parent.end]` begins at the callee
identifier (past the ``new`` keyword). The parent call's
``is_constructor`` flag was not used when reassembling the receiver.

## How

In the fluent-chain branch of `find_calls`, when the chained parent
`is_constructor` is set and the reconstructed expression does not already
start with ``new ``, prepend ``new `` to the parent expression before
concatenating it as the receiver. The change is minimal and confined to
receiver reconstruction; no other call-parsing behavior is altered.

## Testing

- New regression test `test_call_parser_preserves_new_prefix_on_chained_constructor`
  asserts `receiver == "new MyTrainer()"` and `assigned_to == "model"` for the
  chained-constructor case.
- Confirmed the new test fails against pre-fix main (`StopIteration`) and
  passes with the fix.
- Full C# adapter suite: 42 passed, including the existing chained-receiver
  parametrized tests (`Kernel.CreateBuilder()...`, `ml.BinaryClassification...`).
- Lint: `ruff check` clean; type check: `mypy` clean on `_source.py`.

Fixes #260
