### PR TITLE
fix(probe): skip ADK fast-path when hint_path is explicitly set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tmp/
 !.env.example
 tests/redteam/.env
 .python-version
+tests/local/
 
 # Canary seed files contain fake-but-realistic PII — do not commit live versions
 # (the .example version is intentionally tracked)

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -765,7 +765,7 @@ async def probe_chat_endpoints(
         raw_frameworks = getattr(summary, "frameworks", None)
         if isinstance(raw_frameworks, (list, tuple)):
             sbom_frameworks = [str(f).lower() for f in raw_frameworks if f]
-    if ADK_FRAMEWORK_NAMES & set(sbom_frameworks):
+    if ADK_FRAMEWORK_NAMES & set(sbom_frameworks) and not hint_path:
         _log.info("endpoint_probe: Google ADK detected in SBOM — skipping detection, using /run")
         return ProbeResult("/run", "__adk__", False)
 


### PR DESCRIPTION
Closes #386

## Summary

Fixes a regression introduced by PR #391 (Option B probe) where the ADK fast-path in `probe_chat_endpoints()` was ignoring the caller-provided `hint_path`, causing the preflight to fail for apps like gemini-auto that use Google ADK internally.

**Root cause chain:**
1. PR #391 added Option B in `_maybe_probe_endpoints()`: when `target_endpoint` is configured but `chat_payload_key` is still the default `'message'`, the orchestrator calls `probe_chat_endpoints(hint_path=...)` to detect only the key shape.
2. The ADK fast-path inside `probe_chat_endpoints()` checked `ADK_FRAMEWORK_NAMES & set(sbom_frameworks)` unconditionally and returned `ProbeResult("/run", "__adk__", False)` — ignoring `hint_path`.
3. The orchestrator then set `chat_payload_key = "__adk__"` instead of `"message"`, causing the preflight to send `{"__adk__": "Hello"}` → server returned 400 → scan aborted.

**Fix:** Guard the ADK shortcut with `and not hint_path` — it only fires in full auto-discovery mode. When `hint_path` is provided the endpoint is already known; only the key shape needs detecting.

**One-line change in `nuguard/common/endpoint_probe.py`:**
```diff
-    if ADK_FRAMEWORK_NAMES & set(sbom_frameworks):
+    if ADK_FRAMEWORK_NAMES & set(sbom_frameworks) and not hint_path:
```

## Validation

Ran `nuguard redteam --config tests/apps/Gemini-Auto-app/nuguard.prepublish.yaml` locally with the fix. Probe correctly selects `/api/agent/chat (key='message', status=200)` instead of being hijacked to `/run`.