### PR TITLE
fix(redteam): add missing 'aborted_endpoint_unreachable' to RedteamRunResult scan_outcome

### DIFF
--- a/nuguard/redteam/public_api.py
+++ b/nuguard/redteam/public_api.py
@@ -127,6 +127,7 @@ class RedteamRunResult(BaseModel):
         "high_findings",
         "findings",
         "aborted_target_unavailable",
+        "aborted_endpoint_unreachable",
         "inconclusive_target_errors",
         "no_findings",
     ]


### PR DESCRIPTION
## Summary

The orchestrator sets scan_outcome='aborted_endpoint_unreachable' when the pre-flight chat endpoint check fails, but this value was absent from the Literal type in RedteamRunResult, causing a Pydantic ValidationError that masked the real failure with a confusing schema error.

## Change

One line added to the scan_outcome Literal in nuguard/redteam/public_api.py.