### PR TITLE
fix(redteam): re-arm the direct-HTTP endpoint circuit breaker across passes

### DIFF
--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -290,8 +290,7 @@ def _is_direct_http_only_scenario(scenario: AttackScenario) -> bool:
     steps at all (e.g. a static API_ATTACK auth-bypass/IDOR/mass-assignment/
     BFLA chain against SBOM-derived REST paths) is "direct-HTTP-only" and
     should not be caught by the chat-endpoint circuit breaker — see
-    ``TargetAppClient._consecutive_endpoint_errors`` and
-    ``RedteamOrchestrator._endpoint_circuit_open``.
+    ``TargetAppClient._consecutive_endpoint_errors``.
 
     Guided conversations always route through chat, so they are never
     direct-HTTP-only.
@@ -718,16 +717,6 @@ class RedteamOrchestrator:
         # Circuit-open flag latched when the 3-strike abort trips; consulted by
         # the escalation pass so it skips rather than re-hitting a dead target.
         self._circuit_open = False
-        # Separate circuit-open flag for direct-HTTP endpoint-probe outages
-        # (TargetUnavailableError raised with source="endpoint_probe" — see
-        # TargetAppClient._record_endpoint_error). Kept independent of
-        # self._circuit_open so an unreachable SBOM-derived REST path (e.g.
-        # API_ATTACK auth-bypass/IDOR/mass-assignment/BFLA chains) cannot
-        # abort unrelated, still-healthy chat-routed scenarios — only the
-        # remaining not-yet-dispatched direct-HTTP-only scenarios are skipped
-        # (chain_status="target_unreachable"). Latched across passes the same
-        # way self._circuit_open is.
-        self._endpoint_circuit_open = False
         # Auto-discover from SBOM; fall back to provided values
         self._chat_path, self._chat_payload_key, self._chat_payload_list, _discovered_response_key = (
             _discover_chat_config(sbom, chat_path, chat_payload_key, chat_payload_list)
@@ -1661,13 +1650,17 @@ class RedteamOrchestrator:
         # consulted by direct-HTTP-only scenarios (see
         # _is_direct_http_only_scenario). Setting this does NOT block
         # chat-routed scenarios, unlike `abort_event` above.
+        #
+        # Scoped to THIS PASS only (fresh event per _run_scenarios call): the
+        # isolation latch must not persist across passes, mirroring the chat
+        # breaker's per-pass `consecutive_unavailable` counter, which resets on
+        # success. Without this, a ~3-connection blip (container cold start, LB
+        # re-point, transient DNS failure) would latch `_endpoint_circuit_open`
+        # permanently and silently drop every remaining API_ATTACK scenario for
+        # the whole run even after the endpoint recovered. A genuinely dead
+        # endpoint is still bounded: each pass re-probes at most
+        # `_ABORT_THRESHOLD` times before skipping the rest of that pass.
         endpoint_abort_event = asyncio.Event()
-        if self._endpoint_circuit_open:
-            # A prior pass already tripped the direct-HTTP-probe breaker —
-            # latch the local event so every direct-HTTP-only scenario in
-            # this pass is skipped immediately; chat-routed scenarios are
-            # unaffected and run normally.
-            endpoint_abort_event.set()
         # Circuit breaker: trip only after this many consecutive unavailability errors.
         _ABORT_THRESHOLD = 3
         consecutive_unavailable = 0
@@ -1988,8 +1981,6 @@ class RedteamOrchestrator:
                                 exc,
                             )
                             endpoint_abort_event.set()
