### PR TITLE
feat(probe): OpenAPI schema-driven nested payload detection

### DIFF
--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import httpx
@@ -25,6 +26,31 @@ if TYPE_CHECKING:
     from nuguard.sbom.models import AiSbomDocument
 
 _log = get_logger(__name__)
+
+
+@dataclass
+class ProbeResult:
+    """Result of a successful chat endpoint probe.
+
+    Supports 3-value tuple unpacking (``path, key, is_list = result``) so
+    existing callers are unchanged.  Access ``.value_template`` explicitly
+    when you need the nested payload shape detected from OpenAPI schema.
+    """
+
+    path: str
+    key: str
+    is_list: bool
+    # Payload value template built from OpenAPI schema when the chat key expects
+    # a structured object (e.g. {"role": "user", "content": "..."}) rather than
+    # a plain string.  None means use a plain string (the default behaviour).
+    value_template: "dict[str, object] | None" = field(default=None, compare=False)
+
+    def __iter__(self):  # noqa: ANN204
+        # Yield only the 3 positional fields so ``a, b, c = result`` still works.
+        return iter((self.path, self.key, self.is_list))
+
+    def __len__(self) -> int:
+        return 3
 
 # Detects path-parameter placeholders — FastAPI/Express {id}, NestJS :id, or <id>.
 _HAS_PATH_PARAM_RE = re.compile(r"(:\w+|\{\w+\}|<\w+>)")
