### PR TITLE
feat(probe): improve chat API endpoint detection

### DIFF
--- a/nuguard/common/discovery.py
+++ b/nuguard/common/discovery.py
@@ -218,6 +218,31 @@ _CAPABILITY_PROBE = (
 )
 
 
+def _detect_domain_from_text(text: str) -> str:
+    """Infer the app domain from an agent response's natural language.
+
+    Returns ``"airline"``, ``"banking"``, ``"healthcare"``, or ``""`` (unknown).
+    Used to upgrade the discovery plan when the SBOM use_case tag is generic.
+    """
+    lc = text.lower()
+    if any(k in lc for k in (
+        "flight", "booking", "check-in", "check in", "boarding",
+        "reservation", "departure", "arrival", "itinerary",
+    )):
+        return "airline"
+    if any(k in lc for k in (
+        "account", "balance", "transaction", "payment", "transfer",
+        "card", "credit", "debit", "deposit", "withdrawal",
+    )):
+        return "banking"
+    if any(k in lc for k in (
+        "appointment", "prescription", "doctor", "patient",
+        "clinic", "medication", "medical record",
+    )):
+        return "healthcare"
+    return ""
+
+
 def _domain_messages(use_case: str) -> list[str]:
     """Return the ordered list of primary (bulk-data) discovery messages."""
     lc = use_case.lower()
