### PR TITLE
fix: dedup checkov findings for the same rule + affected component

### DIFF
--- a/nuguard/analysis/plugins/checkov_scanner.py
+++ b/nuguard/analysis/plugins/checkov_scanner.py
@@ -90,6 +90,7 @@ class CheckovScannerPlugin(AnalysisPlugin):
         all_findings: list[dict[str, Any]] = []
         for path in iac_paths:
             all_findings.extend(_run_checkov(binary, path, config))
+        all_findings = _dedupe_findings(all_findings)
 
         status = "warning" if all_findings else "ok"
         message = (
@@ -105,6 +106,39 @@ class CheckovScannerPlugin(AnalysisPlugin):
             findings=all_findings,
             details={"total": len(all_findings), "scanned_paths": list(iac_paths)},
         )
+
+
+def _dedupe_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse findings for the same rule + affected component.
+
+    Checkov has no CLI flag for this (checked: no dedup/uniqueness option
+    exists). The same (rule_id, resource-address) pair can legitimately be
+    reported more than once — e.g. two different files each defining a
+    Terraform resource with the same address — which the report then
+    displays as repeated, identical-looking finding blocks since it groups
+    by the bare resource address with no file qualifier. Rather than drop
+    the duplicate (losing the fact that a second file also has the issue),
+    merge their ``evidence`` (file:line) values so a reader still sees every
+    affected location. remediation is a deterministic function of rule_id
+    alone (checkov's guideline URL doesn't vary per-resource), so rule_id
+    equality already implies remediation equality.
+    """
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    order: list[tuple[str, str]] = []
+    for f in findings:
+        key = (f["rule_id"], f["affected"][0] if f["affected"] else "")
+        if key not in merged:
+            merged[key] = dict(f)
+            order.append(key)
+            continue
+        existing = merged[key]
+        new_evidence = f.get("evidence")
+        if new_evidence:
+            locations = existing["evidence"].split("; ") if existing.get("evidence") else []
+            if new_evidence not in locations:
+                locations.append(new_evidence)
+                existing["evidence"] = "; ".join(locations)
+    return [merged[k] for k in order]
 
 
 def _collect_iac_paths(sbom: dict[str, Any], config: dict[str, Any]) -> set[str]:

--- a/tests/analysis/test_checkov_scanner.py
+++ b/tests/analysis/test_checkov_scanner.py
@@ -7,7 +7,7 @@ output (top-level ``check_name``/``guideline``/``severity`` — no nested
 
 from __future__ import annotations
 
-from nuguard.analysis.plugins.checkov_scanner import _parse_checkov_output
+from nuguard.analysis.plugins.checkov_scanner import _dedupe_findings, _parse_checkov_output
 
 
 def _base_check_result(**overrides: object) -> dict:
@@ -114,3 +114,59 @@ def test_missing_check_name_falls_back_to_check_id():
     finding = _parse_checkov_output(data, "/main.tf")[0]
 
     assert finding["title"] == "[IaC misconfiguration] CKV_AWS_150 — aws_s3_bucket.example"
+
+
+def _finding(**overrides: object) -> dict:
+    base = {
+        "rule_id": "CKV_AWS_150",
+        "title": "[IaC misconfiguration] Ensure deletion protection — aws_lb.juice_shop",
+        "description": "IaC misconfiguration: Ensure deletion protection in `aws_lb.juice_shop`",
+        "severity": "MEDIUM",
+        "affected": ["aws_lb.juice_shop"],
+        "evidence": "terraform/networking.tf:12",
+        "remediation": "https://docs.example.com/CKV_AWS_150",
+        "url": "https://docs.example.com/CKV_AWS_150",
+        "source": "checkov",
+        "scan_target": "/repo",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_dedupe_collapses_same_rule_and_component_merging_evidence():
+    findings = [
+        _finding(evidence="terraform/networking.tf:12"),
+        _finding(evidence="infrastructure/terraform/networking.tf:12"),
+    ]
+
+    deduped = _dedupe_findings(findings)
+
+    assert len(deduped) == 1
+    assert deduped[0]["evidence"] == (
+        "terraform/networking.tf:12; infrastructure/terraform/networking.tf:12"
+    )
+
+
+def test_dedupe_leaves_distinct_components_and_rules_untouched():
+    findings = [
+        _finding(rule_id="CKV_AWS_150", affected=["aws_lb.juice_shop"]),
+        _finding(rule_id="CKV_AWS_91", affected=["aws_lb.juice_shop"]),
+        _finding(rule_id="CKV_AWS_150", affected=["aws_lb.other"]),
+    ]
+
+    deduped = _dedupe_findings(findings)
+
+    assert len(deduped) == 3
+
+
+def test_dedupe_handles_missing_or_identical_evidence_without_artifacts():
+    findings = [
+        _finding(evidence="terraform/networking.tf:12"),
+        _finding(evidence="terraform/networking.tf:12"),  # exact duplicate
+        _finding(evidence=None),
+    ]
+
+    deduped = _dedupe_findings(findings)
+
+    assert len(deduped) == 1
+    assert deduped[0]["evidence"] == "terraform/networking.tf:12"


### PR DESCRIPTION
## Summary
Stacks on #478 (stacks on #477). Fixes visually duplicated Checkov finding blocks in reports, e.g. `CKV_AWS_150`/`CKV_AWS_91` each appearing twice under `aws_lb.juice_shop` in `tests/apps/owasp-juice-shop/reports/juice-shop-analysis.md`.

**Checked for a checkov config option first** — none exists (`checkov --help` has no dedup/uniqueness flag; `--compact` only suppresses code blocks in CLI text output). `--skip-path`/`--download-external-modules` solve a different problem (stale `.terraform/` module caches) and don't apply here.

**Root cause**: this SBOM's IaC-typed nodes carry no `source_path`, so checkov runs exactly once against the whole repo — not once per overlapping path. The "duplicates" are checkov legitimately reporting the same Terraform resource *address* defined in two different files in the repo (`terraform/networking.tf` and `infrastructure/terraform/networking.tf` both define `aws_lb.juice_shop`). Since the report groups by bare resource-address text with no file qualifier, these two distinct findings render as repeated, identical-looking blocks.

**Fix**: added `_dedupe_findings()`, applied once across all collected findings in `CheckovScannerPlugin.run()`. Collapses on `(rule_id, affected component)` — rather than dropping the second occurrence outright, merges the `evidence` (file:line) values from every duplicate so a reader still sees every affected location instead of losing information.

## Test plan
- [x] `uv run pytest tests/analysis/test_checkov_scanner.py -v` — 11 passed (3 new dedup tests)
- [x] `uv run pytest tests/analysis tests/cli -q` — 157 passed
- [x] `uv run ruff check` / `uv run mypy` on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4eUBua9oWeYrWyzsMep8