### PR TITLE
fix: Checkov title/field parsing and nested asyncio.run() in ATLAS enrichment

### DIFF
--- a/nuguard/analysis/plugins/checkov_scanner.py
+++ b/nuguard/analysis/plugins/checkov_scanner.py
@@ -20,6 +20,7 @@ Usage
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -39,6 +40,11 @@ _SEV_MAP: dict[str, str] = {
     "LOW":      "LOW",
     "UNKNOWN":  "LOW",
 }
+
+# Checkov's secrets runner sets `resource` to a hex hash of the detected
+# secret rather than a real resource address; matched so we can fall back
+# to the file location instead of surfacing the hash as a display name.
+_HEX_HASH_RE = re.compile(r"^[0-9a-f]{20,}(:[0-9a-f]{20,})?$", re.IGNORECASE)
 
 
 def _checkov_path() -> str | None:
@@ -211,22 +217,25 @@ def _parse_checkov_output(data: Any, scan_path: str) -> list[dict[str, Any]]:
             continue
         for check_result in (entry.get("results", {}).get("failed_checks") or []):
             check_id  = check_result.get("check_id", "")
-            check_obj = check_result.get("check", {})
-            name      = check_obj.get("name", check_id)
+            name      = check_result.get("check_name", check_id)
             resource  = check_result.get("resource", "")
             file_path = check_result.get("file_path", scan_path)
-            guideline = check_obj.get("guideline", "")
+            guideline = check_result.get("guideline", "")
             severity  = _SEV_MAP.get(
-                str(check_result.get("severity") or check_obj.get("severity") or "MEDIUM").upper(),
+                str(check_result.get("severity") or "MEDIUM").upper(),
                 "MEDIUM",
             )
