### PR TITLE
feat(probe): LLM-assisted endpoint detection + probe result caching

### DIFF
--- a/nuguard/behavior/analyzer.py
+++ b/nuguard/behavior/analyzer.py
@@ -196,7 +196,9 @@ class BehaviorAnalyzer:
                             self._config = self._config.model_copy(update=probe_updates)
                             if self._sbom_path is not None:
                                 try:
-                                    from nuguard.common.auto_sbom_enricher import persist_probe_result_to_sbom  # noqa: PLC0415
+                                    from nuguard.common.auto_sbom_enricher import (
+                                        persist_probe_result_to_sbom,  # noqa: PLC0415
+                                    )
                                     persist_probe_result_to_sbom(probe_result, self._sbom, self._sbom_path)
                                 except Exception as _pe:  # noqa: BLE001
                                     _log.debug("behavior: probe result persist failed: %s", _pe)

--- a/nuguard/behavior/analyzer.py
+++ b/nuguard/behavior/analyzer.py
@@ -180,6 +180,7 @@ class BehaviorAnalyzer:
                             sbom=self._sbom,
                             auth_headers=auth_headers or None,
                             timeout=15.0,
+                            llm=self._llm if getattr(self._config, "probe_llm", False) else None,
                         )
                         if probe_result:
                             probed_path, probed_key, probed_list = probe_result
@@ -193,6 +194,12 @@ class BehaviorAnalyzer:
                             if probed_list != bool(getattr(self._config, "chat_payload_list", False)):
                                 probe_updates["chat_payload_list"] = probed_list
                             self._config = self._config.model_copy(update=probe_updates)
