### PR TITLE
fix(config): wire tool_trace_hits from YAML to RedteamFindingTriggers

### DIFF
--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -406,6 +406,10 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             flat["redteam_trigger_any_inject_success"] = bool(
                 finding_triggers["any_inject_success"]
             )
+        if "tool_trace_hits" in finding_triggers:
+            flat["redteam_trigger_tool_trace_hits"] = bool(
+                finding_triggers["tool_trace_hits"]
+            )
 
     # Redteam LLM section — skip keys whose env-var interpolation produced None
     redteam_llm = redteam.get("llm", {}) or {}
@@ -1425,6 +1429,13 @@ class NuGuardConfig(BaseSettings):
             "signals (yaml: redteam.finding_triggers.any_inject_success)."
         ),
     )
+    redteam_trigger_tool_trace_hits: bool = Field(
+        default=True,
+        description=(
+            "Emit findings when tool-call traces reveal destructive actions "
+            "(yaml: redteam.finding_triggers.tool_trace_hits)."
+        ),
+    )
     redteam_pre_run_warmup: int = Field(
         default=0,
         ge=0,
@@ -1656,6 +1667,7 @@ class NuGuardConfig(BaseSettings):
             policy_violations=self.redteam_trigger_policy_violations,
             critical_success_hits=self.redteam_trigger_critical_success_hits,
             any_inject_success=self.redteam_trigger_any_inject_success,
+            tool_trace_hits=self.redteam_trigger_tool_trace_hits,
         )
 
     model_config = SettingsConfigDict(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -857,3 +857,37 @@ class TestUnsetEnvVarScalarFields:
               emit_pytest_dir: ${EPD}
         """)
         assert "emit_pytest_dir" not in flat
+
+
+class TestToolTraceHitsConfig:
+    """Verify tool_trace_hits is parsed from YAML and wired to RedteamFindingTriggers."""
+
+    def test_flatten_yaml_tool_trace_hits_true(self) -> None:
+        flat = _flatten("""
+            redteam:
+              finding_triggers:
+                tool_trace_hits: true
+        """)
+        assert flat["redteam_trigger_tool_trace_hits"] is True
+
+    def test_flatten_yaml_tool_trace_hits_false(self) -> None:
+        flat = _flatten("""
+            redteam:
+              finding_triggers:
+                tool_trace_hits: false
+        """)
+        assert flat["redteam_trigger_tool_trace_hits"] is False
+
+    def test_default_tool_trace_hits_is_true(self) -> None:
+        cfg = NuGuardConfig()
+        assert cfg.redteam_trigger_tool_trace_hits is True
+
+    def test_resolved_triggers_passes_tool_trace_hits(self) -> None:
+        cfg = NuGuardConfig(redteam_trigger_tool_trace_hits=False)
+        triggers = cfg.resolved_redteam_finding_triggers()
+        assert triggers.tool_trace_hits is False
+
+    def test_resolved_triggers_default_tool_trace_hits(self) -> None:
+        cfg = NuGuardConfig()
+        triggers = cfg.resolved_redteam_finding_triggers()
+        assert triggers.tool_trace_hits is True


### PR DESCRIPTION
## PR Type
- [x] Bug fix
- [ ] Feature

## Root Cause
`RedteamFindingTriggers.tool_trace_hits` exists in the data model and is
included in `any_enabled()`, but the YAML→`NuGuardConfig`→trigger
pipeline never wired it: `_flatten_yaml` skipped the key, the
`NuGuardConfig` had no `redteam_trigger_tool_trace_hits` Field, and
`resolved_redteam_finding_triggers()` didn't pass it through. Setting
`redteam.finding_triggers.tool_trace_hits: false` in `nuguard.yaml` was
silently ignored.

## What Changed
1. `_flatten_yaml`: map `finding_triggers.tool_trace_hits` →
   `redteam_trigger_tool_trace_hits`
2. `NuGuardConfig`: add `redteam_trigger_tool_trace_hits: bool` Field
   (default `True`)
3. `resolved_redteam_finding_triggers()`: pass the field through

## Why
Users who set `tool_trace_hits: false` in their config expected the
trigger to be disabled. Because the wiring was missing, the setting was
dropped and the trigger defaulted to `True` regardless of configuration.

## How Validated
- 5 new tests in `TestToolTraceHitsConfig`:
  - `test_flatten_yaml_tool_trace_hits_true`
  - `test_flatten_yaml_tool_trace_hits_false`
  - `test_default_tool_trace_hits_is_true`
  - `test_resolved_triggers_passes_tool_trace_hits`
  - `test_resolved_triggers_default_tool_trace_hits`
- `uv run pytest tests/test_config.py -v` — 150 passed, 1 skipped
- `uv run ruff check nuguard/config.py` — clean

## Release Notes
The `redteam.finding_triggers.tool_trace_hits` YAML setting now
correctly propagates through `NuGuardConfig` to `RedteamFindingTriggers`.
Previously the setting was silently ignored and always defaulted to
enabled.

Fixes #417