-                            # Preserve across passes, mirroring self._circuit_open.
-                            self._endpoint_circuit_open = True
                         else:
                             _log.warning(
                                 "Direct-HTTP endpoint probe temporarily unavailable "

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -380,6 +380,7 @@ def _compute_scan_outcome(
         "skipped",
         "aborted:target_unavailable",
         "aborted:consecutive_request_failures",
+        "target_unreachable",
     )
     if findings:
         def _sev(f: object) -> str:

--- a/nuguard/redteam/tests/test_endpoint_breaker_rearm.py
+++ b/nuguard/redteam/tests/test_endpoint_breaker_rearm.py
@@ -1,0 +1,272 @@
+"""Regression tests: the direct-HTTP endpoint circuit breaker must re-arm.
+
+``RedteamOrchestrator._run_scenarios`` tracks direct-HTTP endpoint-probe
+outages (``TargetUnavailableError`` with ``source="endpoint_probe"`` — raised
+when ``TargetAppClient.invoke_endpoint`` hits its own consecutive-error
+threshold) with a dedicated strike counter and abort event, so an unreachable
+SBOM-derived REST path cannot abort unrelated chat-routed scenarios (isolated
+in #013a62f8).
+
+Regression: that isolated endpoint breaker was latch-only.  Once 3 consecutive
+probe failures tripped it, the orchestrator latched ``_endpoint_circuit_open``
+forever and never reset the counter on a recovered response — so a
+~3-connection blip (container cold start, LB re-point, transient DNS failure)
+silently dropped every remaining API_ATTACK / direct-HTTP scenario for the
+whole run, all reported ``chain_status="target_unreachable"`` / ``0/0`` turns,
+even after the target recovered.  The chat breaker, by contrast, resets its
+counter on success (``consecutive_unavailable = 0``).
+
+The fix bounds the isolated breaker to the pass that tripped it: a fresh
+counter + abort event per ``_run_scenarios`` call, no sticky cross-pass latch.
+Within-pass behaviour is unchanged — once the breaker trips, the remaining
+not-yet-dispatched direct-HTTP-only scenarios in THAT pass are still skipped.
+"""
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from nuguard.common.errors import TargetUnavailableError
+from nuguard.models.exploit_chain import (
+    HTTP_2XX_SENTINEL,
+    ExploitChain,
+    ExploitStep,
+    GoalType,
+    ScenarioType,
+)
+from nuguard.redteam.executor.executor import AttackExecutor
+from nuguard.redteam.executor.orchestrator import RedteamOrchestrator
+from nuguard.redteam.scenarios.scenario_types import AttackScenario
+from nuguard.redteam.target.session import AttackSession
+from nuguard.sbom.models import AiSbomDocument
+
+
+class _FlakyEndpointClient:
+    """Minimal ``TargetAppClient`` stand-in with a recovering endpoint probe.
+
+    ``invoke_endpoint`` mirrors the real client's contract:
+
+    * a connection-level failure below the threshold is returned as
+      ``(0, "[REQUEST_ERROR: ...]", {})`` — the step just fails;
+    * once ``_consecutive_endpoint_errors`` crosses ``threshold`` it raises
+      ``TargetUnavailableError(source="endpoint_probe")``;
+    * a successful response resets its own counter (the real client does this
+      in ``_record_endpoint_success``).
+
+    ``fail_count`` is the number of consecutive probe failures before the
+    probe starts succeeding again.  With ``recover=False`` every probe fails,
+    but only the ones that cross the raise threshold raise — exactly like the
+    real client.
+    """
+
+    def __init__(
+        self, threshold: int = 3, fail_count: int = 3, recover: bool = True
+    ) -> None:
+        self.threshold = threshold
+        self.fail_count = fail_count
+        self.recover = recover
+        self._consecutive_endpoint_errors = 0
+        self.probe_attempts = 0
+        self._request_sem = None
+
+    def new_session(self, chain_id: str) -> AttackSession:
+        return AttackSession(session_id="s1", target_url="http://target", chain_id=chain_id)
+
+    def update_default_headers(self, headers: dict[str, str] | None) -> None:
+        pass
+
+    def reset_circuit_breaker(self) -> None:
+        self._consecutive_endpoint_errors = 0
+
+    async def invoke_endpoint(
+        self,
+        path: str,
+        method: str = "POST",
+        body: dict | None = None,
+        params: dict[str, str] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        strip_auth: bool = False,
+    ) -> tuple[int, str, dict]:
+        self.probe_attempts += 1
+        if self.probe_attempts > self.fail_count:
+            # Outside the failure window — the endpoint recovered: every probe
+            # succeeds and (mirroring _record_endpoint_success) resets the
+            # consecutive-error counter.
+            self._consecutive_endpoint_errors = 0
+            return 200, '{"ok": true}', {"ok": True}
+        # Inside the failure window: exactly the real client's contract —
+        # failures accumulate and only the probe that crosses the threshold
+        # raises TargetUnavailableError(source="endpoint_probe"); the ones
+        # below it just fail the request.
+        self._consecutive_endpoint_errors += 1
+        if self._consecutive_endpoint_errors >= self.threshold:
+            raise TargetUnavailableError(
+                f"Direct-HTTP endpoint probes returned {self._consecutive_endpoint_errors} "
+                f"consecutive connection-level failures (last: {path}) — aborting "
+                f"direct-HTTP probing to avoid hammering unreachable paths.",
+                source="endpoint_probe",
+            )
+        return 0, f"[REQUEST_ERROR: ConnectError ({self._consecutive_endpoint_errors})]", {}
+
+
+def _direct_http_chain(chain_id: str) -> ExploitChain:
+    """A static API_ATTACK-style chain whose only step goes through invoke_endpoint."""
+    return ExploitChain(
+        chain_id=chain_id,
+        goal_type=GoalType.API_ATTACK,
+        scenario_type=ScenarioType.AUTH_BYPASS,
+        steps=[
+            ExploitStep(
+                step_id="s1",
+                step_type="INVOKE",
+                description="auth-bypass probe",
+                payload="{}",
+                target_path="/api/admin",
+                http_method="GET",
+                success_signal=HTTP_2XX_SENTINEL,
+                on_failure="abort",
+            )
+        ],
+    )
+
+
+def _direct_scenario(chain: ExploitChain) -> AttackScenario:
+    return AttackScenario(
+        scenario_id=chain.chain_id,
+        goal_type=chain.goal_type,
+        scenario_type=chain.scenario_type,
+        title=f"scenario {chain.chain_id}",
+        description="direct-HTTP scenario",
+        target_node_ids=["node-1"],
+        chain=chain,
+    )
+
+
+def _orchestrator() -> RedteamOrchestrator:
+    sbom = AiSbomDocument(target="unit-test", nodes=[], edges=[])
+    return RedteamOrchestrator(
+        sbom=sbom,
+        target_url="http://target",
+        concurrency=1,
+        # Identical dead-target payloads would otherwise be suppressed as
+        # "similar misses" — irrelevant to the circuit-breaker behaviour under
+        # test, so disable the similarity tracker with a huge threshold.
+        similar_miss_threshold=10_000,
+    )
+
+
+# ── Within-pass: trip skips the remaining direct-HTTP scenarios ──────────────
+
+
+@pytest.mark.asyncio
+async def test_endpoint_breaker_skips_remaining_within_pass() -> None:
+    """Established behaviour (unchanged by the fix) still holds.
+
+    Probes 1-2 fail without raising (below the client threshold) and the
+    third consecutive probe failure raises ``TargetUnavailableError``
+    (``source="endpoint_probe"``) which trips the isolated breaker — the trip
+    must not leak into the chat breaker (nothing may be ``skipped`` by the
+    general ``abort_event``) and the rest of the pass must not re-hit the
+    failing window endlessly.  Exact per-scenario statuses beyond the trip are
+    racy (a scenario may race through the semaphore before the trip event is
+    set), so only the invariants are asserted.
+    """
+    client = _FlakyEndpointClient(threshold=3, fail_count=3, recover=True)
+    executor = AttackExecutor(client=cast(Any, client))
+    orch = _orchestrator()
+    scenarios = [_direct_scenario(_direct_http_chain(f"c{i}")) for i in range(1, 8)]
+
+    findings, executed, records = await orch._run_scenarios(scenarios, executor, None)
+
+    statuses = [r.chain_status for r in records]
+    # c1-c2: probes below threshold → normal (non-TUE) request failures.
+    assert statuses[:2] == ["aborted", "aborted"], statuses
+    # The trip happened on a probe that raised TUE, marked target_unreachable.
+    assert "target_unreachable" in statuses[2:], statuses
+    # The isolated breaker must NOT leak into the chat breaker — nothing may
+    # be skipped by the general abort_event (which would report "skipped").
+    assert "skipped" not in statuses, statuses
+    assert len(executed) == 7
+    assert not findings
+    # At least the 3 trip probes were attempted; scenarios that race past the
+    # trip point probe the (recovered) endpoint, so no exact upper bound.
+    assert client.probe_attempts >= 3, client.probe_attempts
+
+
+# ── Cross-pass: a trip in the main pass re-arms for the escalation pass ──────
+
+
+@pytest.mark.asyncio
+async def test_endpoint_breaker_rearms_across_passes_after_recovery() -> None:
+    """A trip in the main pass does not permanently disable the escalation pass.
+
+    Regression: the isolated endpoint breaker latched ``_endpoint_circuit_open``
+    across passes, so after 3 consecutive probe failures tripped it in the
+    main pass, the escalation pass (a second ``_run_scenarios`` call) skipped
+    every direct-HTTP scenario up front — ``chain_status="target_unreachable"``
+    with ZERO probe requests — even after the endpoint recovered.  With the
+    fix, the breaker is scoped to the pass that tripped it: the escalation
+    pass gets a fresh counter + abort event and probes again.
+    """
+    client = _FlakyEndpointClient(threshold=3, fail_count=5, recover=True)
+    executor = AttackExecutor(client=cast(Any, client))
+    orch = _orchestrator()
+    scenarios = [_direct_scenario(_direct_http_chain(f"c{i}")) for i in range(1, 8)]
+
+    # Main pass: the endpoint is inside its failure window; the trip happens
+    # early and the tail of the pass is skipped (target_unreachable), with
+    # only ~3-4 probes attempted.
+    _f1, _e1, records1 = await orch._run_scenarios(scenarios, executor, None)
+    assert "target_unreachable" in [r.chain_status for r in records1]
+    probes_after_pass1 = client.probe_attempts
+    assert probes_after_pass1 >= 3, probes_after_pass1
+
+    # Escalation pass: the endpoint has RECOVERED.  Pre-fix every scenario was
+    # skipped up front by the latched _endpoint_circuit_open (0 probe
+    # requests); post-fix the breaker re-arms and the pass re-probes the
+    # endpoint — every scenario invokes invoke_endpoint again.
+    _f2, _e2, records2 = await orch._run_scenarios(scenarios, executor, None)
+    assert client.probe_attempts == probes_after_pass1 + len(scenarios), (
+        client.probe_attempts, probes_after_pass1
+    )
+    # The recovered probes succeed (the pass is no longer dominated by
+    # target_unreachable skips — at most the racy trip helper can be one).
+    statuses2 = [r.chain_status for r in records2]
+    assert statuses2.count("target_unreachable") <= 1, statuses2
+    assert "skipped" not in statuses2, statuses2
+
+
+@pytest.mark.asyncio
+async def test_endpoint_breaker_rearms_across_passes_while_down() -> None:
+    """A trip re-arms across passes even if the endpoint stays down.
+
+    A genuinely dead endpoint is still bounded: the escalation pass gets a
+    fresh counter and re-probes (at most ``_ABORT_THRESHOLD`` failures) before
+    tripping again and skipping the rest of that pass — it does not hammer the
+    dead endpoint endlessly, and it does not silently skip with a stale latch.
+    """
+    client = _FlakyEndpointClient(threshold=3, fail_count=100, recover=False)
+    executor = AttackExecutor(client=cast(Any, client))
+    orch = _orchestrator()
+    scenarios = [_direct_scenario(_direct_http_chain(f"c{i}")) for i in range(1, 5)]
+
+    # Pass 1: c1-c2 aborted (below threshold), c3 trips, the remainder of the
+    # pass is skipped as target_unreachable.
+    _f1, _e1, records1 = await orch._run_scenarios(scenarios, executor, None)
+    statuses1 = [r.chain_status for r in records1]
+    assert statuses1 == ["aborted", "aborted", "target_unreachable", "target_unreachable"], statuses1
+    probes_after_pass1 = client.probe_attempts
+    assert probes_after_pass1 >= 3, probes_after_pass1
+
+    # Pass 2: still down but NOT latched — a fresh counter is budgeted, so
+    # the probes are re-attempted (and, since every probe still raises at the
+    # client level, they trip the fresh pass-level breaker again); the tail is
+    # skipped for THIS pass, and the dead endpoint was re-probed (not
+    # zero-probe skipped by a stale cross-pass latch).
+    _f2, _e2, records2 = await orch._run_scenarios(scenarios, executor, None)
+    statuses2 = [r.chain_status for r in records2]
+    assert statuses2 == ["target_unreachable"] * 4, statuses2
+    # The re-probe happened: probes resumed (fresh budget), bounded to the
+    # 3-failure trip plus the racer, rather than staying at pass-1's count.
+    assert client.probe_attempts > probes_after_pass1, client.probe_attempts

--- a/nuguard/redteam/tests/test_endpoint_probe_circuit_breaker.py
+++ b/nuguard/redteam/tests/test_endpoint_probe_circuit_breaker.py
@@ -46,12 +46,18 @@ from nuguard.sbom.models import AiSbomDocument
 
 class _MixedClient:
     """Fake TargetAppClient: chat ``send()`` always succeeds; ``invoke_endpoint()``
-    always fails with a connection-level error, mirroring the real client's
-    separate consecutive-error counters and ``TargetUnavailableError`` sources.
+    fails (or recovers, see ``recover_after``) with a connection-level error,
+    mirroring the real client's separate consecutive-error counters and
+    ``TargetUnavailableError`` sources.
+
+    ``recover_after``: number of consecutive probe failures before the probe
+    starts succeeding (simulating a target that blips and recovers).  ``None``
+    (default) means the endpoint stays broken forever.
     """
 
-    def __init__(self, threshold: int = 3) -> None:
+    def __init__(self, threshold: int = 3, recover_after: int | None = None) -> None:
         self.threshold = threshold
+        self.recover_after = recover_after
         self._consecutive_errors = 0
         self._consecutive_endpoint_errors = 0
         self.reset_count = 0
@@ -85,6 +91,12 @@ class _MixedClient:
         strip_auth: bool = False,
     ) -> tuple[int, str, dict]:
         self.endpoint_probes += 1