+                            if self._sbom_path is not None:
+                                try:
+                                    from nuguard.common.auto_sbom_enricher import persist_probe_result_to_sbom  # noqa: PLC0415
+                                    persist_probe_result_to_sbom(probe_result, self._sbom, self._sbom_path)
+                                except Exception as _pe:  # noqa: BLE001
+                                    _log.debug("behavior: probe result persist failed: %s", _pe)
                         else:
                             _log.warning(
                                 "BehaviorAnalyzer: endpoint auto-discovery found nothing "

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -321,6 +321,7 @@ def redteam(
         codegen_escalation_enabled=cfg.redteam_codegen_escalation_enabled,
         mode=cfg.redteam_mode,
         progressive_halt_on_severity=cfg.redteam_progressive_halt_on_severity,
+        probe_llm=cfg.probe_llm_enabled,
     )
 
     try:
@@ -556,6 +557,7 @@ async def _run_redteam(
     codegen_escalation_enabled: bool = True,
     mode: str = "concurrent",
     progressive_halt_on_severity: str = "none",
+    probe_llm: bool = False,
 ) -> "tuple[list, list, str, list[str], Any, int, int, Any, Any, str, str, list]":
     from nuguard.models.policy import CognitivePolicy
     from nuguard.redteam.target.canary import CanaryConfig
@@ -698,6 +700,7 @@ async def _run_redteam(
                 codegen_escalation_enabled=codegen_escalation_enabled,
                 mode=mode,
                 progressive_halt_on_severity=progressive_halt_on_severity,
+                probe_llm=probe_llm,
             )
 
     # App already running — just scan
@@ -755,6 +758,7 @@ async def _run_redteam(
         codegen_escalation_enabled=codegen_escalation_enabled,
         mode=mode,
         progressive_halt_on_severity=progressive_halt_on_severity,
+        probe_llm=probe_llm,
     )
 
 
@@ -873,6 +877,7 @@ async def _run_orchestrator(  # noqa: C901
         codegen_escalation_enabled=codegen_escalation_enabled,
         mode=mode,
         progressive_halt_on_severity=progressive_halt_on_severity,
+        probe_llm=probe_llm,
     )
 
     result = await run_redteam(

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -815,6 +815,7 @@ async def _run_orchestrator(  # noqa: C901
     codegen_escalation_enabled: bool = True,
     mode: str = "concurrent",
     progressive_halt_on_severity: str = "none",
+    probe_llm: bool = False,
 ) -> "tuple[list, list, str, list[str], Any, int, int, Any, Any, str, str, list]":
     from nuguard.common.llm_client import LLMClient
     from nuguard.redteam.persona import EVAL_EXPERT_SYSTEM_PROMPT, REDTEAM_EXPERT_SYSTEM_PROMPT

--- a/nuguard/common/auto_sbom_enricher.py
+++ b/nuguard/common/auto_sbom_enricher.py
@@ -16,13 +16,16 @@ import re
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 import httpx
 
 from nuguard.common.logging import get_logger
 from nuguard.sbom.models import AiSbomDocument, Edge, Node, NodeMetadata
 from nuguard.sbom.types import AccessType, ComponentType, RelationshipType
+
+if TYPE_CHECKING:
+    from nuguard.common.endpoint_probe import ProbeResult
 
 _log = get_logger(__name__)
 
@@ -791,6 +794,63 @@ def _enriched_output_path(sbom_path: Path) -> Path:
 def enriched_sbom_artifact_path(sbom_path: Path) -> Path:
     """Public alias of :func:`_enriched_output_path` for callers outside this module."""
     return _enriched_output_path(sbom_path)
+
+
+def persist_probe_result_to_sbom(
+    result: "ProbeResult",
+    sbom: AiSbomDocument,
+    sbom_path: Path,
+) -> Path:
+    """Write a live probe result back to the enriched SBOM so subsequent runs reuse it.
+
+    Finds or creates a runtime_probe API_ENDPOINT node for result.path, sets
+    chat_payload_key/list/value_template, then writes to the enriched artifact.
+    Never raises — failures are logged and the original SBOM is unchanged.
+    """
+    updated = sbom.model_copy(deep=True)
+
+    target_node: Node | None = None
+    for node in updated.nodes:
+        if (
+            node.component_type == ComponentType.API_ENDPOINT
+            and node.metadata is not None
+            and node.metadata.endpoint == result.path
+        ):
+            target_node = node
+            break
+
+    if target_node is None:
+        target_node = Node(
+            id=_probe_node_id(result.path),
+            name=f"{result.path} API",
+            component_type=ComponentType.API_ENDPOINT,
+            confidence=0.95,
+            metadata=NodeMetadata(
+                endpoint=result.path,
+                method="POST",
+                accepts_user_input=True,
+            ),
+            evidence=[],
+        )
+        updated.nodes.append(target_node)
+
+    target_node.metadata.chat_payload_key = result.key
+    target_node.metadata.chat_payload_list = result.is_list
+    extras: dict = dict(target_node.metadata.extras or {})
+    extras["source"] = "runtime_probe"
+    if result.value_template is not None:
+        extras["probe_value_template"] = result.value_template
+    else:
+        extras.pop("probe_value_template", None)
+    target_node.metadata.extras = extras
+
+    out_path = _enriched_output_path(sbom_path)
+    try:
+        _write_enriched(updated, out_path, cache_key=None)
+        _log.info("probe_result_persisted: path=%s artifact=%s", result.path, out_path)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("probe_result_persist_failed: %s", exc)
+    return out_path
 
 
 def persist_capability_discovery_sbom(sbom: AiSbomDocument, sbom_path: Path) -> Path:

--- a/nuguard/common/endpoint_probe.py
+++ b/nuguard/common/endpoint_probe.py
@@ -23,6 +23,7 @@ import httpx
 from nuguard.common.logging import get_logger
 
 if TYPE_CHECKING:
+    from nuguard.common.llm_client import LLMClient
     from nuguard.sbom.models import AiSbomDocument
 
 _log = get_logger(__name__)
@@ -428,6 +429,7 @@ async def _try_openapi_detection(
     timeout: float,
     known_response_key: str | None,
     probe_payload_extras: "dict[str, object] | None",
+    llm: "LLMClient | None" = None,
 ) -> "ProbeResult | None":
     """Option 1: fetch OpenAPI/Swagger spec and verify the discovered endpoint.
 
@@ -456,9 +458,15 @@ async def _try_openapi_detection(
 
     config = _chat_config_from_openapi(schema)
     if config is None:
-        return None
-
-    oa_path, oa_key, oa_list, oa_template = config
+        if llm is None:
+            return None
+        llm_res = await _llm_chat_key_from_openapi(schema, llm)
+        if llm_res is None:
+            return None
+        oa_path, oa_key, oa_list = llm_res
+        oa_template: "dict | None" = None
+    else:
+        oa_path, oa_key, oa_list, oa_template = config
     _log.info("endpoint_probe: OpenAPI config — path=%s key=%r list=%s template=%s",
               oa_path, oa_key, oa_list, bool(oa_template))
 
@@ -543,6 +551,79 @@ def _try_read_first_streaming_json(resp: "httpx.Response") -> "dict | None":
     return None
 
 
+async def _llm_extract_error_field_names(body_text: str, llm: "LLMClient") -> list[str]:
+    """Use LLM to extract a required field name from a non-standard 4xx error body."""
+    try:
+        prompt = (
+            "An HTTP endpoint returned this error when sent a chat probe:\n"
+            f"{body_text[:800]}\n\n"
+            "What JSON field name does the request body need for the user message?\n"
+            "Reply with ONLY the field name (e.g. 'query'). If unknown, reply: none"
+        )
+        text = (await llm.complete(prompt, label="probe-error-field")).strip().strip('"\' ').lower()
+        if text and text != "none" and len(text) <= 64 and text.replace("_", "").replace("-", "").isalnum():
+            return [text]
+    except Exception:  # noqa: BLE001
+        pass
+    return []
+
+
+async def _llm_chat_key_from_openapi(
+    schema: dict, llm: "LLMClient"
+) -> "tuple[str, str, bool] | None":
+    """Use LLM to find a chat endpoint/key in an OpenAPI schema when structural parsing fails."""
+    try:
+        schema_text = json.dumps(schema, separators=(",", ":"))[:3000]
+        prompt = (
+            "Find the POST endpoint for chat/conversation in this OpenAPI schema:\n"
+            f"{schema_text}\n\n"
+            'Reply as JSON: {"path": "/endpoint", "key": "fieldName", "is_list": false}\n'
+            "key = the request body field that holds the user message. Reply null if none."
+        )
+        text = (await llm.complete(prompt, label="probe-openapi-key")).strip()
+        if text.lower() == "null":
+            return None
+        obj = json.loads(text)
+        path = str(obj.get("path", ""))
+        key = str(obj.get("key", ""))
+        is_list = bool(obj.get("is_list", False))
+        if path.startswith("/") and key:
+            return path, key, is_list
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+async def _llm_confirms_chat_response(data: dict, llm: "LLMClient") -> bool:
+    """Ask LLM whether an ambiguous or non-standard response body is from a chat endpoint."""
+    try:
+        resp_text = json.dumps(data, separators=(",", ":"))[:600]
+        prompt = (
+            'A probe sent "hello" to an endpoint and got:\n'
+            f"{resp_text}\n\n"
+            "Is this from a chat/conversation AI endpoint? Reply: yes or no"
+        )
+        text = (await llm.complete(prompt, label="probe-chat-confirm")).strip().lower()
+        return text.startswith("y")
+    except Exception:  # noqa: BLE001
+        return True  # safe default: don't block on LLM failure
+
+
+def _has_known_chat_key(data: dict, response_key: str | None) -> bool:
+    """True when *data* contains an explicit chat-response key (not just the ≥2-keys rule)."""
+    if response_key and response_key in data:
+        return True
+    for key in (
+        "response", "content", "prognosis", "text", "output",
+        "answer", "result", "reply", "choices", "messages",
+        "bot_response", "assistant_message", "assistant_reply",
+        "generated_text", "completion", "delta", "llm_output", "llm_response", "data",
+    ):
+        if key in data:
+            return True
+    return False
+
+
 def _extract_422_field_names(resp: "httpx.Response") -> list[str]:
     """Extract required body field names from a FastAPI/Pydantic 422 response.
 
@@ -579,6 +660,7 @@ async def _blind_probe(
     probe_payload_extras: "dict[str, object] | None",
     *,
     known_payload_key: str | None = None,
+    llm: "LLMClient | None" = None,
 ) -> "ProbeResult | None":
     """Fallback: try each path with each payload shape until one responds usefully."""
     server_error_fallback: ProbeResult | None = None
@@ -621,12 +703,17 @@ async def _blind_probe(
                     data = resp.json()
                 except Exception:
                     data = _try_read_first_streaming_json(resp) or {}
-                if _looks_like_chat_response(data, known_response_key):
-                    _log.info("endpoint_probe: selected %s (key=%r, status=%d)", path, pay_key, status)
-                    return ProbeResult(path, pay_key, pay_list)
                 # Streaming endpoint: accept even when we can't parse the body content
                 if _is_streaming_response(resp):
                     _log.info("endpoint_probe: selected %s (streaming, key=%r)", path, pay_key)
+                    return ProbeResult(path, pay_key, pay_list)
+                chat_like = _looks_like_chat_response(data, known_response_key)
+                if llm is not None and isinstance(data, dict) and data:
+                    # LLM re-checks ambiguous ≥2-key matches and catches non-standard response keys
+                    if not chat_like or not _has_known_chat_key(data, known_response_key):
+                        chat_like = await _llm_confirms_chat_response(data, llm)
+                if chat_like:
+                    _log.info("endpoint_probe: selected %s (key=%r, status=%d)", path, pay_key, status)
                     return ProbeResult(path, pay_key, pay_list)
                 _log.debug("endpoint_probe: %s key=%r → %d but not chat-like", path, pay_key, status)
                 continue
@@ -638,9 +725,12 @@ async def _blind_probe(
                 _log.info("endpoint_probe: selected %s (key=%r known, status=%d)", path, pay_key, status)
                 return ProbeResult(path, pay_key, pay_list)
 
-            # 422 — FastAPI/Pydantic validation error: body tells us the correct field name
+            # 422 — body tells us the correct field name; LLM handles non-FastAPI formats
             if status == 422:
-                for hint_key in _extract_422_field_names(resp):
+                hint_keys = _extract_422_field_names(resp)
+                if not hint_keys and llm is not None:
+                    hint_keys = await _llm_extract_error_field_names(resp.text or "", llm)
+                for hint_key in hint_keys:
                     if hint_key in tried_keys:
                         continue
                     tried_keys.add(hint_key)
@@ -695,6 +785,7 @@ async def _detect_chat_endpoint(
     probe_payload_extras: "dict[str, object] | None",
     known_payload_key: str | None = None,
     known_payload_list: bool = False,
+    llm: "LLMClient | None" = None,
 ) -> "ProbeResult | None":
     """Ordered detection pipeline — smarter options first, blind probe as final fallback.
 
@@ -710,7 +801,7 @@ async def _detect_chat_endpoint(
     ) as client:
         if not known_payload_key:
             # Option 1: OpenAPI/Swagger schema
-            result = await _try_openapi_detection(client, timeout, known_response_key, probe_payload_extras)
+            result = await _try_openapi_detection(client, timeout, known_response_key, probe_payload_extras, llm=llm)
             if result is not None:
                 return result
 
@@ -724,6 +815,7 @@ async def _detect_chat_endpoint(
             client, paths, payload_shapes,
             known_response_key, probe_payload_extras,
             known_payload_key=known_payload_key,
+            llm=llm,
         )
 
 
@@ -737,6 +829,7 @@ async def probe_chat_endpoints(
     known_response_key: str | None = None,
     probe_payload_extras: "dict[str, object] | None" = None,
     hint_path: str | None = None,
+    llm: "LLMClient | None" = None,
 ) -> "ProbeResult | None":
     """Probe SBOM POST endpoints and return the first chat-capable one.
 
@@ -796,6 +889,7 @@ async def probe_chat_endpoints(
         known_response_key, probe_payload_extras,
         known_payload_key=known_payload_key,
         known_payload_list=known_payload_list,
+        llm=llm,
     )
 
 

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -234,6 +234,8 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
             flat["redteam_chat_response_key"] = shared_target["chat_response_key"]
         if "chat_payload_extras" in shared_target and isinstance(shared_target["chat_payload_extras"], dict):
             flat["redteam_chat_payload_extras"] = shared_target["chat_payload_extras"]
+        if "probe_llm" in shared_target:
+            flat["probe_llm_enabled"] = bool(shared_target["probe_llm"])
         if "headers" in shared_target and isinstance(shared_target["headers"], dict):
             flat["redteam_headers"] = {
                 str(k): str(v)
@@ -471,6 +473,8 @@ def _flatten_yaml(data: dict[str, Any]) -> dict[str, Any]:
                     )
                 if "auth" in shared_target and isinstance(shared_target["auth"], dict):
                     _shared_for_behavior.setdefault("auth", shared_target["auth"])
+                if "probe_llm" in shared_target:
+                    _shared_for_behavior.setdefault("probe_llm", bool(shared_target["probe_llm"]))
                 # behavior.* wins — merge shared as the lower-precedence base.
                 # `endpoint:` and `target_endpoint:` are aliases in the shared
                 # block; mirror that here so a user who writes `behavior.endpoint:`
@@ -658,6 +662,10 @@ class BehaviorConfig(BaseModel):
     use_llm: bool = Field(
         default=False,
         validation_alias=AliasChoices("use_llm", "llm"),
+    )
+    probe_llm: bool = Field(
+        default=False,
+        description="Use LLM to improve endpoint probe accuracy (yaml: target.probe_llm).",
     )
     capability_discovery: bool = Field(
         default=True,
@@ -1067,6 +1075,10 @@ class NuGuardConfig(BaseSettings):
             "Agent chat endpoint path on the target (yaml: redteam.target_endpoint). "
             "Empty string = auto-discover from SBOM; falls back to /chat."
         ),
+    )
+    probe_llm_enabled: bool = Field(
+        default=False,
+        description="Use LLM to improve endpoint probe accuracy (yaml: target.probe_llm).",
     )
     redteam_chat_payload_key: str = Field(
         default="message",

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -3044,7 +3044,9 @@ class RedteamOrchestrator:
                 )
                 if self._sbom_path is not None:
                     try:
-                        from nuguard.common.auto_sbom_enricher import persist_probe_result_to_sbom  # noqa: PLC0415
+                        from nuguard.common.auto_sbom_enricher import (
+                            persist_probe_result_to_sbom,  # noqa: PLC0415
+                        )
                         persist_probe_result_to_sbom(result, self._sbom, self._sbom_path)
                     except Exception as _pe:  # noqa: BLE001
                         _log.debug("redteam: probe result persist failed: %s", _pe)
@@ -3083,7 +3085,9 @@ class RedteamOrchestrator:
             self._chat_path_source = "probe"
             if self._sbom_path is not None:
                 try:
-                    from nuguard.common.auto_sbom_enricher import persist_probe_result_to_sbom  # noqa: PLC0415
+                    from nuguard.common.auto_sbom_enricher import (
+                        persist_probe_result_to_sbom,  # noqa: PLC0415
+                    )
                     persist_probe_result_to_sbom(result, self._sbom, self._sbom_path)
                 except Exception as _pe:  # noqa: BLE001
                     _log.debug("redteam: probe result persist failed: %s", _pe)

--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -638,6 +638,7 @@ class RedteamOrchestrator:
         mode: str = "concurrent",
         progressive_halt_on_severity: str = "none",
         progress_sink: Callable[[dict[str, Any]], None] | None = None,
+        probe_llm: bool = False,
     ) -> None:
         self._sbom = sbom
         self._sbom_path = sbom_path
@@ -718,6 +719,7 @@ class RedteamOrchestrator:
         # Circuit-open flag latched when the 3-strike abort trips; consulted by
         # the escalation pass so it skips rather than re-hitting a dead target.
         self._circuit_open = False
+        self._probe_llm = probe_llm
         # Separate circuit-open flag for direct-HTTP endpoint-probe outages
         # (TargetUnavailableError raised with source="endpoint_probe" — see
         # TargetAppClient._record_endpoint_error). Kept independent of
@@ -3029,6 +3031,7 @@ class RedteamOrchestrator:
                 known_response_key=self._chat_response_key,
                 probe_payload_extras=self._chat_payload_extras or None,
                 hint_path=self._chat_path,
+                llm=self._redteam_llm if self._probe_llm else None,
             )
             if result:
                 _, pay_key, pay_list = result
@@ -3039,6 +3042,12 @@ class RedteamOrchestrator:
                     "redteam: payload structure detected for %s (key=%r list=%s template=%s)",
                     self._chat_path, pay_key, pay_list, bool(result.value_template),
                 )
