### PR TITLE
fix(config): wire tool_trace_hits from YAML to RedteamFindingTriggers

### DIFF
--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -401,6 +401,10 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             flat["redteam_trigger_any_inject_success"] = bool(
                 finding_triggers["any_inject_success"]
             )
+        if "tool_trace_hits" in finding_triggers:
+            flat["redteam_trigger_tool_trace_hits"] = bool(
+                finding_triggers["tool_trace_hits"]
+            )
 
     # Redteam LLM section — skip keys whose env-var interpolation produced None
     redteam_llm = redteam.get("llm", {}) or {}
@@ -1403,6 +1407,13 @@ class NuGuardConfig(BaseSettings):
             "signals (yaml: redteam.finding_triggers.any_inject_success)."
         ),
     )
+    redteam_trigger_tool_trace_hits: bool = Field(
+        default=True,
+        description=(
+            "Emit findings when tool-call traces reveal destructive actions "
+            "(yaml: redteam.finding_triggers.tool_trace_hits)."
+        ),
+    )
     redteam_pre_run_warmup: int = Field(
         default=0,
         ge=0,
@@ -1621,6 +1632,7 @@ class NuGuardConfig(BaseSettings):
             policy_violations=self.redteam_trigger_policy_violations,
             critical_success_hits=self.redteam_trigger_critical_success_hits,
             any_inject_success=self.redteam_trigger_any_inject_success,
+            tool_trace_hits=self.redteam_trigger_tool_trace_hits,
         )
 
     model_config = SettingsConfigDict(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -857,3 +857,37 @@ class TestUnsetEnvVarScalarFields:
               emit_pytest_dir: ${EPD}
         """)
         assert "emit_pytest_dir" not in flat
+
+
+class TestToolTraceHitsConfig:
+    """Verify tool_trace_hits is parsed from YAML and wired to RedteamFindingTriggers."""
+
+    def test_flatten_yaml_tool_trace_hits_true(self) -> None:
+        flat = _flatten("""
+            redteam:
+              finding_triggers:
+                tool_trace_hits: true
+        """)
+        assert flat["redteam_trigger_tool_trace_hits"] is True
+
+    def test_flatten_yaml_tool_trace_hits_false(self) -> None:
+        flat = _flatten("""
+            redteam:
+              finding_triggers:
+                tool_trace_hits: false
+        """)
+        assert flat["redteam_trigger_tool_trace_hits"] is False
+
+    def test_default_tool_trace_hits_is_true(self) -> None:
+        cfg = NuGuardConfig()
+        assert cfg.redteam_trigger_tool_trace_hits is True
+
+    def test_resolved_triggers_passes_tool_trace_hits(self) -> None:
+        cfg = NuGuardConfig(redteam_trigger_tool_trace_hits=False)
+        triggers = cfg.resolved_redteam_finding_triggers()
+        assert triggers.tool_trace_hits is False
+
+    def test_resolved_triggers_default_tool_trace_hits(self) -> None:
+        cfg = NuGuardConfig()
+        triggers = cfg.resolved_redteam_finding_triggers()
+        assert triggers.tool_trace_hits is True


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

## Summary

The `tool_trace_hits` config option was documented in `nuguard.yaml.example` and defined in `RedteamFindingTriggers`, but was never parsed from YAML and never wired to the constructor — making it silently dead.

## Root cause

Three missing links in the config pipeline:

1. `_flatten_yaml()` parsed `canary_hits`, `policy_violations`, `critical_success_hits`, and `any_inject_success` from `redteam.finding_triggers` but skipped `tool_trace_hits`
2. `NuGuardConfig` had no `redteam_trigger_tool_trace_hits` field
3. `resolved_redteam_finding_triggers()` didn't pass `tool_trace_hits` to the `RedteamFindingTriggers` constructor

Result: `tool_trace_hits` always defaulted to `True` regardless of what the user configured.

## Fix

- Add `tool_trace_hits` parsing in `_flatten_yaml()` (3 lines)
- Add `redteam_trigger_tool_trace_hits` field to `NuGuardConfig` (7 lines)
- Pass `tool_trace_hits` in `resolved_redteam_finding_triggers()` (1 line)

## Tests

5 new tests verifying YAML true/false parsing, default value, and wiring through `resolved_redteam_finding_triggers()`.

## Testing

```bash
uv run pytest tests/test_config.py::TestToolTraceHitsConfig -v
```

Fixes #417