### PR TITLE
fix(behavior): write plain text instead of Markdown for --format text --output

### DIFF
--- a/nuguard/behavior/report.py
+++ b/nuguard/behavior/report.py
@@ -984,3 +984,65 @@ def to_text(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = None) 
             sev = str(f.get("severity", "")).upper()
             color = {"CRITICAL": "red", "HIGH": "red", "MEDIUM": "yellow", "LOW": "blue"}.get(sev, "white")
             console.print(f"  [{color}][{sev}][/{color}] {f.get('title', '')}")
+
+
+def to_text_str(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = None) -> str:
+    """Return a plain-text (no Rich markup) report string.
+
+    Used when ``--format text --output <file>`` is requested so that the
+    written file contains readable plain text rather than Markdown.
+
+    Args:
+        result: Complete BehaviorAnalysisResult.
+        meta: Optional report metadata.
+
+    Returns:
+        Plain-text report as a string.
+    """
+    lines: list[str] = []
+
+    # Summary
+    lines.append("Behavior Analysis Summary")
+    lines.append("=" * 40)
+    lines.append(f"  Intent:        {result.intent.app_purpose or 'not determined'}")
+    lines.append(f"  Risk Score:    {result.overall_risk_score:.1f} / 100")
+    lines.append(f"  Coverage:      {result.coverage_percentage * 100:.0f}%")
+    lines.append(f"  Alignment:     {result.intent_alignment_score:.2f} / 5.0")
+    lines.append(f"  Findings:      {len(result.static_findings) + len(result.dynamic_findings)}")
+    lines.append(f"  Outcome:       {result.scan_outcome}")
+    lines.append("")
+
+    # Config notes
+    if result.config_notes:
+        lines.append("Configuration Notes")
+        lines.append("-" * 40)
+        for note in result.config_notes:
+            lines.append(f"  - {note}")
+        lines.append("")
+
+    # Coverage table
+    if result.coverage:
+        lines.append("Component Coverage")
+        lines.append("-" * 40)
+        header = f"  {'Component':<30} {'Type':<15} {'Exercised':<10} {'In Policy':<10} {'Deviations':<10}"
+        lines.append(header)
+        lines.append("  " + "-" * 75)
+        for cov in result.coverage:
+            ex = "Yes" if cov.exercised else "No"
+            wp = "Yes" if cov.exercised_within_policy else ("No" if cov.exercised else "-")
+            name = cov.component_name[:29]
+            ntype = cov.node_type[:14]
+            lines.append(f"  {name:<30} {ntype:<15} {ex:<10} {wp:<10} {len(cov.deviations):<10}")
+        lines.append("")
+
+    # Findings
+    all_findings = list(result.static_findings) + list(result.dynamic_findings)
+    if all_findings:
+        lines.append("Findings")
+        lines.append("-" * 40)
+        for f in all_findings:
+            sev = str(f.get("severity", "")).upper()
+            lines.append(f"  [{sev}] {f.get('title', '')}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/nuguard/cli/commands/behavior.py
+++ b/nuguard/cli/commands/behavior.py
@@ -351,12 +351,14 @@ async def _run_behavior(
             return to_json(result, meta)
         if fmt == "markdown":
             return to_markdown(result, meta)
-        if output_path is None:
-            to_text(result, meta)
-            return None
-        # Preserve prior behavior for --format text --output ...
-        # where markdown was written to file.
-        return to_markdown(result, meta)
+        if fmt == "text":
+            if output_path is None:
+                to_text(result, meta)
+                return None
+            from nuguard.behavior.report import to_text_str  # noqa: PLC0415
+
+            return to_text_str(result, meta)
+        return None
 
     if output_path is not None:
         for fmt in formats:

--- a/tests/behavior/test_report.py
+++ b/tests/behavior/test_report.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 
 from nuguard.behavior.models import BehaviorAnalysisResult, BehaviorCoverage, IntentProfile, ScenarioResult
-from nuguard.behavior.report import to_markdown
+from nuguard.behavior.report import to_markdown, to_text_str
 from nuguard.cli.report_meta import ReportMeta
 
 
@@ -216,3 +216,89 @@ def test_to_markdown_recommendations_and_remediation_are_separate_sections():
     assert "## Recommendations" in md
     # No remediation_plan was supplied, so no Remediation Plan section is emitted.
     assert "## Remediation Plan" not in md
+
+
+# ---------------------------------------------------------------------------
+# to_text_str — plain-text file output
+# ---------------------------------------------------------------------------
+
+
+def test_to_text_str_returns_string():
+    """to_text_str must return a plain-text string, not None."""
+    result = _make_result()
+    output = to_text_str(result)
+    assert isinstance(output, str)
+    assert len(output) > 0
+
+
+def test_to_text_str_no_markdown_syntax():
+    """Plain-text output must not contain Markdown heading or table syntax."""
+    result = _make_result(
+        dynamic_findings=[_finding("high")],
+    )
+    output = to_text_str(result)
+    assert not output.lstrip().startswith("#"), "Should not start with Markdown heading"
+    assert "|" not in output, "Should not contain Markdown table pipes"
+
+
+def test_to_text_str_no_ansi_escapes():
+    """Plain-text output must not contain ANSI escape sequences."""
+    result = _make_result()
+    output = to_text_str(result)
+    assert "\x1b[" not in output, "Plain text must not contain ANSI escapes"
+
+
+def test_to_text_str_contains_summary_fields():
+    """Summary section must include all key metrics."""
+    result = _make_result(dynamic_findings=[_finding("critical")])
+    output = to_text_str(result)
+    assert "Behavior Analysis Summary" in output
+    assert "Intent:" in output
+    assert "Risk Score:" in output
+    assert "Coverage:" in output
+    assert "Findings:" in output
+    assert "Outcome:" in output
+
+
+def test_to_text_str_with_findings():
+    """Findings section must list severity and title."""
+    result = _make_result(
+        dynamic_findings=[_finding("critical"), _finding("low")],
+    )
+    output = to_text_str(result)
+    assert "[CRITICAL]" in output
+    assert "[LOW]" in output
+    assert "critical issue" in output
+    assert "low issue" in output
+
+
+def test_to_text_str_with_config_notes():
+    """Config notes must appear when present."""
+    result = _make_result(config_notes=["No SBOM provided"])
+    output = to_text_str(result)
+    assert "Configuration Notes" in output
+    assert "No SBOM provided" in output
+
+
+def test_to_text_str_without_config_notes():
+    """Config notes section must be omitted when empty."""
+    result = _make_result()
+    output = to_text_str(result)
+    assert "Configuration Notes" not in output
+
+
+def test_to_text_str_with_coverage():
+    """Coverage table must render as aligned text, not Markdown table."""
+    cov = BehaviorCoverage(
+        component_name="booking_agent",
+        node_type="AGENT",
+        exercised=True,
+        exercised_within_policy=True,
+    )
+    result = _make_result(coverage=[cov])
+    output = to_text_str(result)
+    assert "Component Coverage" in output
+    assert "booking_agent" in output
+    assert "AGENT" in output
+    # Must be a plain-text table (dashes for alignment), not Markdown pipes
+    assert "---" in output


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

## What changed

Fixed the behavior command's `--format text --output` dispatch so it writes plain text instead of Markdown.

The `_render` closure in `behavior.py` fell through to `to_markdown()` when `fmt == "text"` and `output_path` was set, because `to_text()` returns `None` (it prints to stdout via Rich). This caused `nuguard behavior --format text --output report.txt` to silently write Markdown content to the file.

## Why it changed

Users requesting `--format text --output report.txt` expect a plain-text file, not Markdown. Any downstream tooling (parsing, diffing, piping) expecting plain text would break.

## How I validated

- Added `to_text_str()` in `nuguard/behavior/report.py` that returns a plain-text string (no Rich markup, no Markdown syntax)
- Updated `_render` in `behavior.py` to call `to_text_str()` for file-backed text output
- Added 8 unit tests covering: return type, no Markdown syntax, no ANSI escapes, summary fields, findings, config notes, and coverage table
- All existing tests pass (2140 passed, 4 pre-existing failures unrelated to this change)
- Lint (`ruff check`) and type check (`mypy`) clean

Fixes #412
