### PR TITLE
fix(sbom): add .mjs and .cjs to TypeScript extension dispatch

### DIFF
--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -110,7 +110,8 @@ _SQL_EXTENSIONS = {".sql"}
 # Jupyter notebooks: cells are extracted and parsed as Python
 _NOTEBOOK_EXTENSIONS = {".ipynb"}
 # TypeScript/JavaScript: tree-sitter (or regex fallback) via core/ts_parser
-_TYPESCRIPT_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx"}
+# .mjs = ESM JavaScript, .cjs = CommonJS JavaScript — both contain JS/TS-compatible code
+_TYPESCRIPT_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}
 # Dockerfile: extensionless file named "Dockerfile" or suffixed ".dockerfile"
 _DOCKERFILE_EXTENSIONS = {".dockerfile"}
 _DOCKERFILE_NAMES = {"dockerfile"}  # lower-cased stem match

--- a/nuguard/sbom/tests/test_mjs_cjs_dispatch.py
+++ b/nuguard/sbom/tests/test_mjs_cjs_dispatch.py
@@ -1,0 +1,100 @@
+"""Test that .mjs and .cjs files are dispatched through the TS adapter pipeline."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from nuguard.sbom.config import AiSbomConfig
+from nuguard.sbom.extractor import AiSbomExtractor
+from nuguard.sbom.extractor.core import _TYPESCRIPT_EXTENSIONS
+from nuguard.sbom.types import ComponentType
+
+
+def _extract_from_tmp(files: dict[str, str], config: AiSbomConfig | None = None):
+    """Create a temp dir with the given files and extract from it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for name, content in files.items():
+            path = Path(tmpdir) / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        cfg = config or AiSbomConfig(enable_llm=False)
+        return AiSbomExtractor().extract_from_path(Path(tmpdir), cfg)
+
+
+class TestMjsCjsInTypescriptExtensions:
+    """Verify .mjs and .cjs are included in the TypeScript extension set."""
+
+    def test_mjs_in_typescript_extensions(self) -> None:
+        assert ".mjs" in _TYPESCRIPT_EXTENSIONS
+
+    def test_cjs_in_typescript_extensions(self) -> None:
+        assert ".cjs" in _TYPESCRIPT_EXTENSIONS
+
+    def test_original_extensions_still_present(self) -> None:
+        for ext in (".ts", ".tsx", ".js", ".jsx"):
+            assert ext in _TYPESCRIPT_EXTENSIONS
+
+
+class TestMjsFileProcessedByTsAdapters:
+    """Verify .mjs files go through the TS adapter pipeline."""
+
+    def test_mjs_with_openai_client_detected(self) -> None:
+        """An .mjs file importing openai should produce a MODEL detection."""
+        source = """\
+import OpenAI from 'openai';
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const response = await client.chat.completions.create({
+    model: "gpt-4o",
+    messages: [{ role: "user", content: "Hello" }],
+});
+"""
+        cfg = AiSbomConfig(
+            include_extensions={".mjs"},
+            enable_llm=False,
+        )
+        doc = _extract_from_tmp({"src/index.mjs": source}, cfg)
+        models = [n for n in doc.nodes if n.component_type == ComponentType.MODEL]
+        assert len(models) >= 1, "Expected MODEL node from .mjs OpenAI import"
+
+    def test_cjs_with_openai_client_detected(self) -> None:
+        """A .cjs file requiring openai should produce a MODEL detection."""
+        source = """\
+const OpenAI = require('openai');
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+async function main() {
+    const response = await client.chat.completions.create({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello" }],
+    });
+}
+"""
+        cfg = AiSbomConfig(
+            include_extensions={".cjs"},
+            enable_llm=False,
+        )
+        doc = _extract_from_tmp({"src/index.cjs": source}, cfg)
+        models = [n for n in doc.nodes if n.component_type == ComponentType.MODEL]
+        assert len(models) >= 1, "Expected MODEL node from .cjs OpenAI import"
+
+    def test_mjs_unrelated_not_false_positive(self) -> None:
+        """An .mjs file without AI imports should produce no detections."""
+        source = """\
+import express from 'express';
+const app = express();
+app.get('/', (req, res) => res.send('Hello World'));
+app.listen(3000);
+"""
+        cfg = AiSbomConfig(
+            include_extensions={".mjs"},
+            enable_llm=False,
+        )
+        doc = _extract_from_tmp({"src/server.mjs": source}, cfg)
+        ai_nodes = [
+            n for n in doc.nodes
+            if n.component_type in (
+                ComponentType.MODEL, ComponentType.FRAMEWORK,
+                ComponentType.TOOL, ComponentType.AGENT,
+            )
+        ]
+        assert len(ai_nodes) == 0, "Unrelated .mjs should produce no AI detections"


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

## Summary

ESM (`.mjs`) and CommonJS (`.cjs`) JavaScript files were silently skipped by the tree-sitter-based TypeScript adapter pipeline, receiving only regex-based fallback detection.

## Root cause

`_TYPESCRIPT_EXTENSIONS` in `extractor/core.py` only contained `{".ts", ".tsx", ".js", ".jsx"}`. Files with `.mjs` or `.cjs` extensions — increasingly common in modern Node.js projects — were never dispatched to the TS adapter pipeline, so they missed framework-specific detection (LangChain, OpenAI Agents, LLM clients, etc.).

## Fix

Add `.mjs` and `.cjs` to `_TYPESCRIPT_EXTENSIONS` so they route through the same adapter pipeline as `.ts/.tsx/.js/.jsx`. The `_iter_ts_sources` cross-file pre-pass remains `.ts/.tsx`-only since ESM/CJS files rarely contain TypeScript-specific type exports needed for cross-file DTO resolution.

## Tests

6 new tests verifying:
- `.mjs`/`.cjs` are in the extension set
- Original extensions are preserved
- `.mjs` with OpenAI import produces MODEL detection
- `.cjs` with OpenAI `require` produces MODEL detection
- Unrelated `.mjs` produces no false positives

## Testing

```bash
uv run pytest nuguard/sbom/tests/test_mjs_cjs_dispatch.py -v
```

## Related

Addresses #386 (partial — the `.mjs`/`.cjs` dispatch gap)

Fixes #416