### PR TITLE
fix(behavior): render remediation for promoted gap findings in markdown

### DIFF
--- a/nuguard/behavior/report.py
+++ b/nuguard/behavior/report.py
@@ -43,6 +43,18 @@ _GAP_FALLBACK_REMEDIATION = {
 }
 
 
+def _escape_md_cell(value: Any) -> str:
+    """Escape *value* for safe embedding inside a Markdown table cell.
+
+    Pipes (``|``) break column boundaries and newlines create extra rows,
+    so both must be neutralised.  Non-string values are coerced to ``str``
+    first to guard against upstream type drift (gap findings are plain
+    dicts, not Pydantic-validated).
+    """
+    text = str(value) if value is not None else ""
+    return text.replace("|", "\\|").replace("\n", " ").replace("\r", "")
+
+
 def _gap_remediation_text(finding: dict[str, Any]) -> str:
     """Return the remediation text for a promoted gap finding.
 
@@ -56,7 +68,8 @@ def _gap_remediation_text(finding: dict[str, Any]) -> str:
         Remediation text, or an empty string when neither the finding nor the
         type template provides one.
     """
-    remediation = (finding.get("remediation") or "").strip()
+    raw = finding.get("remediation")
+    remediation = str(raw).strip() if raw else ""
     if remediation:
         return remediation
     ftype = finding.get("finding_type", "")
