### PR TITLE
feat(redteam): log effective chat endpoint after resolution

### DIFF
--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -916,6 +916,14 @@ class RedteamOrchestrator:
         if not self._chat_path or self._chat_payload_key == "message":
             await self._maybe_probe_endpoints()
 
+        _log.info(
+            "Effective chat endpoint: path=%r key=%r list=%s source=%s",
+            self._chat_path or "/chat",
+            self._chat_payload_key,
+            self._chat_payload_list,
+            self._chat_path_source,
+        )
+
         # 0b. Auth bootstrap — resolve effective auth and verify every credential
         #    before running any scenario. Raises TargetUnavailableError on network
         #    failure; raises AuthError when the default credential is rejected.


### PR DESCRIPTION
Closes #386

## Summary

Adds a single structured `INFO` log line in the orchestrator immediately after all endpoint/key resolution completes (SBOM scoring, probe, config), making it easy to diagnose which endpoint and payload shape nuguard selected and how it was detected.

**Log line format:**
```
INFO  Effective chat endpoint: path='/api/agent/chat' key='message' list=False source=sbom
```

**`source` values:**
- `config` — endpoint was explicitly set in `nuguard.yaml`
- `sbom` — selected via SBOM endpoint scoring
- `probe` — discovered by live probe
- `default` — fell back to `/chat` (no SBOM candidates, probe failed)

## Validation

Ran locally against gemini-auto with endpoint commented out — log line correctly shows `source=sbom` with the SBOM-discovered endpoint.