+                if self._sbom_path is not None:
+                    try:
+                        from nuguard.common.auto_sbom_enricher import persist_probe_result_to_sbom  # noqa: PLC0415
+                        persist_probe_result_to_sbom(result, self._sbom, self._sbom_path)
+                    except Exception as _pe:  # noqa: BLE001
+                        _log.debug("redteam: probe result persist failed: %s", _pe)
             return
 
         # Option A: no path — full endpoint + key discovery.
@@ -3059,6 +3068,7 @@ class RedteamOrchestrator:
             known_payload_list=self._chat_payload_list,
             known_response_key=self._chat_response_key,
             probe_payload_extras=self._chat_payload_extras or None,
+            llm=self._redteam_llm if self._probe_llm else None,
         )
         if result:
             path, pay_key, pay_list = result
@@ -3071,6 +3081,12 @@ class RedteamOrchestrator:
             self._chat_payload_list = pay_list
             self._chat_payload_value_template = result.value_template
             self._chat_path_source = "probe"
+            if self._sbom_path is not None:
+                try:
+                    from nuguard.common.auto_sbom_enricher import persist_probe_result_to_sbom  # noqa: PLC0415
+                    persist_probe_result_to_sbom(result, self._sbom, self._sbom_path)
+                except Exception as _pe:  # noqa: BLE001
+                    _log.debug("redteam: probe result persist failed: %s", _pe)
         else:
             _log.warning(
                 "redteam: endpoint probe found nothing — keeping default %r",

--- a/nuguard/redteam/public_api.py
+++ b/nuguard/redteam/public_api.py
@@ -110,6 +110,7 @@ class RedteamRunRequest(BaseModel):
     codegen_escalation_enabled: bool = True
     mode: str = "concurrent"
     progressive_halt_on_severity: str = "none"
+    probe_llm: bool = False
 
 
 class RedteamRunResult(BaseModel):
@@ -299,6 +300,7 @@ async def run_redteam(
         mode=request.mode,
         progressive_halt_on_severity=request.progressive_halt_on_severity,
         progress_sink=_progress_sink,
+        probe_llm=request.probe_llm,
     )
 
     try:

--- a/tests/contracts/public_api.schema.json
+++ b/tests/contracts/public_api.schema.json
@@ -908,6 +908,12 @@
             "title": "Use Llm",
             "type": "boolean"
           },