@@ -716,7 +729,10 @@ def to_markdown(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = No
                 sample = "; ".join(str(g)[:120] for g in (gf.get("gap_texts") or [gf.get("description", "")])[:3])
                 remediation = _gap_remediation_text(gf)
                 comp_display = f"{comp} ({fid})" if fid else comp
-                lines.append(f"| {comp_display} | {count} | {sample} | {remediation} |")
+                lines.append(
+                    f"| {_escape_md_cell(comp_display)} | {count} "
+                    f"| {_escape_md_cell(sample)} | {_escape_md_cell(remediation)} |"
+                )
             lines.append("")
 
     # Dynamic Analysis Findings (policy violations, canary hits — not gap aggregates)

--- a/nuguard/behavior/report.py
+++ b/nuguard/behavior/report.py
@@ -34,6 +34,38 @@ _MAX_DIAG_SNIPPET_CHARS = 800
 # excluded from the Dynamic Analysis Findings section.
 _GAP_FINDING_TYPES = frozenset({"CAPABILITY_GAP", "INTENT_MISALIGNMENT", "TOOL_CHAIN_BROKEN"})
 
+# Per-type fallback remediation used when a promoted gap finding carries no
+# remediation text (e.g. gap aggregation records predate remediation backfill).
+_GAP_FALLBACK_REMEDIATION = {
+    "CAPABILITY_GAP": "Verify {component} is correctly wired and returns expected output",
+    "INTENT_MISALIGNMENT": "Align {component} system prompt with application's stated purpose",
+    "TOOL_CHAIN_BROKEN": "Repair broken tool invocation chain in {component}",
+}
+
+
+def _gap_remediation_text(finding: dict[str, Any]) -> str:
+    """Return the remediation text for a promoted gap finding.
+
+    Prefers an explicit ``remediation`` value; falls back to the per-type
+    guidance template keyed off the finding type when it is missing.
+
+    Args:
+        finding: A gap-aggregated dynamic finding.
+
+    Returns:
+        Remediation text, or an empty string when neither the finding nor the
+        type template provides one.
+    """
+    remediation = (finding.get("remediation") or "").strip()
+    if remediation:
+        return remediation
+    ftype = finding.get("finding_type", "")
+    template = _GAP_FALLBACK_REMEDIATION.get(ftype, "")
+    if not template:
+        return ""
+    comp = finding.get("affected_component", "unknown")
+    return template.format(component=comp)
+
 
 def to_json(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = None) -> str:
     """Generate JSON report string.
@@ -675,15 +707,16 @@ def to_markdown(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = No
             label = ftype.replace("_", " ").title()
             lines.append(f"### {label}")
             lines.append("")
-            lines.append("| Component | Occurrences | Sample Gaps |")
-            lines.append("|---|---|---|")
+            lines.append("| Component | Occurrences | Sample Gaps | Remediation |")
+            lines.append("|---|---|---|---|")
             for gf in type_findings:
                 comp = gf.get("affected_component", "unknown")
                 fid = gf.get("finding_id", "")
                 count = gf.get("occurrence_count", 1)
                 sample = "; ".join(str(g)[:120] for g in (gf.get("gap_texts") or [gf.get("description", "")])[:3])
+                remediation = _gap_remediation_text(gf)
                 comp_display = f"{comp} ({fid})" if fid else comp
-                lines.append(f"| {comp_display} | {count} | {sample} |")
+                lines.append(f"| {comp_display} | {count} | {sample} | {remediation} |")
             lines.append("")
 
     # Dynamic Analysis Findings (policy violations, canary hits — not gap aggregates)

--- a/nuguard/behavior/tests/test_report.py
+++ b/nuguard/behavior/tests/test_report.py
@@ -485,6 +485,74 @@ def test_to_markdown_gap_summary_empty_remediation_falls_back():
     assert "Repair broken tool invocation chain in scraper" in md
 
 
+def test_to_markdown_gap_summary_escapes_pipe_in_remediation():
+    """Remediation text containing | must not break the Markdown table."""
+    result = _make_result(
+        dynamic_findings=[
+            {
+                "finding_id": "G-4",
+                "severity": "medium",
+                "title": "Capability Gap: router",
+                "description": "desc",
+                "finding_type": "CAPABILITY_GAP",
+                "affected_component": "router",
+                "occurrence_count": 1,
+                "remediation": "Route A | Route B | Route C",
+            }
+        ],
+        gap_aggregation_stats={"min_occurrences_threshold": 1},
+    )
+    md = to_markdown(result)
+    # The pipe must be escaped so the table stays valid (4 columns).
+    assert "Route A \\| Route B \\| Route C" in md
+
+
+def test_to_markdown_gap_summary_escapes_newline_in_remediation():
+    """Remediation text containing newlines must not produce extra table rows."""
+    result = _make_result(
+        dynamic_findings=[
+            {
+                "finding_id": "G-5",
+                "severity": "medium",
+                "title": "Intent Misalignment: agent",
+                "description": "desc",
+                "finding_type": "INTENT_MISALIGNMENT",
+                "affected_component": "agent",
+                "occurrence_count": 1,
+                "remediation": "Step one.\nStep two.\nStep three.",
+            }
+        ],
+        gap_aggregation_stats={"min_occurrences_threshold": 1},
+    )
+    md = to_markdown(result)
+    # Newlines should be collapsed into the cell, not create extra rows.
+    assert "Step one. Step two. Step three." in md
+    # Ensure no bare newline split the remediation across table rows.
+    assert "Step one.\n" not in md.split("## Dynamic")[0]
+
+
+def test_to_markdown_gap_summary_handles_non_string_remediation():
+    """Non-string remediation values (dict/list) must not crash the renderer."""
+    result = _make_result(
+        dynamic_findings=[
+            {
+                "finding_id": "G-6",
+                "severity": "medium",
+                "title": "Tool Chain Broken: svc",
+                "description": "desc",
+                "finding_type": "TOOL_CHAIN_BROKEN",
+                "affected_component": "svc",
+                "occurrence_count": 1,
+                "remediation": {"step": "fix the chain"},
+            }
+        ],
+        gap_aggregation_stats={"min_occurrences_threshold": 1},
+    )
+    # Must not raise AttributeError from .strip() on a dict.
+    md = to_markdown(result)
+    assert "Behavioral Gap Summary" in md
+
+
 def test_to_markdown_covered_components_tagged_matched_unmatched():
     verdicts = [
         {

--- a/nuguard/behavior/tests/test_report.py
+++ b/nuguard/behavior/tests/test_report.py
@@ -427,6 +427,64 @@ def test_to_markdown_uses_llm_authored_deviation_remediation_over_template():
     assert "Review the agent's system prompt and tool configuration" not in md
 
 
+def test_to_markdown_gap_summary_renders_remediation_and_fallback():
+    result = _make_result(
+        dynamic_findings=[
+            {
+                "finding_id": "G-1",
+                "severity": "medium",
+                "title": "Capability Gap: faq_retriever",
+                "description": "desc",
+                "finding_type": "CAPABILITY_GAP",
+                "affected_component": "faq_retriever",
+                "occurrence_count": 3,
+                "remediation": "Add a wheelchair-assistance entry to the FAQ knowledge base.",
+            },
+            {
+                "finding_id": "G-2",
+                "severity": "medium",
+                "title": "Intent Misalignment: doc_agent",
+                "description": "desc",
+                "finding_type": "INTENT_MISALIGNMENT",
+                "affected_component": "doc_agent",
+                "occurrence_count": 2,
+            },
+        ],
+        gap_aggregation_stats={
+            "raw_gap_observations": 5,
+            "unique_gap_observations": 4,
+            "min_occurrences_threshold": 1,
+        },
+    )
+    md = to_markdown(result)
+    assert "## Behavioral Gap Summary" in md
+    assert "| Component | Occurrences | Sample Gaps | Remediation |" in md
+    # Explicit remediation is rendered verbatim.
+    assert "Add a wheelchair-assistance entry to the FAQ knowledge base." in md
+    # Missing remediation falls back to the per-type guidance template.
+    assert "Align doc_agent system prompt with application's stated purpose" in md
+
+
+def test_to_markdown_gap_summary_empty_remediation_falls_back():
+    result = _make_result(
+        dynamic_findings=[
+            {
+                "finding_id": "G-3",
+                "severity": "medium",
+                "title": "Tool Chain Broken: scraper",
+                "description": "desc",
+                "finding_type": "TOOL_CHAIN_BROKEN",
+                "affected_component": "scraper",
+                "occurrence_count": 1,
+                "remediation": "",
+            }
+        ],
+        gap_aggregation_stats={"min_occurrences_threshold": 1},
+    )
+    md = to_markdown(result)
+    assert "Repair broken tool invocation chain in scraper" in md
+
+
 def test_to_markdown_covered_components_tagged_matched_unmatched():
     verdicts = [
         {


### PR DESCRIPTION
## Summary

The Behavioral Gap Summary section of the Behavior Markdown report aggregates dynamic findings by `(finding_type, affected_component)`. Each promoted finding carries a backfilled `remediation` value (via `remediation.analyzer` backfill), but the report table **dropped it** — so maintainers/users reading a gap summary saw the gap and its component but no guidance on what to do about it.

This change adds a **Remediation column** to the `Component | Occurrences | Sample Gaps` table. When a finding has no remediation text (e.g. gap aggregation records predate remediation backfill), the renderer falls back to the per-type guidance templates already used by the recommendations synthesizer (e.g. `Verify {component} is correctly wired and returns expected output` for `CAPABILITY_GAP`), so rows never render blank.

## Motivation / Issue

Closes #322. Acceptance criteria addressed:

1. ✅ A **Remediation column** is added to the Behavioral Gap Summary table.
2. ✅ When remediation is missing, the renderer applies per-type fallback guidance rather than leaving the cell blank.
3. ✅ The structure of the report is otherwise unchanged (existing sections/tables preserved).
4. ✅ Regression tests assert remediation presence and fallback in the gap summary rows for `CAPABILITY_GAP`, `INTENT_MISALIGNMENT`, and `TOOL_CHAIN_BROKEN`.

## Changes

- `nuguard/behavior/report.py`: add `_gap_remediation_text()` helper + per-type fallback map; render a `Remediation` column in the gap summary table.
- `nuguard/behavior/tests/test_report.py`: two regression tests (`test_to_markdown_gap_summary_renders_remediation_and_fallback`, `test_to_markdown_gap_summary_empty_remediation_falls_back`).

## Test Plan

- New tests fail on the pre-fix code (verified: `2 failed` against upstream `df7f5bae`), pass after the fix.
- `pytest nuguard/behavior/tests/test_report.py` → 34 passed.
- `pytest nuguard/behavior/` → 300 passed.
- `ruff check` and `mypy` clean on changed files.

## Checklist

- [x] Tests added and passing (narrow + full behavior suite)
- [x] Lint/type check clean
- [x] No unrelated changes (diff is limited to `report.py` + its test file)
