### PR TITLE
fix(e2e): add chat_payload_extras for gemini-auto to fix preflight 422

### DIFF
--- a/tests/apps/Gemini-Auto-app/nuguard.prepublish.yaml
+++ b/tests/apps/Gemini-Auto-app/nuguard.prepublish.yaml
@@ -63,25 +63,25 @@ target:
   #   vehicleState.fuel, .tirePressure, .music.playing, .weather.temp are mandatory
   #   — the server throws 'Cannot read properties of undefined' for each missing one.
   #   language / googleAccessToken are optional but included for fidelity.
-  #chat_payload_extras:
-  #  vehicleState:
-  #    fuel: 75
-  #    temp: 21
-  #    tirePressure: [32, 32, 32, 32]   # any array; server reads [0]
-  #    battery: 85
-  #    destination: null
-  #    stops: []
-  #    navMetadata: null
-  #    music:
-  #      playing: false                 # required; track/artist/provider optional
-  #      track: ""
-  #      artist: ""
-  #      provider: simulated
-  #    weather:
-  #      temp: 22                       # required; condition optional
-  #      condition: sunny
-  #  language: en-US
-  #  googleAccessToken: null
+  chat_payload_extras:
+    vehicleState:
+      fuel: 75
+      temp: 21
+      tirePressure: [32, 32, 32, 32]
+      battery: 85
+      destination: null
+      stops: []
+      navMetadata: null
+      music:
+        playing: false
+        track: ""
+        artist: ""
+        provider: simulated
+      weather:
+        temp: 22
+        condition: sunny
+    language: en-US
+    googleAccessToken: null
 
 # ─── Behavior mode ────────────────────────────────────────────────────────────
 sbom: ./gemini-auto.sbom.json


### PR DESCRIPTION
Closes #386

## Summary

The gemini-auto prepublish redteam scan was failing with `redteam_scenarios_executed_zero` because:

1. `/api/agent/chat` requires `vehicleState` (fuel, tirePressure, music.playing, weather.temp) in every request — without it the server returns 422.
2. `endpoint_preflight` treats HTTP 422 as a rotation trigger (same as 400/404/405).
3. With `target_endpoint` explicitly configured, the preflight enforces endpoint precedence and returns `ok=False` instead of rotating.
4. The orchestrator aborts with `scan_outcome=aborted_endpoint_unreachable` → zero scenarios → gate fails.

**Fix:** Uncomment `chat_payload_extras` in `nuguard.prepublish.yaml` so the preflight test request and every redteam scenario include the required `vehicleState` fields, allowing the endpoint to return 200.

## Validation

Locally confirmed that `chat_payload_extras` is now active in the gemini-auto prepublish config. The required fields match what the server expects per the inline YAML comments (fuel, tirePressure, music.playing, weather.temp are mandatory).