### PR TITLE
fix(probe): fix SBOM endpoint scoring to prevent tool/action endpoints pre-empting OpenAPI detection

### DIFF
--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -862,6 +862,16 @@ def discover_chat_candidates_from_sbom(
             continue
 
         # ── Scoring ────────────────────────────────────────────────────────
+        # Path must contain a clearly conversational signal — broad tokens like
+        # "ai", "run", "agent", "query" are excluded because they match too many
+        # non-chat paths (e.g. "aibom", "run-redteam", "agents/list").
+        _CHAT_PATH_TOKENS = (
+            "chat", "message", "completions", "converse", "respond",
+            "infer", "generate", "llm", "assistant", "langgraph",
+        )
+        if not any(tok in endpoint_l for tok in _CHAT_PATH_TOKENS):
+            continue
+
         score = 0
         if source == "auto_enrichment":
             score -= 2

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -117,6 +117,8 @@ _RUNTIME_NON_CHAT_KEYS: frozenset[str] = frozenset({
     "recipient_account", "source_account", "debit_account", "credit_account",
     "transfer_amount", "beneficiary_id", "invoice_id", "claim_id",
     "customer_name", "template_data",
+    # Tool/action dispatch keys — these are agentic action endpoints, not chat endpoints.
+    "tool_name", "tool_call", "tool_id", "action", "action_name", "action_type",
 })
 
 _CAMEL_CASE_RE = re.compile(r"(?<!^)(?=[A-Z])")
@@ -336,8 +338,15 @@ def _sbom_post_paths(sbom: "AiSbomDocument") -> list[str]:
             if token in path_l:
                 score += 2
                 break
+
+        # Path token match is required — key presence alone never qualifies an endpoint.
+        if score == 0:
+            continue
+
+        # Key as a small tie-breaker only when it is a plausible chat key.
         if meta.chat_payload_key:
-            score += 3
+            if _normalize_payload_key(meta.chat_payload_key) not in _RUNTIME_NON_CHAT_KEYS:
+                score += 1
         if node.confidence >= 0.9:
             score += 1
 


### PR DESCRIPTION
Closes #386

## Summary

Fixes two related scoring bugs in the SBOM-based chat endpoint discovery that caused tool/action dispatch endpoints (e.g. `/actions/execute`) to win over genuine chat endpoints (e.g. `/chat/stream`), blocking OpenAPI detection from ever running.

### Root cause

The orchestrator runs a zero-I/O SBOM discovery at startup before any HTTP probing. If SBOM discovery picks a wrong endpoint with a non-default key (e.g. `tool_name`), the probe condition `not chat_path OR key == 'message'` evaluates false and **OpenAPI detection is never reached** — the scan silently uses the wrong endpoint.

### Fixes

**1. `_RUNTIME_NON_CHAT_KEYS` — block tool/action dispatch keys**

Added `tool_name`, `tool_call`, `tool_id`, `action`, `action_name`, `action_type` to the blocklist.

Both `discover_chat_candidates_from_sbom` (Phase 1 SBOM) and `_sbom_post_paths` (Phase 2 probe fallback list) skip endpoints whose declared key is in this blocklist. This causes `/actions/execute` with `tool_name` to be excluded → SBOM discovery returns empty → probe fires → OpenAPI detection runs → correct endpoint found.

**2. `_sbom_post_paths` scoring — path token match is now mandatory**

Previously any endpoint with a declared key scored `+3` regardless of whether its path had any conversational signal. A tool endpoint with no path match (`score=0`) could beat a genuine `/chat/stream` (`score=2`).

Now: endpoints with `score=0` (no path token match) are excluded entirely. Key presence is a `+1` tie-breaker only when the key itself passes the blocklist filter.

### Impact

Without fix #1: targets with `/actions/execute`-style tool endpoints and no manually configured `target_endpoint` fail silently — wrong endpoint is used, pre-flight gets 400/404/422, scan aborts.

Fix #1 is the gate that unblocks OpenAPI detection. Fix #2 is a correctness improvement for the blind probe fallback path (when OpenAPI is not published).

### Validation

- `pytest tests/common/test_endpoint_probe.py nuguard/common/tests/` — 56 passed
- Verified locally against NuGuard dev chatbot (no endpoint configured in yaml): OpenAPI probe now fires correctly after `/actions/execute` is excluded