+
+            line_range = check_result.get("file_line_range") or []
+            location = f"{file_path}:{line_range[0]}" if line_range else file_path
+            display_resource = location if _HEX_HASH_RE.match(resource) else (resource or location)
 
             findings.append({
                 "rule_id":     check_id,
                 "title":       name,
-                "description": f"IaC misconfiguration: {name} in `{resource}`",
+                "description": f"IaC misconfiguration: {name} in `{display_resource}`",
                 "severity":    severity,
-                "affected":    [resource] if resource else [file_path],
+                "affected":    [display_resource],
                 "remediation": guideline,
                 "url":         guideline,
                 "source":      "checkov",

--- a/nuguard/analysis/static_analyzer.py
+++ b/nuguard/analysis/static_analyzer.py
@@ -314,7 +314,9 @@ class StaticAnalyzer:
         # skip_nga=True so the annotator does not re-run NGA rules; Step 1
         # already annotated NGA findings with ATLAS techniques directly.
         if self.enable_atlas:
-            atlas = self._run_atlas_native(sbom_dict, sbom_graph=sbom_graph)
+            atlas = await asyncio.to_thread(
+                self._run_atlas_native, sbom_dict, sbom_graph=sbom_graph
+            )
             all_findings.extend(atlas)
             self.tool_status["atlas"] = {"status": "ok", "findings": str(len(atlas))}
         else:

--- a/tests/analysis/test_checkov_scanner.py
+++ b/tests/analysis/test_checkov_scanner.py
@@ -1,0 +1,97 @@
+"""Tests for the Checkov IaC scanner plugin's JSON parsing.
+
+Covers ``_parse_checkov_output`` against fixtures shaped like real Checkov
+output (top-level ``check_name``/``guideline``/``severity`` — no nested
+``"check"`` object, which never exists in actual Checkov JSON).
+"""
+
+from __future__ import annotations
+
+from nuguard.analysis.plugins.checkov_scanner import _parse_checkov_output
+
+
+def _base_check_result(**overrides: object) -> dict:
+    result = {
+        "check_id": "CKV_AWS_150",
+        "check_name": "Ensure that S3 buckets are encrypted with KMS by default",
+        "check_result": {"result": "FAILED"},
+        "resource": "aws_s3_bucket.example",
+        "file_path": "/main.tf",
+        "file_line_range": [10, 15],
+        "guideline": "https://docs.example.com/CKV_AWS_150",
+        "severity": "HIGH",
+    }
+    result.update(overrides)
+    return result
+
+
+def _checkov_output(*check_results: dict) -> dict:
+    return {"results": {"failed_checks": list(check_results)}}
+
+
+def test_resolves_real_check_name_not_rule_id():
+    data = _checkov_output(_base_check_result())
+    findings = _parse_checkov_output(data, "/main.tf")
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["rule_id"] == "CKV_AWS_150"
+    assert finding["title"] == "Ensure that S3 buckets are encrypted with KMS by default"
+    assert finding["title"] != finding["rule_id"]
+
+
+def test_populates_remediation_and_severity_from_top_level_fields():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["remediation"] == "https://docs.example.com/CKV_AWS_150"
+    assert finding["url"] == "https://docs.example.com/CKV_AWS_150"
+    assert finding["severity"] == "HIGH"
+
+
+def test_normal_resource_used_as_affected_component():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["affected"] == ["aws_s3_bucket.example"]
+    assert "aws_s3_bucket.example" in finding["description"]
+
+
+def test_secret_hash_resource_falls_back_to_file_location():
+    secret_result = _base_check_result(
+        check_id="CKV_SECRET_13",
+        check_name="CKV_SECRET_13",
+        resource="967649db3de73fc65f333fcbdf3fe58e334bcc7a",
+        file_path="/app/config.py",
+        file_line_range=[42, 42],
+        guideline="",
+    )
+    data = _checkov_output(secret_result)
+    finding = _parse_checkov_output(data, "/app/config.py")[0]
+
+    assert finding["affected"] == ["/app/config.py:42"]
+    assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["affected"][0]
+    assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["description"]
+
+
+def test_missing_line_range_falls_back_to_bare_file_path():
+    secret_result = _base_check_result(
+        check_id="CKV_SECRET_6",
+        check_name="CKV_SECRET_6",
+        resource="a" * 40,
+        file_path="/app/settings.py",
+        file_line_range=[],
+    )
+    data = _checkov_output(secret_result)
+    finding = _parse_checkov_output(data, "/app/settings.py")[0]
+
+    assert finding["affected"] == ["/app/settings.py"]
+
+
+def test_missing_check_name_falls_back_to_check_id():
+    check_result = _base_check_result()
+    del check_result["check_name"]
+    data = _checkov_output(check_result)
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["title"] == "CKV_AWS_150"

--- a/tests/apps/owasp-juice-shop/nuguard-azure.yaml
+++ b/tests/apps/owasp-juice-shop/nuguard-azure.yaml
@@ -173,16 +173,16 @@ redteam:
 
   # LLM for attack-payload generation (must tolerate adversarial content)
   llm:
-    model: azure/DeepSeek-V4-Pro    # any LiteLLM model string (openai/gpt-4o, etc.)
+    model: azure/${AZURE_DEEPSEEK_MODEL_NAME}    # any LiteLLM model string (openai/gpt-4o, etc.)
     api_key: ${AZURE_DEEPSEEK_KEY}
     api_base: ${AZURE_DEEPSEEK_ENDPOINT}     # optional override for Azure OpenAI endpoint URL
 
   # LLM for response evaluation and finding summarisation
   eval_llm:
-  model: azure/${AZURE_DEEPSEEK_MODEL_NAME}    # any LiteLLM model string (openai/gpt-4o, etc.)
-  api_key: ${AZURE_DEEPSEEK_KEY}     # never put keys here; use env var interpolation
-  api_base: ${AZURE_DEEPSEEK_ENDPOINT}
-  
+    model: azure/${AZURE_DEEPSEEK_MODEL_NAME}    # any LiteLLM model string (openai/gpt-4o, etc.)
+    api_key: ${AZURE_DEEPSEEK_KEY}     # never put keys here; use env var interpolation
+    api_base: ${AZURE_DEEPSEEK_ENDPOINT}
+
   # MCP server hostnames treated as trusted.
   # Servers absent from this list are classified 'untrusted' and eligible
   # as toxic-flow attack sources.


### PR DESCRIPTION
## Summary
- Checkov's `_parse_checkov_output` read a nested `"check"` object that doesn't exist in real Checkov JSON, so every finding title collapsed to the bare rule ID and remediation guideline URLs/severity were dropped; `CKV_SECRET_*` findings also leaked a raw secret hash into "Affected Components" instead of a canonical file location.
- ATLAS LLM enrichment silently failed on every `nuguard scan` run because `_run_atlas_native` was called synchronously from within `StaticAnalyzer.analyze()`'s already-running event loop, causing a nested `asyncio.run()` RuntimeError that was swallowed and fell back to static output.
- Bonus: fixed a hardcoded wrong Azure DeepSeek deployment name and a broken YAML indentation (`eval_llm` silently parsed as `None`) in the juice-shop Azure test config, found while diagnosing a related Azure auth failure.

## Test plan
- [x] `uv run pytest tests/analysis -q` — 26 passed
- [x] `uv run pytest tests/analysis/test_checkov_scanner.py -v` — 6 passed (new)
- [x] `uv run ruff check nuguard/analysis/plugins/checkov_scanner.py nuguard/analysis/static_analyzer.py tests/analysis/test_checkov_scanner.py`
- [x] `uv run mypy nuguard/analysis/plugins/checkov_scanner.py nuguard/analysis/static_analyzer.py`

Closes #475
Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4eUBua9oWeYrWyzsMep8