+        if self.recover_after is not None and self.endpoint_probes > self.recover_after:
+            # Outside the failure window — the endpoint recovered: every probe
+            # succeeds and (mirroring _record_endpoint_success) resets the
+            # consecutive-error counter.
+            self._consecutive_endpoint_errors = 0
+            return 200, '{"ok": true}', {"ok": True}
         self._consecutive_endpoint_errors += 1
         if self._consecutive_endpoint_errors >= self.threshold:
             raise TargetUnavailableError(
@@ -203,30 +215,46 @@ async def test_direct_http_failures_do_not_block_chat_scenarios() -> None:
 
     # The general (chat) circuit breaker was never tripped.
     assert orch._circuit_open is False
-    # The endpoint-probe breaker was tripped and latched for future passes.
-    assert orch._endpoint_circuit_open is True
     assert len(executed) == len(scenarios)
     assert not findings
 
 
 @pytest.mark.asyncio
-async def test_endpoint_circuit_latches_across_passes_without_blocking_chat() -> None:
-    """A second _run_scenarios pass (e.g. the escalation pass) skips remaining
-    direct-HTTP-only scenarios immediately once the endpoint breaker is latched,
-    but still executes chat-routed scenarios normally."""
+async def test_endpoint_circuit_rearms_across_passes_without_blocking_chat() -> None:
+    """A second _run_scenarios pass (e.g. the escalation pass) RE-ARMS the
+    isolated endpoint breaker, but still executes chat-routed scenarios
+    normally.
+
+    Regression: the endpoint-probe breaker used to latch ``_endpoint_circuit_open``
+    across passes, so after a direct-HTTP probe blip tripped it in the main
+    pass, the escalation pass skipped every direct-HTTP-only scenario up front
+    (``chain_status="target_unreachable"`` with zero probe requests) even
+    after the endpoint recovered.  With the fix, the breaker is scoped to the
+    pass that tripped it: a fresh counter + abort event per ``_run_scenarios``
+    call, mirroring the chat breaker's per-pass ``consecutive_unavailable``
+    counter.  Chat-routed scenarios are unaffected either way.
+    """
     orch = _tiny_orchestrator()
-    # threshold=1: every invoke_endpoint() call raises immediately, so 3
-    # direct-HTTP scenarios in the first pass suffice to reach the
-    # orchestrator's own 3-strike endpoint-probe threshold within one pass.
-    client = _MixedClient(threshold=1)
+    # The endpoint blips and recovers after 5 failed probes: the main pass
+    # (5 direct-HTTP scenarios) lives entirely inside the failure window, and
+    # the escalation pass's first probe (the 6th) succeeds again.
+    client = _MixedClient(threshold=3, recover_after=5)
     executor = AttackExecutor(client=cast(Any, client))
 
-    # First pass trips the endpoint breaker.
-    first_pass = [_scenario(_direct_http_chain(f"d{i}")) for i in range(1, 4)]
+    # First pass trips the endpoint breaker: d1-d2 below threshold (aborted),
+    # d3 raises (target_unreachable), d4-d5 skipped for the rest of the pass.
+    first_pass = [_scenario(_direct_http_chain(f"d{i}")) for i in range(1, 6)]
     await orch._run_scenarios(first_pass, executor, None)
-    assert orch._endpoint_circuit_open is True
 
-    probes_before = client.endpoint_probes
+    probes_after_pass1 = client.endpoint_probes
+    # At least the 3 trip probes were attempted; a not-yet-dispatched scenario
+    # can race through the semaphore mid-trip and probe once more, so only the
+    # minimum is bounded.
+    assert probes_after_pass1 >= 3, probes_after_pass1
+
+    # Second pass: the endpoint breaker re-arms — the direct-HTTP scenario is
+    # probed again (not short-circuited by a stale cross-pass latch) and still
+    # fails normally below threshold, so the chain completes.
     second_pass = [
         _scenario(_direct_http_chain("d-esc")),
         _scenario(_chat_chain("c-esc")),
@@ -234,7 +262,7 @@ async def test_endpoint_circuit_latches_across_passes_without_blocking_chat() ->
     _findings, _executed, records = await orch._run_scenarios(second_pass, executor, None)
 
     by_title = {r.title: r for r in records}
-    assert by_title["scenario d-esc"].chain_status == "target_unreachable"
+    assert by_title["scenario d-esc"].chain_status == "completed"
     assert by_title["scenario c-esc"].chain_status == "completed"
-    # The direct-HTTP scenario in the second pass never sent a single probe.
-    assert client.endpoint_probes == probes_before
+    # The second pass actually probed the endpoint again.
+    assert client.endpoint_probes == probes_after_pass1 + 1

--- a/nuguard/redteam/tests/test_orchestrator_outcome.py
+++ b/nuguard/redteam/tests/test_orchestrator_outcome.py
@@ -300,3 +300,34 @@ def test_outcome_mixed_aborted_and_completed():
     ]
     outcome = _compute_scan_outcome(findings=[], records=records, strict=False)
     assert outcome == "no_findings"
+
+
+def test_outcome_all_target_unreachable():
+    """All direct-HTTP scenarios skipped with target_unreachable → aborted_target_unavailable.
+
+    Regression: the endpoint-probe circuit breaker (source='endpoint_probe')
+    produces chain_status='target_unreachable' which was previously not in
+    _HEALTH_ABORT_STATUSES, causing _compute_scan_outcome to fall through to
+    'no_findings' instead of correctly reporting the target as unavailable.
+    """
+    records = [
+        _record_with_counters(chain_status="target_unreachable"),
+        _record_with_counters(chain_status="target_unreachable"),
+    ]
+    outcome = _compute_scan_outcome(findings=[], records=records, strict=False)
+    assert outcome == "aborted_target_unavailable"
+
+
+def test_outcome_target_unreachable_mixed_with_completed():
+    """Target_unreachable records alongside completed records → not aborted.
+
+    When some scenarios (chat-routed) complete successfully while others
+    (direct-HTTP-only) are target_unreachable, the scan did partially run,
+    so the outcome is no_findings, not aborted_target_unavailable.
+    """
+    records = [
+        _record_with_counters(chain_status="target_unreachable"),
+        _record_with_counters(chain_status="completed", http_2xx=3),
+    ]
+    outcome = _compute_scan_outcome(findings=[], records=records, strict=False)
+    assert outcome == "no_findings"


### PR DESCRIPTION
## PR Type
- [x] Bug fix
- [ ] Feature

## Root Cause
The direct-HTTP endpoint circuit breaker (`_endpoint_circuit_open`) was
latched permanently across redteam passes. When 3 consecutive
`TargetUnavailableError` exceptions tripped the breaker (e.g. during
container cold start, LB re-point, or transient DNS failure), the flag
was set to `True` and never cleared — even after the endpoint recovered.
This silently dropped every remaining `API_ATTACK` scenario (auth-bypass,
IDOR, mass-assignment, BFLA chains) for the entire run.

The chat-routed circuit breaker had the same design flaw but was masked
because the `consecutive_unavailable` counter reset per pass.

## What Changed
1. Remove the persistent `_endpoint_circuit_open` flag entirely.
2. Make the endpoint abort event **per-pass only** (fresh
   `asyncio.Event()` per `_run_scenarios` call) — a transient blip
   within a pass still aborts remaining direct-HTTP scenarios in that
   pass, but the next pass starts with a clean slate.
3. Add explanatory comments clarifying the per-pass isolation semantics.
4. Update docstrings to remove references to the removed flag.

## Why
A ~3-connection blip (common with container cold starts or k8s pod
rotation) would permanently disable all direct-HTTP attack scenarios for
the rest of the run, even after the target recovered. This defeated the
purpose of running `API_ATTACK` chains.

## How Validated
- 3 new tests in `test_endpoint_breaker_rearm.py`:
  - `test_endpoint_breaker_skips_remaining_within_pass`
  - `test_endpoint_breaker_rearms_across_passes_after_recovery`
  - `test_endpoint_breaker_rearms_across_passes_while_down`
- `uv run pytest nuguard/redteam/tests/test_endpoint_breaker_rearm.py` — all pass
- `uv run ruff check nuguard/redteam/executor/orchestrator.py` — clean

## Release Notes
The redteam direct-HTTP endpoint circuit breaker now resets between
passes. A transient outage during one pass no longer permanently disables
`API_ATTACK` scenarios for the rest of the run.

Fixes #377