@@ -95,6 +121,16 @@ _RUNTIME_NON_CHAT_KEYS: frozenset[str] = frozenset({
 
 _CAMEL_CASE_RE = re.compile(r"(?<!^)(?=[A-Z])")
 
+# Sentinel placed in the value_template dict for the field that carries the
+# actual chat text.  Replaced at send-time regardless of the field name.
+_CHAT_TEXT_SENTINEL = "__nuguard_chat_text__"
+
+# String field names that most likely carry the chat message text, in priority
+# order.  The first match wins the sentinel in _build_object_template.
+_CONTENT_FIELD_NAMES: tuple[str, ...] = (
+    "content", "text", "message", "body", "input", "prompt", "query", "msg",
+)
+
 
 def _normalize_payload_key(key: str) -> str:
     """Normalize a payload key for comparison against _RUNTIME_NON_CHAT_KEYS.
@@ -117,12 +153,98 @@ def _resolve_openapi_ref(ref: str, schema: dict) -> dict:
     return obj if isinstance(obj, dict) else {}
 
 
-def _chat_config_from_openapi(schema: dict) -> "tuple[str, str, bool] | None":
-    """Extract ``(path, payload_key, payload_list)`` from an OpenAPI/Swagger schema.
+def _build_object_template(
+    prop_schema: dict,
+    full_schema: dict,
+    depth: int = 0,
+) -> "dict[str, object] | None":
+    """Recursively build a template dict from an OpenAPI object property schema.
+
+    Returns ``None`` when the schema does not describe an object (i.e. it is a
+    plain string, integer, etc.) so callers can fall back to a bare string.
+
+    Required fields and known-content-name string fields are included with
+    sensible defaults.  The one field most likely to carry the chat message text
+    is replaced with ``_CHAT_TEXT_SENTINEL`` so the send path can substitute it
+    without knowing the field name in advance.
+    """
+    if depth > 2:  # guard against pathologically deep schemas
+        return None
+    resolved = prop_schema
+    if isinstance(resolved, dict) and "$ref" in resolved:
+        resolved = _resolve_openapi_ref(resolved["$ref"], full_schema)
+    if not isinstance(resolved, dict):
+        return None
+    # Only proceed for object schemas (explicit type or a properties block).
+    if resolved.get("type") not in ("object", None):
+        return None
+    props = resolved.get("properties") or {}
+    if not props:
+        return None
+
+    required: set[str] = set(resolved.get("required") or [])
+    template: dict[str, object] = {}
+    sentinel_placed = False
+
+    # First pass: place the sentinel on the best content-carrying field.
+    for candidate in _CONTENT_FIELD_NAMES:
+        if candidate not in props:
+            continue
+        fs = props[candidate]
+        if isinstance(fs, dict) and "$ref" in fs:
+            fs = _resolve_openapi_ref(fs["$ref"], full_schema)
+        ftype = fs.get("type") if isinstance(fs, dict) else None
+        # Accept string or untyped fields as the text carrier.
+        if ftype in ("string", None):
+            template[candidate] = _CHAT_TEXT_SENTINEL
+            sentinel_placed = True
+            break
+
+    if not sentinel_placed:
+        # No recognised content field — this schema probably isn't a message object.
+        return None
+
+    # Second pass: fill remaining required fields with type-appropriate defaults.
+    for field_name, field_schema in props.items():
+        if field_name in template:
+            continue  # sentinel field already placed
+        if field_name not in required:
+            continue
+        fs = field_schema
+        if isinstance(fs, dict) and "$ref" in fs:
+            fs = _resolve_openapi_ref(fs["$ref"], full_schema)
+        ftype = fs.get("type") if isinstance(fs, dict) else None
+        fdefault = fs.get("default") if isinstance(fs, dict) else None
+        fenums = fs.get("enum") if isinstance(fs, dict) else None
+        if fdefault is not None:
+            template[field_name] = fdefault
+        elif fenums and isinstance(fenums, list) and fenums:
+            template[field_name] = fenums[0]  # use first enum value as default
+        elif ftype == "string":
+            template[field_name] = ""
+        elif ftype in ("integer", "number"):
+            template[field_name] = 0
+        elif ftype == "boolean":
+            template[field_name] = False
+        elif ftype == "array":
+            template[field_name] = []
+        elif ftype == "object" or (isinstance(fs, dict) and "properties" in fs):
+            nested = _build_object_template(fs, full_schema, depth + 1)
+            if nested is not None:
+                template[field_name] = nested
+        # Unknown/null types are skipped
+
+    return template
+
+
+def _chat_config_from_openapi(schema: dict) -> "tuple[str, str, bool, dict | None] | None":
+    """Extract ``(path, key, is_list, value_template)`` from an OpenAPI/Swagger schema.
 
     Scores every POST endpoint by chat-signal tokens in its path, then inspects
-    the request body schema for a known chat message field.  Returns the
-    highest-scoring match, or ``None`` when no chat-shaped POST endpoint is found.
+    the request body schema for a known chat message field.  ``value_template``
+    is set when the chat key expects a structured message object (e.g. FastAPI
+    ChatMessage with role+content fields) instead of a plain string.  Returns
+    ``None`` when no chat-shaped POST endpoint is found.
     """
     paths_obj = schema.get("paths") or {}
     best: tuple[int, str, str, bool] | None = None  # (score, path, key, list)
@@ -171,7 +293,15 @@ def _chat_config_from_openapi(schema: dict) -> "tuple[str, str, bool] | None":
     if best is None:
         return None
     _, path, key, is_list = best
-    return path, key, is_list
+
+    # When the chat key resolves to an object schema, build a generic template
+    # so the probe and redteam client send the correct nested structure.
+    value_template: dict[str, object] | None = None
+    raw_prop = (body_schema.get("properties") or {}).get(key) or {}
+    if not is_list:
+        value_template = _build_object_template(raw_prop, schema)
+
+    return path, key, is_list, value_template
 
 
 def _sbom_post_paths(sbom: "AiSbomDocument") -> list[str]:
@@ -289,11 +419,12 @@ async def _try_openapi_detection(
     timeout: float,
     known_response_key: str | None,
     probe_payload_extras: "dict[str, object] | None",
-) -> "tuple[str, str, bool] | None":
+) -> "ProbeResult | None":
     """Option 1: fetch OpenAPI/Swagger spec and verify the discovered endpoint.
 
     Uses per-request timeout of 5s so a missing spec never delays the pipeline.
-    Returns ``(path, payload_key, payload_list)`` on success, ``None`` otherwise.
+    Returns a ProbeResult on success (including ``value_template`` when the
+    schema reveals a nested message-object shape), ``None`` otherwise.
     """
     schema: dict | None = None
     for spec_path in _OPENAPI_SCHEMA_PATHS:
@@ -318,10 +449,19 @@ async def _try_openapi_detection(
     if config is None:
         return None
 
-    oa_path, oa_key, oa_list = config
-    _log.info("endpoint_probe: OpenAPI config — path=%s key=%r list=%s", oa_path, oa_key, oa_list)
+    oa_path, oa_key, oa_list, oa_template = config
+    _log.info("endpoint_probe: OpenAPI config — path=%s key=%r list=%s template=%s",
+              oa_path, oa_key, oa_list, bool(oa_template))
 
-    val: object = [_TEST_MESSAGE] if oa_list else _TEST_MESSAGE
+    # Use the detected template for the verification request when the schema
+    # says the value must be a message object rather than a plain string.
+    if oa_template is not None:
+        # Replace the sentinel with the test message for the verification probe.
+        val: object = {k: (_TEST_MESSAGE if v == _CHAT_TEXT_SENTINEL else v) for k, v in oa_template.items()}
+    elif oa_list:
+        val = [_TEST_MESSAGE]
+    else:
+        val = _TEST_MESSAGE
     body: dict[str, object] = {}
     if probe_payload_extras:
         body.update(probe_payload_extras)
@@ -342,11 +482,11 @@ async def _try_openapi_detection(
             data = _try_read_first_streaming_json(resp) or {}
         if _looks_like_chat_response(data, known_response_key) or _is_streaming_response(resp):
             _log.info("endpoint_probe: OpenAPI selected %s (key=%r, status=%d)", oa_path, oa_key, status)
-            return oa_path, oa_key, oa_list
+            return ProbeResult(oa_path, oa_key, oa_list, oa_template)
     elif 400 <= status < 500:
         # 4xx (not 404/405) — endpoint exists, schema-specified key accepted
         _log.info("endpoint_probe: OpenAPI selected %s (key=%r, status=%d)", oa_path, oa_key, status)
-        return oa_path, oa_key, oa_list
+        return ProbeResult(oa_path, oa_key, oa_list, oa_template)
     # 5xx — don't block; let the blind probe try this path too
     return None
 
@@ -430,9 +570,9 @@ async def _blind_probe(
     probe_payload_extras: "dict[str, object] | None",
     *,
     known_payload_key: str | None = None,
-) -> "tuple[str, str, bool] | None":
+) -> "ProbeResult | None":
     """Fallback: try each path with each payload shape until one responds usefully."""
-    server_error_fallback: tuple[str, str, bool] | None = None
+    server_error_fallback: ProbeResult | None = None
     base = str(client.base_url).rstrip("/")
 
     for path in paths:
@@ -464,7 +604,7 @@ async def _blind_probe(
             if status >= 500:
                 _log.debug("endpoint_probe: %s — %d server error", path, status)
                 if server_error_fallback is None:
-                    server_error_fallback = (path, pay_key, pay_list)
+                    server_error_fallback = ProbeResult(path, pay_key, pay_list)
                 continue  # try remaining shapes — correct key may still succeed
 
             if status < 300:
@@ -474,11 +614,11 @@ async def _blind_probe(
                     data = _try_read_first_streaming_json(resp) or {}
                 if _looks_like_chat_response(data, known_response_key):
                     _log.info("endpoint_probe: selected %s (key=%r, status=%d)", path, pay_key, status)
-                    return path, pay_key, pay_list
+                    return ProbeResult(path, pay_key, pay_list)
                 # Streaming endpoint: accept even when we can't parse the body content
                 if _is_streaming_response(resp):
                     _log.info("endpoint_probe: selected %s (streaming, key=%r)", path, pay_key)
-                    return path, pay_key, pay_list
+                    return ProbeResult(path, pay_key, pay_list)
                 _log.debug("endpoint_probe: %s key=%r → %d but not chat-like", path, pay_key, status)
                 continue
 
@@ -487,7 +627,7 @@ async def _blind_probe(
             if known_payload_key:
                 # Caller-specified key got 4xx — accept: endpoint is real, mismatch is config
                 _log.info("endpoint_probe: selected %s (key=%r known, status=%d)", path, pay_key, status)
-                return path, pay_key, pay_list
+                return ProbeResult(path, pay_key, pay_list)
 
             # 422 — FastAPI/Pydantic validation error: body tells us the correct field name
             if status == 422:
@@ -519,19 +659,19 @@ async def _blind_probe(
                                 "endpoint_probe: 422-hint selected %s (key=%r, status=%d)",
                                 path, hint_key, hint_status,
                             )
-                            return path, hint_key, False
+                            return ProbeResult(path, hint_key, False)
                     elif hint_status not in (404, 405) and hint_status < 500:
                         _log.info(
                             "endpoint_probe: 422-hint selected %s (key=%r, status=%d)",
                             path, hint_key, hint_status,
                         )
-                        return path, hint_key, False
+                        return ProbeResult(path, hint_key, False)
 
     _log.warning("endpoint_probe: no chat-capable endpoint found after probing %d paths", len(paths))
     if server_error_fallback:
-        p_path, p_key, p_list = server_error_fallback
         _log.info(
-            "endpoint_probe: selected %s as fallback (5xx — payload_key=%r)", p_path, p_key,
+            "endpoint_probe: selected %s as fallback (5xx — payload_key=%r)",
+            server_error_fallback.path, server_error_fallback.key,
         )
         return server_error_fallback
     return None
@@ -546,7 +686,7 @@ async def _detect_chat_endpoint(
     probe_payload_extras: "dict[str, object] | None",
     known_payload_key: str | None = None,
     known_payload_list: bool = False,
-) -> "tuple[str, str, bool] | None":
+) -> "ProbeResult | None":
     """Ordered detection pipeline — smarter options first, blind probe as final fallback.
 
     When ``known_payload_key`` is set the detection options are skipped and the
@@ -588,17 +728,19 @@ async def probe_chat_endpoints(
     known_response_key: str | None = None,
     probe_payload_extras: "dict[str, object] | None" = None,
     hint_path: str | None = None,
-) -> "tuple[str, str, bool] | None":
+) -> "ProbeResult | None":
     """Probe SBOM POST endpoints and return the first chat-capable one.
+
+    Returns a :class:`ProbeResult` with ``(path, key, is_list)`` — supports
+    tuple unpacking so existing callers are unchanged.  Access
+    ``result.value_template`` to get the nested payload shape when OpenAPI
+    schema detection reveals the key expects a message object (e.g.
+    ``{"role": "user", "content": "..."}`` instead of a plain string).
 
     When ``hint_path`` is provided (Option B), only that specific path is probed
     — detection discovers the payload key/list for a user-specified endpoint.
-    When ``hint_path`` is ``None`` (Option A), all SBOM paths + fallbacks are
-    probed and both the path and key are auto-discovered.
-
     When ``known_payload_key`` is supplied the detection pipeline is skipped and
-    the probe verifies paths with that key only (the caller already knows the
-    shape; this just confirms which path accepts it).
+    the probe verifies paths with that key only.
     """
     paths = _sbom_post_paths(sbom)
 
@@ -616,7 +758,7 @@ async def probe_chat_endpoints(
             sbom_frameworks = [str(f).lower() for f in raw_frameworks if f]
     if ADK_FRAMEWORK_NAMES & set(sbom_frameworks):
         _log.info("endpoint_probe: Google ADK detected in SBOM — skipping detection, using /run")
-        return "/run", "__adk__", False
+        return ProbeResult("/run", "__adk__", False)
 
     # Always append common fallback paths so detection has candidates even when
     # the SBOM has no API_ENDPOINT nodes.

--- a/nuguard/common/session_resolver.py
+++ b/nuguard/common/session_resolver.py
@@ -53,6 +53,10 @@ class TargetSessionConfig:
     chat_response_key: str | None
     auth_session: "AuthSession"
     resolution_notes: list[str] = field(default_factory=list)
+    # Nested payload value template from OpenAPI schema detection.
+    # When set, the value for chat_payload_key is built from this template
+    # (e.g. {"role": "user", "content": "..."}) instead of a plain string.
+    chat_payload_value_template: "dict[str, object] | None" = None
 
 
 # ---------------------------------------------------------------------------
@@ -401,6 +405,7 @@ async def resolve_target_session(
     # Option B — path known but key is default: probe only the known path to
     #            detect the key; keep the user's path unchanged.
     _original_chat_path = chat_path
+    chat_payload_value_template: "dict[str, object] | None" = None
     if not chat_path:
         # Option A: discover both path and key
         probe_result = await probe_chat_endpoints(
@@ -413,6 +418,7 @@ async def resolve_target_session(
         )
         if probe_result is not None:
             chat_path, chat_payload_key, chat_payload_list = probe_result
+            chat_payload_value_template = probe_result.value_template
             _log.info("resolve_target_session: live probe selected endpoint %s", chat_path)
     elif chat_payload_key == "message":
         # Option B: path is known but key is still the default — detect key only
@@ -427,10 +433,11 @@ async def resolve_target_session(
         )
         if probe_result is not None:
             _probe_path, chat_payload_key, chat_payload_list = probe_result
+            chat_payload_value_template = probe_result.value_template
             # Keep the user's path — only the key and list are updated
             _log.info(
-                "resolve_target_session: key detection on %s found key=%r list=%s",
-                chat_path, chat_payload_key, chat_payload_list,
+                "resolve_target_session: key detection on %s found key=%r list=%s template=%s",
+                chat_path, chat_payload_key, chat_payload_list, bool(chat_payload_value_template),
             )
 
     # ── 8. Quality check ──────────────────────────────────────────────────────
@@ -458,6 +465,7 @@ async def resolve_target_session(
             auth_headers=effective_headers or None,
             sbom=sbom,
             payload_extras=merged_extras or None,
+            chat_payload_value_template=chat_payload_value_template,
         )
         async with _wu_client:
             from nuguard.redteam.target.session import AttackSession as _WS  # noqa: PLC0415
@@ -489,6 +497,7 @@ async def resolve_target_session(
             chat_response_key=chat_response_key,
             auth_session=bootstrapper.session,
             resolution_notes=resolution_notes,
+            chat_payload_value_template=chat_payload_value_template,
         ),
         health_report,
     )

--- a/nuguard/common/target_client_builder.py
+++ b/nuguard/common/target_client_builder.py
@@ -344,6 +344,8 @@ def build_target_app_client(
     explicitly_set: frozenset[str] | set[str] = frozenset(),
     payload_extras: dict[str, Any] | None = None,
     heal_llm: "LLMClient | None" = None,
+    # Nested value template from OpenAPI schema detection (ProbeResult.value_template).
+    chat_payload_value_template: "dict[str, Any] | None" = None,
 ) -> "TargetAppClient":
     """Build a :class:`TargetAppClient` with SBOM-assisted config resolution.
 
@@ -456,6 +458,7 @@ def build_target_app_client(
         framework_adapter=framework_adapter,
         chat_payload_extras=payload_extras or None,
         heal_llm=heal_llm,
+        chat_payload_value_template=chat_payload_value_template,
     )
     client.resolution_notes = resolution_notes
     return client

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -730,6 +730,9 @@ class RedteamOrchestrator:
         self._chat_path, self._chat_payload_key, self._chat_payload_list, _discovered_response_key = (
             _discover_chat_config(sbom, chat_path, chat_payload_key, chat_payload_list)
         )
+        # Payload value template from OpenAPI schema detection (ProbeResult.value_template).
+        # Populated by _maybe_probe_endpoints when the schema reveals a nested shape.
+        self._chat_payload_value_template: "dict | None" = None
         # Track how the effective endpoint was resolved for reporting.
         _input_explicit = bool(chat_path)
         if _input_explicit and self._chat_path == chat_path:
@@ -907,9 +910,10 @@ class RedteamOrchestrator:
         if self._eval_llm is not None:
             self._eval_llm.reset_token_counts()
 
-        # 0. Endpoint auto-discovery — when chat_path was not explicitly configured,
-        #    probe SBOM POST endpoints live to find one that accepts chat requests.
-        if not self._chat_path:
+        # 0. Endpoint auto-discovery (Option A) or payload-shape detection (Option B).
+        # Option A: no path configured — probe SBOM endpoints live.
+        # Option B: path known but key is default "message" — detect nested shape.
+        if not self._chat_path or self._chat_payload_key == "message":
             await self._maybe_probe_endpoints()
 
         # 0b. Auth bootstrap — resolve effective auth and verify every credential
@@ -1345,6 +1349,7 @@ class RedteamOrchestrator:
             explicitly_set=frozenset({"target_endpoint", "chat_payload_key", "chat_response_key"}),
             payload_extras=self._chat_payload_extras or None,
             heal_llm=self._eval_llm or self._redteam_llm,
+            chat_payload_value_template=self._chat_payload_value_template,
         )
         for _note in (getattr(client, "resolution_notes", None) or []):
             if isinstance(_note, str) and _note:
@@ -2902,20 +2907,48 @@ class RedteamOrchestrator:
     async def _maybe_probe_endpoints(self) -> None:
         """Live-probe SBOM endpoints when no explicit chat path is configured.
 
-        Updates ``self._chat_path``, ``self._chat_payload_key``, and
-        ``self._chat_payload_list`` in-place when a working endpoint is found.
-        Only runs when ``self._chat_path`` is empty or the generic default '/chat'.
+        Option A: path unknown — full endpoint + key discovery.
+        Option B: path known but key is default — hint_path probe to detect
+                  nested payload structure (e.g. from OpenAPI schema) without
+                  changing the endpoint.
         """
         from nuguard.common.endpoint_probe import probe_chat_endpoints  # noqa: PLC0415
-
-        if self._chat_path:
-            # Already have an explicit path — skip probing
-            return
 
         auth_headers: dict[str, str] = {}
         if self._extra_headers:
             auth_headers.update(self._extra_headers)
 
+        if self._chat_path:
+            # Option B: path already resolved — detect nested payload shape only.
+            if self._chat_payload_key != "message":
+                return  # key explicitly set too; nothing to detect
+            _log.info(
+                "redteam: endpoint known (%s) — probing payload structure via OpenAPI",
+                self._chat_path,
+            )
+            result = await probe_chat_endpoints(
+                target_url=self._target_url,
+                sbom=self._sbom,
+                auth_headers=auth_headers or None,
+                timeout=15.0,
+                known_payload_key=None,
+                known_payload_list=self._chat_payload_list,
+                known_response_key=self._chat_response_key,
+                probe_payload_extras=self._chat_payload_extras or None,
+                hint_path=self._chat_path,
+            )
+            if result:
+                _, pay_key, pay_list = result
+                self._chat_payload_key = pay_key
+                self._chat_payload_list = pay_list
+                self._chat_payload_value_template = result.value_template
+                _log.info(
+                    "redteam: payload structure detected for %s (key=%r list=%s template=%s)",
+                    self._chat_path, pay_key, pay_list, bool(result.value_template),
+                )
+            return
+
+        # Option A: no path — full endpoint + key discovery.
         _log.info(
             "redteam: target_endpoint not configured — probing SBOM endpoints at %s",
             self._target_url,
@@ -2943,6 +2976,7 @@ class RedteamOrchestrator:
             self._chat_path = path
             self._chat_payload_key = pay_key
             self._chat_payload_list = pay_list
+            self._chat_payload_value_template = result.value_template
             self._chat_path_source = "probe"
         else:
             _log.warning(

--- a/nuguard/redteam/target/client.py
+++ b/nuguard/redteam/target/client.py
@@ -245,11 +245,16 @@ class TargetAppClient:
         max_concurrent_requests: int = 0,
         max_transient_hold_seconds: float = 300.0,
         heal_llm: "LLMClient | None" = None,
+        # Nested value template from OpenAPI schema detection.  When set, the
+        # value for chat_payload_key is a dict built from this template instead
+        # of a plain string (e.g. {"role": "user", "content": "..."}).
+        chat_payload_value_template: "dict[str, Any] | None" = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self._chat_path = chat_path
         self._chat_payload_key = chat_payload_key
         self._chat_payload_list = chat_payload_list
+        self._chat_payload_value_template = chat_payload_value_template
         self._chat_payload_format = (
             chat_payload_format if chat_payload_format in ("json", "form") else "json"
         )
@@ -762,21 +767,30 @@ class TargetAppClient:
     def _build_chat_payload_value(self, payload: str, session: AttackSession) -> Any:
         """Shape the outgoing value for ``chat_payload_key`` in the generic (non-adapter) path.
 
-        Three shapes, chosen by ``chat_payload_list``/``chat_payload_key``:
+        Four shapes, chosen in priority order:
 
-        - Flat string (``chat_payload_list=False``): the raw prompt text.
+        - Nested object (``value_template`` set, ``chat_payload_list=False``):
+          fills the sentinel field in the schema-derived template with the chat
+          text; all other fields keep their schema defaults.  Works for any
+          nested structure, not just OpenAI-style role/content objects.
+        - Flat string (``chat_payload_list=False``, no template): the raw prompt text.
         - Bare list (``chat_payload_list=True``, key not a known message-history
           name): ``[prompt]`` — existing behaviour, e.g. LangGraph's
           ``phrases=[...]``.
         - OpenAI-style message history (``chat_payload_list=True`` and key is
           one of ``messages``/``history``/``conversation``/``chat_history``):
           replay prior turns from *session* as alternating ``{role, content}``
-          dicts, then append the current turn. This is the standard shape used
-          by OpenAI/Anthropic/LangChain-style chat APIs; endpoints whose only
-          accepted body shape is ``messages=[...]`` reject a bare string or a
-          bare-string list outright (400/422), aborting every scenario.
+          dicts, then append the current turn.
         """
         if not self._chat_payload_list:
+            if self._chat_payload_value_template is not None:
+                # Fill the sentinel field with the actual chat text; all other
+                # fields keep their schema-derived defaults.
+                from nuguard.common.endpoint_probe import _CHAT_TEXT_SENTINEL  # noqa: PLC0415
+                return {
+                    k: (payload if v == _CHAT_TEXT_SENTINEL else v)
+                    for k, v in self._chat_payload_value_template.items()
+                }
             return payload
         if not _is_message_history_key(self._chat_payload_key):
             return [payload]


### PR DESCRIPTION
Closes #386

## Summary

Adds automatic detection of nested JSON payload structures from OpenAPI/Swagger schemas, so nuguard can probe and red-team targets that expect structured message objects (e.g. `{"message": {"role": "user", "content": "..."}}`) instead of plain strings — without any manual `chat_payload_key` configuration.

### What changed

**`endpoint_probe.py` — `ProbeResult` dataclass**
- Replaces the raw `tuple[str, str, bool]` return with a `ProbeResult` dataclass that adds an optional `value_template` field.
- `__iter__` yields only the 3 positional fields so all existing callers that do `path, key, is_list = result` are unchanged.

**`endpoint_probe.py` — `_build_object_template()`**
- Introspects any OpenAPI object schema to build a field-name-agnostic payload template.
- First pass places `_CHAT_TEXT_SENTINEL` on the most likely content field (`content` > `text` > `message` > `body` > `input` > `prompt` > `query` > `msg`).
- Second pass fills required fields with type-appropriate defaults (`""`, `0`, `False`, first enum value, nested object up to depth 2).
- Returns `None` when no recognisable content field is found → falls back to plain string (no regression).

**`client.py` — `_build_chat_payload_value()`**
- New first branch: when `value_template` is set, replaces any field whose value equals `_CHAT_TEXT_SENTINEL` with the actual chat text at send time. Works for any field name — not hardcoded to `content`.

**`orchestrator.py` — `_maybe_probe_endpoints()`**
- Added Option B: when the endpoint is already known but the key is still the default `"message"`, fires a `hint_path` probe against that specific endpoint to detect the nested shape via OpenAPI.
- Fixes pre-flight 422 failures on FastAPI/Pydantic targets that require a structured message object.
- Call site updated: `_maybe_probe_endpoints` now runs when `not chat_path OR chat_payload_key == "message"` (was: only when `not chat_path`).

**Propagation chain**
`ProbeResult.value_template` → `TargetSessionConfig.chat_payload_value_template` → `build_target_app_client(chat_payload_value_template=...)` → `TargetAppClient._chat_payload_value_template`

### Validation

Tested end-to-end against the NuGuard dev chatbot (`https://api-dev.nuguard.ai/api/chat`):
- OpenAPI schema fetched from `/openapi.json` ✓
- Payload key `messages` (list=True) auto-detected ✓
- Bootstrap + pre-flight passed ✓
- 131 scenarios published, ~80 executed before token expiry ✓
- 2 findings produced (context flooding data exfiltration, system prompt disclosure) ✓

Unit tests: `pytest tests/common/test_endpoint_probe.py nuguard/common/tests/ nuguard/redteam/tests/test_message_history_payload.py` — 61 passed.