### PR TITLE
chore(release): bump nuguard version to 0.9.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "nuguard",
   "name": "nuguard",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI application security for Claude — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications. Slash-command exposure is host-dependent and not claimed by this manifest.",
   "contextFileName": "CLAUDE.md"
 }

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "category": "security",
       "tags": [
         "ai-security",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuguardai/nuguard",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
   "keywords": [
     "mcp",

--- a/nuguard/__init__.py
+++ b/nuguard/__init__.py
@@ -1,3 +1,3 @@
 """NuGuard AI Security CLI — open-source AI penetration testing platform."""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nuguard",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "format": "claude-plugin",
   "source": ".claude-plugin/plugin.json",
   "hostTargets": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuguard",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI Application Security — SBOM generation, static analysis, behavioral testing, and adversarial red-teaming for AI agents and LLM-powered applications.",
   "author": {
     "name": "NuGuard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuguard"
-version = "0.9.4"
+version = "0.9.5"
 description = "AI application security — SBOM generation, vulnerability scanning, behavioral validation, and adversarial red-teaming for AI Agents"
 readme = ".github/README.md"
 license = { text = "Apache-2.0" }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.9.4"
+version: "0.9.5"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/uv.lock
+++ b/uv.lock
@@ -1543,7 +1543,7 @@ wheels = [
 
 [[package]]
 name = "nuguard"
-version = "0.9.4"
+version = "0.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "cyclonedx-bom" },


### PR DESCRIPTION
## Summary
Version bump 0.9.4 → 0.9.5 across all 10 version-carrying files, mirroring the previous release commit (fa687d08):

- `.claude-plugin/plugin.json`, `gemini-extension.json`, `marketplace.json` (both fields), `npm/package.json`, `nuguard/__init__.py`, `openclaw.plugin.json`, `plugin/.claude-plugin/plugin.json`, `pyproject.toml`, `smithery.yaml`
- `uv.lock` regenerated via `uv lock`

## Test plan
- [x] `grep -rl "0.9.4"` across the repo (excluding test fixtures) — no remaining references
- [x] `uv run python -c "import nuguard; print(nuguard.__version__)"` → `0.9.5`

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4eUBua9oWeYrWyzsMep8