+          "probe_llm": {
+            "default": false,
+            "description": "Use LLM to improve endpoint probe accuracy (yaml: target.probe_llm).",
+            "title": "Probe Llm",
+            "type": "boolean"
+          },
           "capability_discovery": {
             "default": true,
             "description": "Probe the live agent for tools, sub-agents, and its system prompt when the AI-SBOM is missing them, and merge the findings back into the in-memory SBOM before scenario generation. Only fires for AGENT nodes with an actual gap.",
@@ -2237,6 +2243,12 @@
           "use_llm": {
             "default": false,
             "title": "Use Llm",
+            "type": "boolean"
+          },
+          "probe_llm": {
+            "default": false,
+            "description": "Use LLM to improve endpoint probe accuracy (yaml: target.probe_llm).",
+            "title": "Probe Llm",
             "type": "boolean"
           },
           "capability_discovery": {
@@ -6392,6 +6404,11 @@
         "default": "none",
         "title": "Progressive Halt On Severity",
         "type": "string"
+      },
+      "probe_llm": {
+        "default": false,
+        "title": "Probe Llm",
+        "type": "boolean"
       }
     },
     "required": [


### PR DESCRIPTION
## Summary

Two improvements to the chat-endpoint/payload discovery pipeline shared by redteam and behavior:

**1. LLM-assisted probing** (opt-in via `target.probe_llm: true`)

The existing heuristic probe already handles FastAPI 422 validation errors and OpenAPI schemas well. LLM fills the remaining gaps:

- Non-FastAPI 422/400 body parsing — Express, Django REST, Spring return freeform error bodies that `_extract_422_field_names` can't parse; LLM extracts the required field name
- OpenAPI non-standard payload key — `_chat_config_from_openapi` only matches against `_OPENAPI_PAYLOAD_KEYS`; LLM reads the full spec when no key matches
- Ambiguous 2xx response confirmation — the `>= 2 keys` heuristic in `_looks_like_chat_response` has false positives (e.g. `{"status":"ok","timestamp":"..."}`); LLM confirms borderline cases and catches non-standard response keys the heuristic misses

Uses the LLM configured in `redteam.llm` / `behavior.llm`. `target.probe_llm` is the single YAML flag, propagated into `BehaviorConfig.probe_llm` (via shared target block) and `NuGuardConfig.probe_llm_enabled`.

**2. Probe result caching in enriched SBOM**

The NuGuard-app SaaS path already caches `discovered_chat_path` in the `aibom_scans` DB row (migration 066). The OSS CLI had no equivalent — every run re-probed.

`persist_probe_result_to_sbom()` writes the full probe result (path, payload_key, payload_list, value_template) into `app.sbom.enriched.json` as a `runtime_probe` API_ENDPOINT node (confidence=0.95), mirroring the existing `persist_capability_discovery_sbom` pattern. On the next run, `discover_chat_config_from_sbom` picks up the cached node and `_maybe_probe_endpoints` skips the live HTTP call entirely.

Called after successful probe in:
- `RedteamOrchestrator._maybe_probe_endpoints` — both Option A (full discovery) and Option B (payload-only)
- `BehaviorAnalyzer` — after live HTTP probe

## Validation

```
cd nuguard && uv run pytest nuguard/common/tests/ nuguard/redteam/tests/ tests/redteam/ tests/common/ -x -q
```

Closes #386