@@ -331,6 +356,21 @@ async def run_discovery_conversation(
 
         all_responses.append(response)
         _log.info("discovery turn %d response: %s", i + 1, response[:200])
+
+        # After turn 1: detect domain from agent's own words and upgrade the plan
+        # when the SBOM use_case was too generic to select domain-specific messages.
+        if i == 0 and not switched and _domain_messages(use_case) is _GENERIC_MESSAGES:
+            detected = _detect_domain_from_text(response)
+            if detected:
+                upgraded_primary = _domain_messages(detected)
+                task = _domain_task_messages(detected)
+                remaining = max_turns - 1
+                plan[1:] = [("primary", m) for m in upgraded_primary[:remaining]]
+                _log.info(
+                    "discovery: domain detected from agent response (%r) — "
+                    "upgrading to %s messages for remaining turns",
+                    response[:80], detected,
+                )
 
         # Tactical pivot: on first refusal, replace remaining turns with task-framed messages
         if _is_refusal(response) and not switched and i + 1 < len(plan):

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -336,8 +336,8 @@ async def _try_openapi_detection(
         try:
             data = resp.json()
         except Exception:
-            data = {}
-        if _looks_like_chat_response(data, known_response_key):
+            data = _try_read_first_streaming_json(resp) or {}
+        if _looks_like_chat_response(data, known_response_key) or _is_streaming_response(resp):
             _log.info("endpoint_probe: OpenAPI selected %s (key=%r, status=%d)", oa_path, oa_key, status)
             return oa_path, oa_key, oa_list
     elif 400 <= status < 500:
@@ -345,6 +345,49 @@ async def _try_openapi_detection(
         _log.info("endpoint_probe: OpenAPI selected %s (key=%r, status=%d)", oa_path, oa_key, status)
         return oa_path, oa_key, oa_list
     # 5xx — don't block; let the blind probe try this path too
+    return None
+
+
+_STREAMING_CONTENT_TYPES: frozenset[str] = frozenset({
+    "text/event-stream",
+    "application/x-ndjson",
+    "application/ndjson",
+    "application/jsonl",
+    "application/x-jsonlines",
+})
+
+
+def _is_streaming_response(resp: "httpx.Response") -> bool:
+    """Return True when the response Content-Type signals a streaming format."""
+    ct = resp.headers.get("content-type", "").lower().split(";")[0].strip()
+    return ct in _STREAMING_CONTENT_TYPES
+
+
+def _try_read_first_streaming_json(resp: "httpx.Response") -> "dict | None":
+    """Extract the first JSON object from an SSE or NDJSON response body.
+
+    Handles SSE (``data: {...}`` lines) and NDJSON (first non-empty line).
+    Returns ``None`` when the response is not a streaming type or unparseable.
+    """
+    if not _is_streaming_response(resp):
+        return None
+    try:
+        for line in resp.text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("data:"):  # SSE prefix
+                line = line[5:].strip()
+                if line == "[DONE]":
+                    continue
+            try:
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    return obj
+            except Exception:
+                continue
+    except Exception:
+        pass
     return None
 
 
@@ -425,9 +468,13 @@ async def _blind_probe(
                 try:
                     data = resp.json()
                 except Exception:
-                    data = {}
+                    data = _try_read_first_streaming_json(resp) or {}
                 if _looks_like_chat_response(data, known_response_key):
                     _log.info("endpoint_probe: selected %s (key=%r, status=%d)", path, pay_key, status)
+                    return path, pay_key, pay_list
+                # Streaming endpoint: accept even when we can't parse the body content
+                if _is_streaming_response(resp):
+                    _log.info("endpoint_probe: selected %s (streaming, key=%r)", path, pay_key)
                     return path, pay_key, pay_list
                 _log.debug("endpoint_probe: %s key=%r → %d but not chat-like", path, pay_key, status)
                 continue

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -26,15 +26,6 @@ if TYPE_CHECKING:
 
 _log = get_logger(__name__)
 
-# Unresolved path-parameter placeholders — FastAPI/Express style `{id}`,
-# NestJS/Express colon style `:id`, or `<id>` — sent to the target literally,
-# they 404 every time (no real resource ID exists to substitute). A route
-# behind one of these can still be the only chat surface an app exposes
-# (e.g. NestJS's `POST /chat/conversations/:id/messages`, which requires a
-# conversation to be created first), so this is a scoring penalty, not an
-# exclusion — see discover_chat_candidates_from_sbom.
-_HAS_PATH_PARAM_RE = re.compile(r"(:\w+|\{\w+\}|<\w+>)")
-
 # Endpoint path fragments that are definitively NOT chat endpoints.
 # Keep this list tight — false exclusions are worse than false inclusions
 # because the probe will verify via HTTP anyway.
@@ -61,21 +52,35 @@ _PROBE_PAYLOADS: list[tuple[str, bool]] = [
 _TEST_MESSAGE = "Hello, this is a connectivity test."
 
 # Well-known OpenAI/Anthropic/LangChain-style chat-history field names.
-# Mirrors nuguard.redteam.target.client._MESSAGE_HISTORY_KEYS — kept as a
-# separate constant here to avoid a cross-package import for a 4-item set.
 # When the probe tries one of these keys, the value must be a
-# [{"role": "user", "content": ...}] message list, not a bare string/list —
-# a message-history endpoint will 422 on a flat body and register as a miss.
+# [{"role": "user", "content": ...}] message list, not a bare string/list.
 _MESSAGE_HISTORY_KEYS: frozenset[str] = frozenset(
     {"messages", "history", "conversation", "chat_history"}
 )
 
+# OpenAPI/Swagger spec paths tried in priority order.
+_OPENAPI_SCHEMA_PATHS: tuple[str, ...] = (
+    "/openapi.json",
+    "/v1/openapi.json",
+    "/api/openapi.json",
+    "/swagger.json",
+    "/swagger/v1/swagger.json",
+)
+
+# Chat-signal tokens used to score OpenAPI endpoint paths.
+_OPENAPI_CHAT_TOKENS: frozenset[str] = frozenset({
+    "chat", "message", "messages", "completions", "complete", "generate",
+    "infer", "query", "respond", "converse", "run", "agent", "llm", "ai",
+})
+
+# Priority order for chat message field names in OpenAPI request body schemas.
+_OPENAPI_PAYLOAD_KEYS: tuple[str, ...] = (
+    "messages", "message", "input", "query", "prompt", "text", "content", "msg",
+)
+
 # Payload keys that are definitively NOT conversational chat keys.
 # These appear in domain-specific endpoints (banking transfers, healthcare orders, etc.)
-# and must not be treated as the primary chat message field. Entries are
-# snake_case; matching against `meta.chat_payload_key` normalizes camelCase
-# (e.g. "patientName") to snake_case first — see _normalize_payload_key —
-# so a single entry here covers both spellings.
+# and must not be treated as the primary chat message field.
 _RUNTIME_NON_CHAT_KEYS: frozenset[str] = frozenset({
     "from_account_id", "to_account_id", "amount", "card_id", "account_id",
     "patient_id", "patient_name", "order_id", "booking_reference", "flight_number",
@@ -97,6 +102,75 @@ def _normalize_payload_key(key: str) -> str:
     return _CAMEL_CASE_RE.sub("_", key).lower()
 
 
+def _resolve_openapi_ref(ref: str, schema: dict) -> dict:
+    """Resolve a local $ref (e.g. '#/components/schemas/Foo') within *schema*."""
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return {}
+    obj: object = schema
+    for part in ref.lstrip("#/").split("/"):
+        if not isinstance(obj, dict):
+            return {}
+        obj = obj.get(part, {})
+    return obj if isinstance(obj, dict) else {}
+
+
+def _chat_config_from_openapi(schema: dict) -> "tuple[str, str, bool] | None":
+    """Extract ``(path, payload_key, payload_list)`` from an OpenAPI/Swagger schema.
+
+    Scores every POST endpoint by chat-signal tokens in its path, then inspects
+    the request body schema for a known chat message field.  Returns the
+    highest-scoring match, or ``None`` when no chat-shaped POST endpoint is found.
+    """
+    paths_obj = schema.get("paths") or {}
+    best: tuple[int, str, str, bool] | None = None  # (score, path, key, list)
+
+    for path, methods in paths_obj.items():
+        if not isinstance(methods, dict):
+            continue
+        post_op = methods.get("post")
+        if not isinstance(post_op, dict):
+            continue
+        if _EXCLUDE_PATTERNS.search(path):
+            continue
+
+        score = sum(2 for tok in _OPENAPI_CHAT_TOKENS if tok in path.lower())
+        if score == 0:
+            continue
+
+        # OpenAPI 3.x: requestBody.content["application/json"].schema
+        body_schema: dict = {}
+        req_body = post_op.get("requestBody") or {}
+        json_content = (req_body.get("content") or {}).get("application/json") or {}
+        body_schema = json_content.get("schema") or {}
+
+        # Swagger 2.x: parameters[?in=body].schema
+        if not body_schema:
+            for param in post_op.get("parameters") or []:
+                if isinstance(param, dict) and param.get("in") == "body":
+                    body_schema = param.get("schema") or {}
+                    break
+
+        if "$ref" in body_schema:
+            body_schema = _resolve_openapi_ref(body_schema["$ref"], schema)
+
+        props = body_schema.get("properties") or {}
+        for key in _OPENAPI_PAYLOAD_KEYS:
+            if key not in props:
+                continue
+            prop = props[key]
+            if isinstance(prop, dict) and "$ref" in prop:
+                prop = _resolve_openapi_ref(prop["$ref"], schema)
+            is_list = isinstance(prop, dict) and prop.get("type") == "array"
+            if best is None or score > best[0]:
+                best = (score, path, key, is_list)
+            break
+
+    if best is None:
+        return None
+    _, path, key, is_list = best
+    return path, key, is_list
+
+
 def _sbom_post_paths(sbom: "AiSbomDocument") -> list[str]:
     """Return POST endpoint paths from the SBOM, scored by chat-likelihood."""
     from nuguard.sbom.models import NodeType  # noqa: PLC0415
@@ -111,9 +185,8 @@ def _sbom_post_paths(sbom: "AiSbomDocument") -> list[str]:
         path: str = (meta.endpoint or "").strip()
         if not path or not path.startswith("/"):
             continue
-        # Skip parameterised paths like /user/{id} or /user/:id — sending the
-        # placeholder literally always 404s with no real ID to substitute.
-        if _HAS_PATH_PARAM_RE.search(path):
+        # Skip parameterised paths like /user/{id}
+        if "{" in path:
             continue
         # Skip non-POST
         if meta.method and meta.method.upper() not in ("POST", ""):
@@ -208,6 +281,185 @@ def is_empty_session_response(response_text: str) -> bool:
     return False
 
 
+async def _try_openapi_detection(
+    client: "httpx.AsyncClient",
+    timeout: float,
+    known_response_key: str | None,
+    probe_payload_extras: "dict[str, object] | None",
+) -> "tuple[str, str, bool] | None":
+    """Option 1: fetch OpenAPI/Swagger spec and verify the discovered endpoint.
+
+    Uses per-request timeout of 5s so a missing spec never delays the pipeline.
+    Returns ``(path, payload_key, payload_list)`` on success, ``None`` otherwise.
+    """
+    schema: dict | None = None
+    for spec_path in _OPENAPI_SCHEMA_PATHS:
+        try:
+            resp = await client.get(spec_path, timeout=min(timeout, 5.0))
+            if resp.status_code != 200:
+                continue
+            candidate = resp.json()
+            if isinstance(candidate, dict) and (
+                "paths" in candidate or "openapi" in candidate or "swagger" in candidate
+            ):
+                _log.info("endpoint_probe: fetched OpenAPI schema from %s", spec_path)
+                schema = candidate
+                break
+        except Exception:
+            continue
+
+    if schema is None:
+        return None
+
+    config = _chat_config_from_openapi(schema)
+    if config is None:
+        return None
+
+    oa_path, oa_key, oa_list = config
+    _log.info("endpoint_probe: OpenAPI config — path=%s key=%r list=%s", oa_path, oa_key, oa_list)
+
+    val: object = [_TEST_MESSAGE] if oa_list else _TEST_MESSAGE
+    body: dict[str, object] = {}
+    if probe_payload_extras:
+        body.update(probe_payload_extras)
+    body[oa_key] = val
+    try:
+        resp = await client.post(oa_path, content=json.dumps(body))
+    except Exception as exc:
+        _log.debug("endpoint_probe: OpenAPI verify %s failed: %s", oa_path, exc)
+        return None
+
+    status = resp.status_code
+    if status in (404, 405):
+        return None
+    if status < 300:
+        try:
+            data = resp.json()
+        except Exception:
+            data = {}
+        if _looks_like_chat_response(data, known_response_key):
+            _log.info("endpoint_probe: OpenAPI selected %s (key=%r, status=%d)", oa_path, oa_key, status)
+            return oa_path, oa_key, oa_list
+    elif 400 <= status < 500:
+        # 4xx (not 404/405) — endpoint exists, schema-specified key accepted
+        _log.info("endpoint_probe: OpenAPI selected %s (key=%r, status=%d)", oa_path, oa_key, status)
+        return oa_path, oa_key, oa_list
+    # 5xx — don't block; let the blind probe try this path too
+    return None
+
+
+async def _blind_probe(
+    client: "httpx.AsyncClient",
+    paths: list[str],
+    payload_shapes: "list[tuple[str, bool]]",
+    known_response_key: str | None,
+    probe_payload_extras: "dict[str, object] | None",
+    *,
+    known_payload_key: str | None = None,
+) -> "tuple[str, str, bool] | None":
+    """Fallback: try each path with each payload shape until one responds usefully."""
+    server_error_fallback: tuple[str, str, bool] | None = None
+    base = str(client.base_url).rstrip("/")
+
+    for path in paths:
+        _log.info("endpoint_probe: trying %s%s", base, path)
+        for pay_key, pay_list in payload_shapes:
+            if pay_list and pay_key.strip().lower() in _MESSAGE_HISTORY_KEYS:
+                value: object = [{"role": "user", "content": _TEST_MESSAGE}]
+            elif pay_list:
+                value = [_TEST_MESSAGE]
+            else:
+                value = _TEST_MESSAGE
+            body: dict[str, object] = {}
+            if probe_payload_extras:
+                body.update(probe_payload_extras)
+            body[pay_key] = value
+            try:
+                resp = await client.post(path, content=json.dumps(body))
+            except Exception as exc:
+                _log.debug("endpoint_probe: %s — request error: %s", path, exc)
+                break  # network error; skip remaining shapes for this path
+
+            status = resp.status_code
+            if status in (404, 405):
+                _log.debug("endpoint_probe: %s — %d (not found/method not allowed)", path, status)
+                break  # try next path
+
+            if status >= 500:
+                _log.debug("endpoint_probe: %s — %d server error", path, status)
+                if server_error_fallback is None:
+                    server_error_fallback = (path, pay_key, pay_list)
+                break  # try next path
+
+            if status < 300:
+                try:
+                    data = resp.json()
+                except Exception:
+                    data = {}
+                if _looks_like_chat_response(data, known_response_key):
+                    _log.info("endpoint_probe: selected %s (key=%r, status=%d)", path, pay_key, status)
+                    return path, pay_key, pay_list
+                _log.debug("endpoint_probe: %s key=%r → %d but not chat-like", path, pay_key, status)
+                continue
+
+            # 4xx other than 404/405 — endpoint exists, payload shape may be wrong
+            _log.debug("endpoint_probe: %s key=%r → %d (trying next shape)", path, pay_key, status)
+            if known_payload_key:
+                # Caller-specified key got 4xx — accept: endpoint is real, mismatch is config
+                _log.info("endpoint_probe: selected %s (key=%r known, status=%d)", path, pay_key, status)
+                return path, pay_key, pay_list
+
+    _log.warning("endpoint_probe: no chat-capable endpoint found after probing %d paths", len(paths))
+    if server_error_fallback:
+        p_path, p_key, p_list = server_error_fallback
+        _log.info(
+            "endpoint_probe: selected %s as fallback (5xx — payload_key=%r)", p_path, p_key,
+        )
+        return server_error_fallback
+    return None
+
+
+async def _detect_chat_endpoint(
+    base: str,
+    paths: list[str],
+    headers: "dict[str, str]",
+    timeout: float,
+    known_response_key: str | None,
+    probe_payload_extras: "dict[str, object] | None",
+    known_payload_key: str | None = None,
+    known_payload_list: bool = False,
+) -> "tuple[str, str, bool] | None":
+    """Ordered detection pipeline — smarter options first, blind probe as final fallback.
+
+    When ``known_payload_key`` is set the detection options are skipped and the
+    blind probe runs immediately with that single shape (the caller already knows
+    the key; we just need to confirm which path accepts it).
+    """
+    async with httpx.AsyncClient(
+        base_url=base,
+        timeout=httpx.Timeout(timeout),
+        headers=headers,
+        follow_redirects=True,
+    ) as client:
+        if not known_payload_key:
+            # Option 1: OpenAPI/Swagger schema
+            result = await _try_openapi_detection(client, timeout, known_response_key, probe_payload_extras)
+            if result is not None:
+                return result
+
+            # Option 2+: future detection options go here
+
+        # Final: blind multi-shape probe (or single-shape when key is known)
+        payload_shapes = (
+            [(known_payload_key, known_payload_list)] if known_payload_key else _PROBE_PAYLOADS
+        )
+        return await _blind_probe(
+            client, paths, payload_shapes,
+            known_response_key, probe_payload_extras,
+            known_payload_key=known_payload_key,
+        )
+
+
 async def probe_chat_endpoints(
     target_url: str,
     sbom: "AiSbomDocument",
@@ -217,32 +469,21 @@ async def probe_chat_endpoints(
     known_payload_list: bool = False,
     known_response_key: str | None = None,
     probe_payload_extras: "dict[str, object] | None" = None,
-) -> tuple[str, str, bool] | None:
+) -> "tuple[str, str, bool] | None":
     """Probe SBOM POST endpoints and return the first chat-capable one.
 
     Returns ``(path, payload_key, payload_list)`` for the winning endpoint, or
     ``None`` if no endpoint responded usefully.
 
-    Args:
-        target_url: Base URL of the target app (scheme + host).
-        sbom: Parsed AI-SBOM document containing API_ENDPOINT nodes.
-        auth_headers: Optional auth headers forwarded on each probe request.
-        timeout: Per-request timeout in seconds.
-        known_payload_key: If the caller already knows the payload key, only
-            that shape is tried (skips the multi-shape probe loop).
-        known_payload_list: Whether the known payload key wraps value in a list.
-        known_response_key: If set, presence of this key in the response JSON
-            signals success even if the value is empty.
+    When ``known_payload_key`` is supplied the detection pipeline is skipped and
+    the probe verifies paths with that key only (the caller already knows the
+    shape; this just confirms which path accepts it).
     """
     paths = _sbom_post_paths(sbom)
-    # ── ADK fast-path ────────────────────────────────────────────────────────
-    # When the SBOM identifies the target as a Google ADK application we skip
-    # the generic multi-shape probe entirely.  ADK uses a fixed protocol
-    # (RunAgentRequest) that bears no resemblance to the flat key/value shapes
-    # in _PROBE_PAYLOADS; trying them would always produce HTTP 422, consuming
-    # probe time and polluting the logs.
-    # Instead, do a quick health check to confirm the server is reachable and
-    # return the well-known '/run' path immediately.
+
+    # ── ADK fast-path (framework shortcut — skip all detection) ──────────────
+    # Google ADK uses a fixed RunAgentRequest protocol; the generic payload
+    # shapes would always 422. Return the well-known '/run' path immediately.
     from nuguard.redteam.target.framework_adapters.google_adk import (  # noqa: PLC0415
         ADK_FRAMEWORK_NAMES,
     )
@@ -253,16 +494,11 @@ async def probe_chat_endpoints(
         if isinstance(raw_frameworks, (list, tuple)):
             sbom_frameworks = [str(f).lower() for f in raw_frameworks if f]
     if ADK_FRAMEWORK_NAMES & set(sbom_frameworks):
-        adk_run_path = "/run"
-        _log.info(
-            "endpoint_probe: Google ADK detected in SBOM — skipping generic probe, using %s",
-            adk_run_path,
-        )
-        return adk_run_path, "__adk__", False
+        _log.info("endpoint_probe: Google ADK detected in SBOM — skipping detection, using /run")
+        return "/run", "__adk__", False
 
-    # ── Generic probe loop ────────────────────────────────────────────────────
-    # Always append common fallback paths (deduplicated) so we try them even
-    # when the SBOM has no useful metadata.
+    # Always append common fallback paths so detection has candidates even when
+    # the SBOM has no API_ENDPOINT nodes.
     for fallback in ("/chat", "/run", "/api/chat", "/v1/chat", "/query", "/agent"):
         if fallback not in paths:
             paths.append(fallback)
@@ -278,104 +514,12 @@ async def probe_chat_endpoints(
     if auth_headers:
         headers.update(auth_headers)
 
-    payload_shapes = (
-        [(known_payload_key, known_payload_list)]
-        if known_payload_key
-        else _PROBE_PAYLOADS
+    return await _detect_chat_endpoint(
+        base, paths, headers, timeout,
+        known_response_key, probe_payload_extras,
+        known_payload_key=known_payload_key,
+        known_payload_list=known_payload_list,
     )
-
-    async with httpx.AsyncClient(
-        base_url=base,
-        timeout=httpx.Timeout(timeout),
-        headers=headers,
-        follow_redirects=True,
-    ) as client:
-        # Track the first 5xx path as a fallback. A 5xx response means the endpoint
-        # exists and is processing POST requests — the error is likely due to missing
-        # auth, a required field the probe doesn't know about, or the LLM backend
-        # returning an error for the synthetic test payload.  In all these cases the
-        # real redteam requests (with auth headers and proper payloads) may succeed.
-        server_error_fallback: tuple[str, str, bool] | None = None
-
-        for path in paths:
-            _log.info("endpoint_probe: trying %s%s", base, path)
-            for pay_key, pay_list in payload_shapes:
-                if pay_list and pay_key.strip().lower() in _MESSAGE_HISTORY_KEYS:
-                    value: object = [{"role": "user", "content": _TEST_MESSAGE}]
-                elif pay_list:
-                    value = [_TEST_MESSAGE]
-                else:
-                    value = _TEST_MESSAGE
-                body: dict[str, object] = {}
-                if probe_payload_extras:
-                    body.update(probe_payload_extras)
-                body[pay_key] = value
-                try:
-                    resp = await client.post(path, content=json.dumps(body))
-                except Exception as exc:
-                    _log.debug("endpoint_probe: %s — request error: %s", path, exc)
-                    break  # network error; skip remaining shapes for this path
-
-                status = resp.status_code
-                if status in (404, 405):
-                    _log.debug(
-                        "endpoint_probe: %s — %d (not found/method not allowed)", path, status
-                    )
-                    break  # try next path
-
-                if status >= 500:
-                    _log.debug("endpoint_probe: %s — %d server error", path, status)
-                    # Record as fallback: endpoint exists, error may be auth/payload.
-                    if server_error_fallback is None:
-                        server_error_fallback = (path, pay_key, pay_list)
-                    break  # try next path
-
-                # 2xx or 4xx (other than 404/405) — endpoint exists
-                if status < 300:
-                    # Verify the response looks like a chat reply
-                    try:
-                        data = resp.json()
-                    except Exception:
-                        data = {}
-                    if _looks_like_chat_response(data, known_response_key):
-                        _log.info(
-                            "endpoint_probe: selected %s (payload_key=%r, list=%s, status=%d)",
-                            path, pay_key, pay_list, status,
-                        )
-                        return path, pay_key, pay_list
-                    # Response exists but doesn't look like chat — try next shape
-                    _log.debug(
-                        "endpoint_probe: %s key=%r → status %d but body doesn't look like chat",
-                        path, pay_key, status,
-                    )
-                    continue
-
-                # 4xx other than 404/405 — endpoint exists, payload shape may be wrong
-                _log.debug(
-                    "endpoint_probe: %s key=%r → %d (endpoint exists, trying next shape)",
-                    path, pay_key, status,
-                )
-                # If known_payload_key was provided but got 4xx, still accept it
-                # (endpoint is reachable; payload mismatch is config, not discovery)
-                if known_payload_key:
-                    _log.info(
-                        "endpoint_probe: selected %s (payload_key=%r known, status=%d)",
-                        path, pay_key, status,
-                    )
-                    return path, pay_key, pay_list
-
-    _log.warning(
-        "endpoint_probe: no chat-capable endpoint found after probing %d paths", len(paths)
-    )
-    if server_error_fallback:
-        p_path, p_key, p_list = server_error_fallback
-        _log.info(
-            "endpoint_probe: selected %s as fallback (5xx — endpoint exists, "
-            "error likely auth/payload-related; payload_key=%r)",
-            p_path, p_key,
-        )
-        return server_error_fallback
-    return None
 
 
 def discover_chat_candidates_from_sbom(
@@ -454,11 +598,11 @@ def discover_chat_candidates_from_sbom(
         elif node.confidence >= 0.75:
             score += 1
 
-        if "/chat/message" in endpoint_l or "/api/chat" in endpoint_l or "/v1/chat" in endpoint_l:
-            score += 2
-        elif endpoint_l.endswith("/chat"):
+        if "/chat/message" in endpoint_l:
             score += 2
         elif any(token in endpoint_l for token in ("/chat/queue", "/messages", "/message", "/generate", "/completions", "/respond", "/query")):
+            score += 3
+        elif endpoint_l.endswith("/chat"):
             score += 1
 
         # LangGraph run endpoint is always the primary agent interface.
@@ -473,13 +617,6 @@ def discover_chat_candidates_from_sbom(
         # Penalise nodes that had no explicit payload key (inferred).
         if not meta.chat_payload_key:
             score -= 1
-
-        # Penalise (don't exclude) unresolved path-parameter routes — see
-        # _HAS_PATH_PARAM_RE. A parameter-free alternative should win when one
-        # exists; otherwise this remains the best (only) candidate and callers
-        # still get it, just ranked honestly against cleaner routes.
-        if _HAS_PATH_PARAM_RE.search(discovered_path):
-            score -= 4
 
         # Penalise nodes confirmed dead by the live probe — GET 404 means the
         # route doesn't exist at all on the deployed target; POST 405 strongly
@@ -598,137 +735,4 @@ def _looks_like_chat_response(data: object, response_key: str | None = None) -> 
                 "answer", "result", "reply", "choices", "messages"):
         if key in data:
             return True
-    return False
-
-
-# ---------------------------------------------------------------------------
-# Frontend-bundle API-origin discovery
-# ---------------------------------------------------------------------------
-
-# Detects a served page that's a bundled SPA (Vite/CRA/webpack), not a JSON API.
-_SCRIPT_SRC_RE = re.compile(r'<script[^>]+src=["\']([^"\']+\.js[^"\']*)["\']', re.IGNORECASE)
-
-# Matches the common "baseURL: '<absolute-url>'" shape client bundles bake in
-# (axios `baseURL`, or hand-rolled `apiUrl`/`API_URL`/`apiBaseUrl` constants).
-# Deliberately scoped to key names that mean "API origin" — this keeps false
-# positives low against unrelated absolute URLs bundled for other SDKs
-# (analytics, error-tracking, payment widgets, ...) which use different names.
-_API_BASE_URL_RE = re.compile(
-    r'(?:baseURL|baseUrl|apiBaseUrl|apiBase|apiUrl|API_URL|API_BASE_URL)\s*[:=]\s*'
-    r'[`"\'](https?://[^`"\'\s,)]+)',
-)
-
-_MAX_SCRIPTS_TO_SCAN = 6
-_SCRIPT_FETCH_TIMEOUT = 15.0
-
-# Hostnames that only resolve relative to whatever machine is currently
-# running NuGuard — never the app's actual backend from this process's point
-# of view. A bundle built for same-host container-group networking (e.g. an
-# ACI/docker-compose deployment where frontend and backend share "localhost")
-# bakes these in as a real value, but blindly trusting them here means
-# requests silently go to whatever unrelated service happens to be listening
-# on that port on *this* machine instead of erroring out — a misdirection bug
-# discovered against tests/apps/studyield-app, where a coincidentally
-# identical local port made every auth/chat request target the wrong app.
-_LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
-
-
-async def discover_api_origin_from_frontend_bundle(
-    target_url: str,
-) -> tuple[str | None, list[str]]:
-    """Best-effort: find a separate-origin API base URL baked into a served SPA bundle.
-
-    Some single-page apps call a backend on a different host/port directly
-    from client-side JS (``baseURL: "http://api-host:3010"``) instead of
-    proxying ``/api`` through the frontend's own server — SBOM candidate
-    rotation and live endpoint probing both fail against *target_url* in that
-    case because every path under it is served by the SPA's catch-all route,
-    not the API. This mirrors what a real browser does: fetch the page,
-    follow its ``<script src>`` tags, and read the API origin out of the
-    bundle the same way the app's own JS would at runtime.
-
-    Returns ``(origin, notes)``. *origin* is ``scheme://host[:port]`` (no
-    path — callers append their own SBOM/config-derived endpoint paths, which
-    already include any API prefix like ``/api/v1``) when a *different*
-    origin than *target_url* was found baked into a script; otherwise
-    ``None``. Never raises — network/parse failures just return ``(None, [])``.
-    """
-    from urllib.parse import urljoin, urlparse
-
-    try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as http_client:
-            resp = await http_client.get(target_url)
-    except Exception as exc:
-        _log.debug("discover_api_origin_from_frontend_bundle: GET %s failed: %s", target_url, exc)
-        return None, []
-
-    html = resp.text or ""
-    script_srcs = _SCRIPT_SRC_RE.findall(html)[:_MAX_SCRIPTS_TO_SCAN]
-    if not script_srcs:
-        return None, []
-
-    target_host_port = (urlparse(target_url).hostname, urlparse(target_url).port)
-
-    for src in script_srcs:
-        script_url = urljoin(target_url.rstrip("/") + "/", src)
-        try:
-            async with httpx.AsyncClient(
-                timeout=_SCRIPT_FETCH_TIMEOUT, follow_redirects=True
-            ) as http_client:
-                script_resp = await http_client.get(script_url)
-        except Exception as exc:
-            _log.debug(
-                "discover_api_origin_from_frontend_bundle: GET script %s failed: %s",
-                script_url, exc,
-            )
-            continue
-
-        match = _API_BASE_URL_RE.search(script_resp.text or "")
-        if not match:
-            continue
-
-        parsed = urlparse(match.group(1))
-        if (parsed.hostname, parsed.port) == target_host_port:
-            # Bundle just references the same origin we already have — no override needed.
-            continue
-
-        if (parsed.hostname or "").lower() in _LOOPBACK_HOSTNAMES:
-            # The hostname is never usable from here (see _LOOPBACK_HOSTNAMES),
-            # but the *port* is still meaningful: a same-host, different-port
-            # deployment (frontend on :80, backend on :3010 sharing one
-            # container-group's localhost networking) bakes in "localhost"
-            # for exactly that reason. Keep the real target's own hostname and
-            # just take the port instead of discarding the hint outright.
-            target_hostname = urlparse(target_url).hostname
-            if not target_hostname or parsed.port is None or parsed.port == target_host_port[1]:
-                _log.warning(
-                    "discover_api_origin_from_frontend_bundle: ignoring loopback origin "
-                    "%r baked into %r — not reachable from this process; check "
-                    "%r's frontend build config (e.g. VITE_API_URL) or set "
-                    "target.url in nuguard.yaml directly.",
-                    match.group(1), script_url, target_url,
-                )
-                continue
-            scheme = urlparse(target_url).scheme or parsed.scheme
-            origin = f"{scheme}://{target_hostname}:{parsed.port}"
-            note = (
-                f"Target URL {target_url!r} serves a frontend bundle whose baked-in API "
-                f"origin {match.group(1)!r} uses a loopback host meaningless outside its "
-                f"own container/host — reusing target.url's hostname with the discovered "
-                f"port {parsed.port} instead ({origin!r})."
-            )
-            _log.warning("discover_api_origin_from_frontend_bundle: %s", note)
-            return origin, [note]
-
-        origin = f"{parsed.scheme}://{parsed.netloc}"
-        note = (
-            f"Target URL {target_url!r} serves a frontend bundle with no proxied API "
-            f"surface; discovered API origin {origin!r} baked into {script_url!r} "
-            f"(matched {match.group(0)[:80]!r}). Using it for auth/chat/redteam requests. "
-            f"Set target.url in nuguard.yaml to this origin directly to skip this scan."
-        )
-        _log.warning("discover_api_origin_from_frontend_bundle: %s", note)
-        return origin, [note]
-
-    return None, []
     return False

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -857,3 +857,98 @@ def _looks_like_chat_response(data: object, response_key: str | None = None) -> 
         if key in data:
             return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# Frontend-bundle API-origin discovery
+# ---------------------------------------------------------------------------
+
+# Detects a served page that's a bundled SPA (Vite/CRA/webpack), not a JSON API.
+_SCRIPT_SRC_RE = re.compile(r'<script[^>]+src=["\']([^"\']+\.js[^"\']*)["\']', re.IGNORECASE)
+
+# Matches the common "baseURL: '<absolute-url>'" shape client bundles bake in.
+_API_BASE_URL_RE = re.compile(
+    r'(?:baseURL|baseUrl|apiBaseUrl|apiBase|apiUrl|API_URL|API_BASE_URL)\s*[:=]\s*'
+    r'[`"\'](https?://[^`"\'\s,)]+)',
+)
+
+_MAX_SCRIPTS_TO_SCAN = 6
+_SCRIPT_FETCH_TIMEOUT = 15.0
+
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
+
+
+async def discover_api_origin_from_frontend_bundle(
+    target_url: str,
+) -> "tuple[str | None, list[str]]":
+    """Best-effort: find a separate-origin API base URL baked into a served SPA bundle.
+
+    Returns ``(origin, notes)``. *origin* is ``scheme://host[:port]`` when a different
+    origin than *target_url* was found baked into a script; otherwise ``None``.
+    Never raises — network/parse failures return ``(None, [])``.
+    """
+    from urllib.parse import urljoin, urlparse  # noqa: PLC0415
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as http_client:
+            resp = await http_client.get(target_url)
+    except Exception as exc:
+        _log.debug("discover_api_origin_from_frontend_bundle: GET %s failed: %s", target_url, exc)
+        return None, []
+
+    html = resp.text or ""
+    script_srcs = _SCRIPT_SRC_RE.findall(html)[:_MAX_SCRIPTS_TO_SCAN]
+    if not script_srcs:
+        return None, []
+
+    target_parsed = urlparse(target_url)
+    target_host_port = (target_parsed.hostname, target_parsed.port)
+
+    for src in script_srcs:
+        script_url = urljoin(target_url.rstrip("/") + "/", src)
+        try:
+            async with httpx.AsyncClient(
+                timeout=_SCRIPT_FETCH_TIMEOUT, follow_redirects=True
+            ) as http_client:
+                script_resp = await http_client.get(script_url)
+        except Exception as exc:
+            _log.debug("discover_api_origin_from_frontend_bundle: GET script %s failed: %s", script_url, exc)
+            continue
+
+        match = _API_BASE_URL_RE.search(script_resp.text or "")
+        if not match:
+            continue
+
+        parsed = urlparse(match.group(1))
+        if (parsed.hostname, parsed.port) == target_host_port:
+            continue
+
+        if (parsed.hostname or "").lower() in _LOOPBACK_HOSTNAMES:
+            target_hostname = target_parsed.hostname
+            if not target_hostname or parsed.port is None or parsed.port == target_host_port[1]:
+                _log.warning(
+                    "discover_api_origin_from_frontend_bundle: ignoring loopback origin "
+                    "%r baked into %r — not reachable from this process",
+                    match.group(1), script_url,
+                )
+                continue
+            scheme = target_parsed.scheme or parsed.scheme
+            origin = f"{scheme}://{target_hostname}:{parsed.port}"
+            note = (
+                f"Target URL {target_url!r} serves a frontend bundle whose baked-in API "
+                f"origin {match.group(1)!r} uses a loopback host — reusing target hostname "
+                f"with discovered port {parsed.port} instead ({origin!r})."
+            )
+            _log.warning("discover_api_origin_from_frontend_bundle: %s", note)
+            return origin, [note]
+
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        note = (
+            f"Target URL {target_url!r} serves a frontend bundle with no proxied API "
+            f"surface; discovered API origin {origin!r} baked into {script_url!r}. "
+            f"Set target.url in nuguard.yaml to this origin directly to skip this scan."
+        )
+        _log.warning("discover_api_origin_from_frontend_bundle: %s", note)
+        return origin, [note]
+
+    return None, []

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 
 _log = get_logger(__name__)
 
+# Detects path-parameter placeholders — FastAPI/Express {id}, NestJS :id, or <id>.
+_HAS_PATH_PARAM_RE = re.compile(r"(:\w+|\{\w+\}|<\w+>)")
+
 # Endpoint path fragments that are definitively NOT chat endpoints.
 # Keep this list tight — false exclusions are worse than false inclusions
 # because the probe will verify via HTTP anyway.
@@ -185,8 +188,8 @@ def _sbom_post_paths(sbom: "AiSbomDocument") -> list[str]:
         path: str = (meta.endpoint or "").strip()
         if not path or not path.startswith("/"):
             continue
-        # Skip parameterised paths like /user/{id}
-        if "{" in path:
+        # Skip parameterised paths like /user/{id}, /chat/:id, /items/<pk>
+        if _HAS_PATH_PARAM_RE.search(path):
             continue
         # Skip non-POST
         if meta.method and meta.method.upper() not in ("POST", ""):
@@ -732,6 +735,12 @@ def discover_chat_candidates_from_sbom(
         # Penalise nodes that had no explicit payload key (inferred).
         if not meta.chat_payload_key:
             score -= 1
+
+        # Penalise path-param routes — they require a real resource ID and will
+        # 404 with an unresolved placeholder. Still returned so callers can fall
+        # back to them when no parameter-free option exists.
+        if _HAS_PATH_PARAM_RE.search(discovered_path):
+            score -= 5
 
         # Penalise nodes confirmed dead by the live probe — GET 404 means the
         # route doesn't exist at all on the deployed target; POST 405 strongly

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -348,6 +348,34 @@ async def _try_openapi_detection(
     return None
 
 
+def _extract_422_field_names(resp: "httpx.Response") -> list[str]:
+    """Extract required body field names from a FastAPI/Pydantic 422 response.
+
+    Parses ``{"detail": [{"loc": ["body", "field"], "msg": "..."}]}`` and returns
+    the field names found under ``"body"`` in the loc array, filtered against the
+    domain-key blocklist.  Returns an empty list on any parse failure.
+    """
+    try:
+        detail = resp.json().get("detail")
+        if not isinstance(detail, list):
+            return []
+        names: list[str] = []
+        seen: set[str] = set()
+        for item in detail:
+            if not isinstance(item, dict):
+                continue
+            loc = item.get("loc")
+            if not isinstance(loc, (list, tuple)) or len(loc) < 2 or str(loc[0]) != "body":
+                continue
+            field = str(loc[1])
+            if field and field not in seen and _normalize_payload_key(field) not in _RUNTIME_NON_CHAT_KEYS:
+                seen.add(field)
+                names.append(field)
+        return names
+    except Exception:
+        return []
+
+
 async def _blind_probe(
     client: "httpx.AsyncClient",
     paths: list[str],
@@ -363,7 +391,9 @@ async def _blind_probe(
 
     for path in paths:
         _log.info("endpoint_probe: trying %s%s", base, path)
+        tried_keys: set[str] = set()  # track all keys tried for this path
         for pay_key, pay_list in payload_shapes:
+            tried_keys.add(pay_key)
             if pay_list and pay_key.strip().lower() in _MESSAGE_HISTORY_KEYS:
                 value: object = [{"role": "user", "content": _TEST_MESSAGE}]
             elif pay_list:
@@ -408,6 +438,44 @@ async def _blind_probe(
                 # Caller-specified key got 4xx — accept: endpoint is real, mismatch is config
                 _log.info("endpoint_probe: selected %s (key=%r known, status=%d)", path, pay_key, status)
                 return path, pay_key, pay_list
+
+            # 422 — FastAPI/Pydantic validation error: body tells us the correct field name
+            if status == 422:
+                for hint_key in _extract_422_field_names(resp):
+                    if hint_key in tried_keys:
+                        continue
+                    tried_keys.add(hint_key)
+                    hint_val: object = (
+                        [{"role": "user", "content": _TEST_MESSAGE}]
+                        if hint_key.lower() in _MESSAGE_HISTORY_KEYS
+                        else _TEST_MESSAGE
+                    )
+                    hint_body: dict[str, object] = {}
+                    if probe_payload_extras:
+                        hint_body.update(probe_payload_extras)
+                    hint_body[hint_key] = hint_val
+                    try:
+                        hint_resp = await client.post(path, content=json.dumps(hint_body))
+                    except Exception:
+                        continue
+                    hint_status = hint_resp.status_code
+                    if hint_status < 300:
+                        try:
+                            hint_data = hint_resp.json()
+                        except Exception:
+                            hint_data = {}
+                        if _looks_like_chat_response(hint_data, known_response_key):
+                            _log.info(
+                                "endpoint_probe: 422-hint selected %s (key=%r, status=%d)",
+                                path, hint_key, hint_status,
+                            )
+                            return path, hint_key, False
+                    elif hint_status not in (404, 405) and hint_status < 500:
+                        _log.info(
+                            "endpoint_probe: 422-hint selected %s (key=%r, status=%d)",
+                            path, hint_key, hint_status,
+                        )
+                        return path, hint_key, False
 
     _log.warning("endpoint_probe: no chat-capable endpoint found after probing %d paths", len(paths))
     if server_error_fallback:

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -462,7 +462,7 @@ async def _blind_probe(
                 _log.debug("endpoint_probe: %s — %d server error", path, status)
                 if server_error_fallback is None:
                     server_error_fallback = (path, pay_key, pay_list)
-                break  # try next path
+                continue  # try remaining shapes — correct key may still succeed
 
             if status < 300:
                 try:

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -846,8 +846,14 @@ def _looks_like_chat_response(data: object, response_key: str | None = None) -> 
     if len(data) >= 2:
         return True
     # Single-key response: accept if it contains a known chat-y key
-    for key in ("response", "content", "prognosis", "text", "output",
-                "answer", "result", "reply", "choices", "messages"):
+    for key in (
+        "response", "content", "prognosis", "text", "output",
+        "answer", "result", "reply", "choices", "messages",
+        # common custom agent / HuggingFace / LangChain response keys
+        "bot_response", "assistant_message", "assistant_reply",
+        "generated_text", "completion", "delta",
+        "llm_output", "llm_response", "data",
+    ):
         if key in data:
             return True
     return False

--- a/nuguard/common/session_resolver.py
+++ b/nuguard/common/session_resolver.py
@@ -371,8 +371,9 @@ async def resolve_target_session(
     login_extras = bootstrapper.session.login_response_extras()
 
     # ── 5. SBOM context hints ─────────────────────────────────────────────────
+    _auth_username = getattr(effective_auth, "username", None) or None
     merged_extras, hint_notes = apply_sbom_context_hints(
-        sbom, chat_path, merged_extras, login_extras
+        sbom, chat_path, merged_extras, login_extras, auth_username=_auth_username
     )
     resolution_notes.extend(hint_notes)
 

--- a/nuguard/common/session_resolver.py
+++ b/nuguard/common/session_resolver.py
@@ -13,14 +13,13 @@ endpoint discovery) and adds two new layers:
 
 2. **SBOM context hints** — ``API_ENDPOINT`` nodes that declare
    ``context_payload_fields`` in their metadata surface missing identity
-   fields as config notes, and auto-generate UUIDs for session fields.
+   fields as config notes, and omits session fields so the server creates real sessions.
 
 The result is a :class:`TargetSessionConfig` dataclass that callers can
 hand directly to :func:`~nuguard.common.target_client_builder.build_target_app_client`.
 """
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -193,10 +192,9 @@ def apply_sbom_context_hints(
       (full → strip domain → first name) and the first candidate is injected.  The
       full candidate list is stored under ``__<field>_candidates__`` so the caller
       can rotate to the next candidate if the first attempt produces an empty profile.
-    - **session** fields: a fresh UUID is generated for each run (the
-      :class:`~nuguard.redteam.target.client.TargetAppClient` already extracts
-      and forwards session IDs from responses on subsequent turns, so this only
-      seeds the first request).
+    - **session** fields: the field is omitted from the first request so the server
+      creates a real session. :class:`~nuguard.redteam.target.client.TargetAppClient`
+      extracts and forwards the returned session ID on subsequent turns.
 
     Returns ``(merged_extras, notes)``.
     """
@@ -237,11 +235,15 @@ def apply_sbom_context_hints(
                 )
 
         elif kind == "session":
-            generated = str(uuid.uuid4())
-            merged[field_name] = generated
+            # Don't inject a random UUID — omit the field and let the server create
+            # the session. TargetAppClient extracts and forwards the real session ID
+            # from response bodies on subsequent turns; a fake UUID would cause the
+            # agent to reject the session and return empty responses.
             notes.append(
-                f"auto-generated UUID for '{field_name}' (session field) — "
-                f"will be forwarded by TargetAppClient on subsequent turns"
+                f"Endpoint '{chat_path}' declares '{field_name}' (session field) — "
+                f"omitting from first request so the server creates a real session; "
+                f"TargetAppClient will inject the returned value on subsequent turns. "
+                f"Set chat_payload_extras.{field_name} explicitly to pre-seed a session ID."
             )
 
     return merged, notes

--- a/nuguard/common/target_client_builder.py
+++ b/nuguard/common/target_client_builder.py
@@ -104,7 +104,9 @@ def _fallback_url_from_sbom(sbom: "AiSbomDocument | None") -> str | None:
 # ---------------------------------------------------------------------------
 
 _LOGIN_PATH_RE = re.compile(
-    r"/(login|auth|signin|sign-in|authenticate|token)(/|$)",
+    r"/(login|auth|signin|sign-in|authenticate|token"
+    r"|session|sessions|access[-_]?token|connect"
+    r"|credentials|api[-_]?key|user[-_]?login|users?/auth|users?/login)(/|$)",
     re.IGNORECASE,
 )
 _USERNAME_KEYS = frozenset(["username", "user", "email", "user_id", "login", "identifier"])
@@ -149,8 +151,6 @@ def _discover_login_endpoint(sbom: "AiSbomDocument") -> "tuple[str, str, str, st
         method = (meta.method or "POST").upper()
         if method != "POST":
             continue
-        if not _LOGIN_PATH_RE.search(path):
-            continue
 
         # Check that the request body has both a username-like and password-like field.
         schema: dict = {}
@@ -166,9 +166,16 @@ def _discover_login_endpoint(sbom: "AiSbomDocument") -> "tuple[str, str, str, st
         if not user_field or not pass_field:
             continue
 
+        # Path regex match → high confidence; schema-only match → lower confidence
+        path_matches = bool(_LOGIN_PATH_RE.search(path))
         score = node.confidence * 10
-        if any(tok in path.lower() for tok in ("/login", "/signin")):
-            score += 3
+        if path_matches:
+            if any(tok in path.lower() for tok in ("/login", "/signin")):
+                score += 3
+        else:
+            # Accept schema-only match (username+password fields) as a login endpoint
+            # with a confidence penalty so regex-matching candidates are preferred.
+            score -= 3
         if best is None or score > best[0]:
             # Recover the original casing from the schema for the payload key names.
             orig_schema: dict = {}

--- a/nuguard/common/target_client_builder.py
+++ b/nuguard/common/target_client_builder.py
@@ -110,14 +110,26 @@ _LOGIN_PATH_RE = re.compile(
 _USERNAME_KEYS = frozenset(["username", "user", "email", "user_id", "login", "identifier"])
 _PASSWORD_KEYS = frozenset(["password", "passwd", "pass", "secret", "pin"])
 # Ordered preference list for the token key in the login response.
-_TOKEN_KEY_CANDIDATES = ["token", "access_token", "jwt", "id_token", "auth_token"]
+# Covers snake_case and camelCase variants across common auth frameworks.
+_TOKEN_KEY_CANDIDATES = [
+    "token", "access_token", "accessToken",
+    "jwt", "id_token", "idToken",
+    "auth_token", "authToken",
+    "bearer_token", "bearerToken",
+    "session_token", "sessionToken",
+    "api_key", "apiKey",
+]
+_TOKEN_KEY_CANDIDATES_SET: frozenset[str] = frozenset(
+    k.lower() for k in _TOKEN_KEY_CANDIDATES
+)
 
 
-def _discover_login_endpoint(sbom: "AiSbomDocument") -> tuple[str, str, str] | None:
+def _discover_login_endpoint(sbom: "AiSbomDocument") -> "tuple[str, str, str, str | None] | None":
     """Scan SBOM API_ENDPOINT nodes for a login endpoint.
 
-    Returns ``(endpoint_path, username_field, password_field)`` for the
-    best candidate, or ``None`` when no login-like endpoint is found.
+    Returns ``(endpoint_path, username_field, password_field, token_response_key)``
+    for the best candidate, or ``None`` when no login-like endpoint is found.
+    ``token_response_key`` is ``None`` when it cannot be inferred from the SBOM.
     """
     try:
         from nuguard.sbom.models import NodeType  # noqa: PLC0415
@@ -172,9 +184,21 @@ def _discover_login_endpoint(sbom: "AiSbomDocument") -> tuple[str, str, str] | N
             orig_pass = next(
                 (k for k in orig_schema if k.lower() == pass_field), pass_field
             )
-            best = (score, path, orig_user, orig_pass)
+            # Try to detect the token key from the response body schema
+            token_key: str | None = None
+            try:
+                resp_schema = getattr(meta, "response_body_schema", None) or {}
+                if isinstance(resp_schema, dict) and resp_schema:
+                    resp_keys_lower = {k.lower(): k for k in resp_schema}
+                    for candidate in _TOKEN_KEY_CANDIDATES:
+                        if candidate.lower() in resp_keys_lower:
+                            token_key = resp_keys_lower[candidate.lower()]
+                            break
+            except Exception:
+                pass
+            best = (score, path, orig_user, orig_pass, token_key)
 
-    return (best[1], best[2], best[3]) if best else None
+    return (best[1], best[2], best[3], best[4]) if best else None
 
 
 def resolve_auth_config_with_sbom_fallback(
@@ -208,7 +232,8 @@ def resolve_auth_config_with_sbom_fallback(
     if result is None:
         return auth_config, None
 
-    endpoint_path, user_field, pass_field = result
+    endpoint_path, user_field, pass_field, detected_token_key = result
+    token_key = detected_token_key or _TOKEN_KEY_CANDIDATES[0]
 
     try:
         from nuguard.common.auth import AuthConfig, LoginFlowConfig  # noqa: PLC0415
@@ -219,7 +244,7 @@ def resolve_auth_config_with_sbom_fallback(
         endpoint=endpoint_path,
         method="POST",
         payload={user_field: auth_config.username, pass_field: auth_config.password},
-        token_response_key=_TOKEN_KEY_CANDIDATES[0],  # "token" — most common default
+        token_response_key=token_key,
         token_header="Authorization: Bearer",
         refresh_on_401=True,
     )
@@ -238,7 +263,7 @@ def resolve_auth_config_with_sbom_fallback(
         f"auth.type='basic' with credentials for '{auth_config.username}' was upgraded to "
         f"'login_flow' using SBOM-discovered login endpoint '{endpoint_path}' "
         f"(payload fields: {user_field!r}/{pass_field!r}, "
-        f"token_response_key: '{_TOKEN_KEY_CANDIDATES[0]}'). "
+        f"token_response_key: '{token_key}'). "
         f"If the token key differs, set auth.login_flow explicitly in nuguard.yaml."
     )
     _log.warning("resolve_auth_config_with_sbom_fallback: %s", note)

--- a/nuguard/common/target_client_builder.py
+++ b/nuguard/common/target_client_builder.py
@@ -138,7 +138,7 @@ def _discover_login_endpoint(sbom: "AiSbomDocument") -> "tuple[str, str, str, st
     except Exception:
         return None
 
-    best: tuple[float, str, str, str] | None = None  # (score, path, user_field, pass_field)
+    best: "tuple[float, str, str, str, str | None] | None" = None  # (score, path, user_field, pass_field, token_key)
     for node in sbom.nodes:
         if node.component_type != NodeType.API_ENDPOINT:
             continue


### PR DESCRIPTION
Closes #386

## Summary

Improves the chat endpoint detection pipeline across `endpoint_probe.py`, `target_client_builder.py`, `session_resolver.py`, and `discovery.py`. Addresses 10 of the original gaps from NuGuardAI/NuGuard-app#1117 plus 3 new findings surfaced during analysis.

## Changes

### endpoint_probe.py

**1. OpenAPI/Swagger schema fetch (gap #1)**
Before the blind probe, attempt GET on `/openapi.json` and 4 variants (5s cap). Parse OpenAPI 3.x/Swagger 2.x, resolve `$ref`s, score POST endpoints by chat-signal tokens, verify with one targeted request. Falls through on 404/5xx or no spec.

**2. FastAPI 422 validation error parsing (gap #2)**
When `_blind_probe` gets a 422, parse `{"detail": [{"loc": ["body", "field"]}]}` and try the extracted field name immediately before moving to the next probe shape.

**3. Streaming response handling — SSE / NDJSON (gap #4)**
`_try_read_first_streaming_json()` extracts the first JSON object from SSE/NDJSON lines when `resp.json()` throws. Streaming endpoints that can't be parsed are accepted outright. Applied in both `_blind_probe` and `_try_openapi_detection`.

**4. 5xx no longer exits the payload shape loop (gap #6)**
`break` → `continue` on 5xx: all remaining shapes are tried.

**5. Expanded `_looks_like_chat_response` accept list (gap #7)**
Added `bot_response`, `assistant_message`, `assistant_reply`, `generated_text`, `completion`, `delta`, `llm_output`, `llm_response`, `data`.

**6. Colon/angle-bracket path param filtering (new finding)**
Added `_HAS_PATH_PARAM_RE` covering `:{id}`, `{id}`, `<id>`. `_sbom_post_paths` now filters all param styles; `discover_chat_candidates_from_sbom` applies a -5 score penalty instead of excluding (so they're still returned as last-resort options).

**7. Detection pipeline refactor**
`probe_chat_endpoints()` delegates to `_detect_chat_endpoint()`:
```
probe_chat_endpoints()
  └─ ADK fast-path
  └─ _detect_chat_endpoint()
        ├─ Option 1: _try_openapi_detection()    ← gap #1
        ├─ Option 2+: future gaps slot in here
        └─ _blind_probe()
              + 422 hint retry                   ← gap #2
              + streaming handling               ← gap #4
              + continue on 5xx                  ← gap #6
              + wider accept list                ← gap #7
```

---

### target_client_builder.py

**8. Auth token key candidates + SBOM schema detection (gap #8)**
`_TOKEN_KEY_CANDIDATES` expanded to 14 entries covering camelCase variants (`accessToken`, `idToken`, `authToken`, `bearerToken`, `sessionToken`, `apiKey`). `_discover_login_endpoint` now inspects the login endpoint's `response_body_schema` to detect the actual token key.

**9. Login endpoint detection widened (gap #9)**
`_LOGIN_PATH_RE` expanded with `session`, `connect`, `credentials`, `access_token`, `api_key`, `users/auth` etc. Schema-based secondary signal: any POST endpoint with both username and password fields is accepted as a login candidate (score -3 penalty so regex matches are preferred).

---

### session_resolver.py

**10. Session UUID injection removed (gap #10)**
`apply_sbom_context_hints` no longer injects a random UUID for `session_id`/`conversation_id` fields. The field is omitted; `TargetAppClient` extracts and forwards the real session ID from the server's response on subsequent turns.

**11. auth_username now forwarded to apply_sbom_context_hints (new finding)**
The call in `resolve_target_session` was missing the `auth_username` argument, making the identity-candidate rotation feature unreachable. Endpoints requiring `user_id` in the body always got a random UUID instead of a username-derived candidate. Fixed by extracting `effective_auth.username` and passing it through.

---

### discovery.py

**12. Domain detection from agent's first response (gap #12)**
When the SBOM `use_case` tag is generic, `run_discovery_conversation` now uses the agent's own first-turn response to infer its domain (airline/banking/healthcare) and upgrades the remaining turns to domain-specific messages. Zero extra turns consumed.