### PR TITLE
fix: richer checkov titles + file/line evidence

### DIFF
--- a/nuguard/analysis/plugins/checkov_scanner.py
+++ b/nuguard/analysis/plugins/checkov_scanner.py
@@ -229,13 +229,17 @@ def _parse_checkov_output(data: Any, scan_path: str) -> list[dict[str, Any]]:
             line_range = check_result.get("file_line_range") or []
             location = f"{file_path}:{line_range[0]}" if line_range else file_path
             display_resource = location if _HEX_HASH_RE.match(resource) else (resource or location)
+            # Omit evidence when it would just repeat the affected-component
+            # value (the CKV_SECRET_* hash-avoidance case already shows it).
+            evidence = None if display_resource == location else location
 
             findings.append({
                 "rule_id":     check_id,
-                "title":       name,
+                "title":       f"[IaC misconfiguration] {name} — {display_resource}",
                 "description": f"IaC misconfiguration: {name} in `{display_resource}`",
                 "severity":    severity,
                 "affected":    [display_resource],
+                "evidence":    evidence,
                 "remediation": guideline,
                 "url":         guideline,
                 "source":      "checkov",

--- a/nuguard/cli/commands/analyze.py
+++ b/nuguard/cli/commands/analyze.py
@@ -1080,6 +1080,8 @@ def _render_markdown(
                     lines += [f"**Remediation:** {f.remediation}  ", ""]
                 if f.affected_component:
                     lines += [f"**Affected Components:** `{_component_label(f)}`  ", ""]
+                if f.evidence:
+                    lines += [f"**Evidence:** `{f.evidence}`  ", ""]
                 lines += [f"**Source:** {sources_str}  ", ""]
                 framework = _framework_mapping_text(
                     f.owasp_llm_ref, f.owasp_asi_ref, f.mitre_atlas_technique

--- a/tests/analysis/test_checkov_scanner.py
+++ b/tests/analysis/test_checkov_scanner.py
@@ -36,8 +36,18 @@ def test_resolves_real_check_name_not_rule_id():
     assert len(findings) == 1
     finding = findings[0]
     assert finding["rule_id"] == "CKV_AWS_150"
-    assert finding["title"] == "Ensure that S3 buckets are encrypted with KMS by default"
+    assert "Ensure that S3 buckets are encrypted with KMS by default" in finding["title"]
     assert finding["title"] != finding["rule_id"]
+
+
+def test_title_includes_category_and_affected_resource():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["title"] == (
+        "[IaC misconfiguration] Ensure that S3 buckets are encrypted with "
+        "KMS by default — aws_s3_bucket.example"
+    )
 
 
 def test_populates_remediation_and_severity_from_top_level_fields():
@@ -57,6 +67,13 @@ def test_normal_resource_used_as_affected_component():
     assert "aws_s3_bucket.example" in finding["description"]
 
 
+def test_evidence_populated_with_file_and_line_for_normal_resource_check():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["evidence"] == "/main.tf:10"
+
+
 def test_secret_hash_resource_falls_back_to_file_location():
     secret_result = _base_check_result(
         check_id="CKV_SECRET_13",
@@ -72,6 +89,8 @@ def test_secret_hash_resource_falls_back_to_file_location():
     assert finding["affected"] == ["/app/config.py:42"]
     assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["affected"][0]
     assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["description"]
+    # Evidence would just repeat the affected-component value here — omitted.
+    assert finding["evidence"] is None
 
 
 def test_missing_line_range_falls_back_to_bare_file_path():
@@ -94,4 +113,4 @@ def test_missing_check_name_falls_back_to_check_id():
     data = _checkov_output(check_result)
     finding = _parse_checkov_output(data, "/main.tf")[0]
 
-    assert finding["title"] == "CKV_AWS_150"
+    assert finding["title"] == "[IaC misconfiguration] CKV_AWS_150 — aws_s3_bucket.example"


### PR DESCRIPTION
## Summary
Stacks on #477. Two readability follow-ups for Checkov findings, requested after reviewing that fix's output in a real report:

- Titles showed only the bare check name with no indication of category or affected resource. Now: `[IaC misconfiguration] {check_name} — {resource}`.
- Normal resource checks (e.g. GitHub Actions workflow permissions) never surfaced a file/line pointer into source — only Checkov's logical resource address. Populated the existing, previously-unused `Finding.evidence` field with `file_path:line` and render it as an `Evidence:` line in the markdown report. Omitted when it would duplicate "Affected Components" (the `CKV_SECRET_*` hash-avoidance case from #477).

## Test plan
- [x] `uv run pytest tests/analysis/test_checkov_scanner.py -v` — 8 passed
- [x] `uv run pytest tests/analysis tests/cli -q` — 154 passed
- [x] `uv run ruff check` / `uv run mypy` on both changed files

**Base note:** targets `bug/checkov-fix` (not `develop`) since #477 hasn't merged yet — this diff is additive on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4eUBua9oWeYrWyzsMep8