### PR TITLE
feat(sbom): enrich Go HTTP endpoints with schema and auth

### DIFF
--- a/nuguard/sbom/adapters/go/_http_endpoint_metadata.py
+++ b/nuguard/sbom/adapters/go/_http_endpoint_metadata.py
@@ -1,0 +1,1078 @@
+"""Request-schema and authentication metadata for Go HTTP endpoints."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ...normalization import canonicalize_text
+from ...types import ComponentType
+from ..base import ComponentDetection, RelationshipHint
+
+if TYPE_CHECKING:
+    from ...core.go_parser import GoFunctionCall, GoParseResult
+
+_PROMPT_FIELD_NAMES = (
+    "message",
+    "query",
+    "prompt",
+    "input",
+    "text",
+    "user_query",
+    "user_input",
+    "user_message",
+    "transcript",
+    "question",
+    "content",
+    "msg",
+)
+_MESSAGE_HISTORY_FIELD_NAMES = (
+    "messages",
+    "history",
+    "conversation",
+    "chat_history",
+)
+
+_GIN_MODULE = "github.com/gin-gonic/gin"
+_ECHO_JWT_MODULES = {
+    "github.com/labstack/echo-jwt",
+    "github.com/labstack/echo-jwt/v4",
+}
+_ECHO_MIDDLEWARE_MODULES = {
+    "github.com/labstack/echo/middleware",
+    "github.com/labstack/echo/v4/middleware",
+}
+_GIN_JWT_MODULES = {
+    "github.com/appleboy/gin-jwt",
+    "github.com/appleboy/gin-jwt/v2",
+    "github.com/appleboy/gin-jwt/v3",
+}
+
+_BIND_PATTERNS = {
+    "gin": re.compile(
+        r"\.(?:ShouldBindJSON|BindJSON|ShouldBind|Bind)\s*\(\s*&?\s*"
+        r"(?P<variable>[A-Za-z_][A-Za-z0-9_]*)"
+    ),
+    "echo": re.compile(
+        r"\.Bind\s*\(\s*&?\s*"
+        r"(?P<variable>[A-Za-z_][A-Za-z0-9_]*)"
+    ),
+    "net_http": re.compile(
+        r"\.Decode\s*\(\s*&?\s*"
+        r"(?P<variable>[A-Za-z_][A-Za-z0-9_]*)"
+    ),
+}
+_TYPE_STRUCT_RE = re.compile(
+    r"(?m)^\s*type\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"\s+struct\s*\{"
+)
+_FUNCTION_RE = re.compile(
+    r"(?m)^\s*func\s+"
+    r"(?:\([^\n)]*\)\s*)?"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\("
+)
+_FIELD_RE = re.compile(
+    r"^(?P<names>[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*)"
+    r"\s+(?P<type>.+?)\s*$"
+)
+_JSON_TAG_RE = re.compile(r'(?:^|\s)json:"(?P<value>[^"]*)"')
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_HANDLER_WRAPPER_RE = re.compile(
+    r"^(?:[A-Za-z_][A-Za-z0-9_]*\.)?"
+    r"HandlerFunc\s*\(\s*"
+    r"(?P<handler>[A-Za-z_][A-Za-z0-9_]*)"
+    r"\s*\)$"
+)
+_AUTH_DISPLAY_NAMES = {
+    "basic": "HTTP Basic Auth",
+    "jwt": "JWT Middleware",
+}
+
+
+@dataclass(frozen=True)
+class GoHTTPAuthEvidence:
+    """One recognized authentication middleware expression."""
+
+    auth_type: str
+    line: int
+    snippet: str
+
+
+@dataclass(frozen=True)
+class GoHTTPRouteAnalysis:
+    """Static request and authentication metadata for one route."""
+
+    request_body_schema: dict[str, str]
+    chat_payload_key: str | None
+    chat_payload_list: bool
+    auth_evidence: tuple[GoHTTPAuthEvidence, ...]
+
+    @property
+    def auth_required(self) -> bool:
+        """Return whether recognized middleware protects this route."""
+        return bool(self.auth_evidence)
+
+
+def enrich_http_endpoint_detections(
+    content: str,
+    result: GoParseResult,
+    detections: list[ComponentDetection],
+    *,
+    framework: str,
+    verb_names: dict[str, str],
+) -> list[ComponentDetection]:
+    """Enrich existing endpoint detections with schema and auth evidence."""
+    endpoints: dict[tuple[str, str], ComponentDetection] = {}
+
+    for detection in detections:
+        if detection.component_type != ComponentType.API_ENDPOINT:
+            continue
+
+        method = detection.metadata.get("method")
+        path = detection.metadata.get("endpoint")
+        if isinstance(method, str) and isinstance(path, str):
+            endpoints[(method, path)] = detection
+
+    auth_nodes: dict[str, ComponentDetection] = {}
+    analyzed: set[tuple[str, str]] = set()
+
+    for call in result.function_calls:
+        method = verb_names.get(call.function_name)
+        if method is None:
+            continue
+
+        path = _resolved_string_argument(call, 0)
+        key = (method, path)
+        endpoint = endpoints.get(key)
+
+        if endpoint is None or key in analyzed:
+            continue
+
+        analyzed.add(key)
+        analysis = analyze_http_route(
+            content,
+            result,
+            call,
+            framework=framework,
+        )
+
+        endpoint.metadata.update(
+            {
+                "request_body_schema": (analysis.request_body_schema),
+                "chat_payload_key": (analysis.chat_payload_key),
+                "chat_payload_list": (analysis.chat_payload_list),
+                "auth_required": (analysis.auth_required),
+            }
+        )
+
+        if analysis.request_body_schema:
+            endpoint.metadata["accepts_user_input"] = True
+
+        auth_types = [item.auth_type for item in analysis.auth_evidence]
+
+        if auth_types:
+            endpoint.metadata["auth_type"] = auth_types[0]
+            endpoint.metadata["auth_types"] = auth_types
+
+        for evidence in analysis.auth_evidence:
+            canonical = canonicalize_text(
+                f"{framework}:auth:{evidence.auth_type}:{endpoint.file_path}:{evidence.line}"
+            )
+
+            auth = auth_nodes.setdefault(
+                canonical,
+                ComponentDetection(
+                    component_type=ComponentType.AUTH,
+                    canonical_name=canonical,
+                    display_name=(_AUTH_DISPLAY_NAMES[evidence.auth_type]),
+                    adapter_name=endpoint.adapter_name,
+                    priority=endpoint.priority,
+                    confidence=0.9,
+                    metadata={
+                        "auth_type": (evidence.auth_type),
+                        "auth_detail": {
+                            "protocols": [evidence.auth_type],
+                            "enforcement_strict": (True),
+                        },
+                        "framework": framework,
+                        "language": "golang",
+                    },
+                    file_path=endpoint.file_path,
+                    line=evidence.line,
+                    snippet=evidence.snippet,
+                    evidence_kind="ast_call",
+                ),
+            )
+
+            relationship = RelationshipHint(
+                source_canonical=canonical,
+                source_type=ComponentType.AUTH,
+                target_canonical=(endpoint.canonical_name),
+                target_type=(ComponentType.API_ENDPOINT),
+                relationship_type="PROTECTS",
+            )
+
+            if relationship not in auth.relationships:
+                auth.relationships.append(relationship)
+
+    return [
+        *detections,
+        *auth_nodes.values(),
+    ]
+
+
+def analyze_http_route(
+    content: str,
+    result: GoParseResult,
+    call: GoFunctionCall,
+    *,
+    framework: str,
+) -> GoHTTPRouteAnalysis:
+    """Recover same-file request schema and recognized auth metadata."""
+    arguments = _call_arguments(call.source_snippet or "")
+    handler = _handler_expression(
+        arguments,
+        framework,
+    )
+    body = _handler_body(
+        content,
+        handler,
+    )
+
+    schema: dict[str, str] = {}
+
+    if body:
+        binding_style = "net_http" if framework == "chi" else framework
+        variable = _bound_request_variable(
+            body,
+            binding_style,
+        )
+        type_name = _variable_type(body, variable) if variable else ""
+
+        if type_name:
+            schema = _struct_schemas(content).get(type_name, {})
+
+    chat_key, chat_list = _chat_payload(schema)
+    auth_evidence = _auth_evidence_for_route(
+        content,
+        result,
+        call,
+        arguments,
+        framework=framework,
+    )
+
+    return GoHTTPRouteAnalysis(
+        request_body_schema=schema,
+        chat_payload_key=chat_key,
+        chat_payload_list=chat_list,
+        auth_evidence=auth_evidence,
+    )
+
+
+def _resolved_string_argument(
+    call: GoFunctionCall,
+    index: int,
+) -> str:
+    if index < 0 or index >= len(call.positional_args):
+        return ""
+
+    value = call.positional_args[index]
+
+    if not isinstance(value, str):
+        return ""
+
+    value = value.strip()
+
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'", "`"}:
+        value = value[1:-1].strip()
+
+    if not value or value.startswith("$"):
+        return ""
+
+    return value
+
+
+def _handler_expression(
+    arguments: list[str],
+    framework: str,
+) -> str:
+    if len(arguments) < 2:
+        return ""
+
+    expression = arguments[-1] if framework == "gin" else arguments[1]
+    expression = expression.strip()
+    wrapper = _HANDLER_WRAPPER_RE.fullmatch(expression)
+
+    return wrapper.group("handler") if wrapper else expression
+
+
+def _handler_body(
+    content: str,
+    expression: str,
+) -> str:
+    expression = expression.strip()
+
+    if not expression:
+        return ""
+
+    if expression.startswith("func"):
+        masked = _mask_non_code(expression)
+        open_brace = masked.find("{")
+
+        if open_brace < 0:
+            return ""
+
+        close_brace = _find_balanced_end(
+            masked,
+            open_brace,
+            "{",
+            "}",
+        )
+
+        if close_brace is None:
+            return ""
+
+        return expression[open_brace + 1 : close_brace]
+
+    if not _IDENTIFIER_RE.fullmatch(expression):
+        return ""
+
+    return _function_bodies(content).get(expression, "")
+
+
+def _function_bodies(
+    content: str,
+) -> dict[str, str]:
+    masked = _mask_non_code(content)
+    bodies: dict[str, str] = {}
+
+    for match in _FUNCTION_RE.finditer(masked):
+        open_brace = masked.find(
+            "{",
+            match.end(),
+        )
+
+        if open_brace < 0:
+            continue
+
+        close_brace = _find_balanced_end(
+            masked,
+            open_brace,
+            "{",
+            "}",
+        )
+
+        if close_brace is None:
+            continue
+
+        bodies.setdefault(
+            match.group("name"),
+            content[open_brace + 1 : close_brace],
+        )
+
+    return bodies
+
+
+def _bound_request_variable(
+    body: str,
+    framework: str,
+) -> str:
+    pattern = _BIND_PATTERNS.get(framework)
+
+    if pattern is None:
+        return ""
+
+    match = pattern.search(_mask_non_code(body))
+
+    return match.group("variable") if match else ""
+
+
+def _variable_type(
+    body: str,
+    variable: str,
+) -> str:
+    escaped = re.escape(variable)
+    masked = _mask_non_code(body)
+
+    patterns = (
+        re.compile(
+            rf"\bvar\s+{escaped}\s+\*?"
+            rf"(?P<type>"
+            rf"[A-Za-z_][A-Za-z0-9_]*"
+            rf")\b"
+        ),
+        re.compile(
+            rf"\b{escaped}\s*"
+            rf"(?::=|=)\s*&?\s*"
+            rf"(?P<type>"
+            rf"[A-Za-z_][A-Za-z0-9_]*"
+            rf")\s*\{{"
+        ),
+        re.compile(
+            rf"\b{escaped}\s*"
+            rf"(?::=|=)\s*new\s*\(\s*"
+            rf"(?P<type>"
+            rf"[A-Za-z_][A-Za-z0-9_]*"
+            rf")\s*\)"
+        ),
+    )
+
+    for pattern in patterns:
+        match = pattern.search(masked)
+
+        if match:
+            return match.group("type")
+
+    return ""
+
+
+def _struct_schemas(
+    content: str,
+) -> dict[str, dict[str, str]]:
+    masked = _mask_non_code(content)
+    schemas: dict[
+        str,
+        dict[str, str],
+    ] = {}
+
+    for match in _TYPE_STRUCT_RE.finditer(masked):
+        open_brace = match.end() - 1
+        close_brace = _find_balanced_end(
+            masked,
+            open_brace,
+            "{",
+            "}",
+        )
+
+        if close_brace is None:
+            continue
+
+        schema: dict[str, str] = {}
+        body = content[open_brace + 1 : close_brace]
+
+        for raw_line in body.splitlines():
+            line = _strip_line_comment(raw_line).strip().rstrip(";")
+
+            if not line or "struct {" in line:
+                continue
+
+            tag_match = re.search(
+                r"`(?P<tag>[^`]*)`\s*$",
+                line,
+            )
+            tag = tag_match.group("tag") if tag_match else ""
+            declaration = line[: tag_match.start()] if tag_match else line
+
+            field_match = _FIELD_RE.fullmatch(declaration.strip())
+
+            if field_match is None:
+                continue
+
+            type_name = field_match.group("type").strip()
+
+            if "{" in type_name or "}" in type_name:
+                continue
+
+            json_name: str | None = None
+            json_tag = _JSON_TAG_RE.search(tag)
+
+            if json_tag:
+                json_name = json_tag.group("value").split(",", 1)[0]
+
+                if json_name == "-":
+                    continue
+
+            for field_name in field_match.group("names").split(","):
+                field_name = field_name.strip()
+
+                if not field_name or not field_name[0].isupper():
+                    continue
+
+                schema[json_name or field_name] = type_name.lstrip("*")
+
+        if schema:
+            schemas[match.group("name")] = schema
+
+    return schemas
+
+
+def _chat_payload(
+    schema: dict[str, str],
+) -> tuple[str | None, bool]:
+    normalized = {
+        _normalize_field_name(field): (
+            field,
+            type_name,
+        )
+        for field, type_name in schema.items()
+    }
+
+    for candidate in _PROMPT_FIELD_NAMES:
+        if candidate in normalized:
+            field, type_name = normalized[candidate]
+            return (
+                field,
+                _is_list_type(type_name),
+            )
+
+    for candidate in _MESSAGE_HISTORY_FIELD_NAMES:
+        if candidate not in normalized:
+            continue
+
+        field, type_name = normalized[candidate]
+
+        if _is_message_list_type(type_name):
+            return field, True
+
+    for field, type_name in schema.items():
+        if type_name.strip().lstrip("*") == "string":
+            return field, False
+
+    return None, False
+
+
+def _normalize_field_name(
+    value: str,
+) -> str:
+    value = value.replace("-", "_")
+    value = re.sub(
+        r"(?<!^)(?=[A-Z])",
+        "_",
+        value,
+    )
+    return value.casefold()
+
+
+def _is_list_type(
+    value: str,
+) -> bool:
+    return value.strip().lstrip("*").startswith("[")
+
+
+def _is_message_list_type(
+    value: str,
+) -> bool:
+    normalized = value.replace(" ", "").lstrip("*")
+
+    return normalized.startswith("[]") and normalized != "[]string"
+
+
+def _auth_evidence_for_route(
+    content: str,
+    result: GoParseResult,
+    route_call: GoFunctionCall,
+    route_arguments: list[str],
+    *,
+    framework: str,
+) -> tuple[GoHTTPAuthEvidence, ...]:
+    if framework not in {
+        "gin",
+        "echo",
+    }:
+        return ()
+
+    aliases = _auth_aliases(result)
+    jwt_variables = _jwt_middleware_variables(
+        content,
+        result,
+        aliases["gin_jwt"],
+    )
+
+    candidates = [
+        (
+            expression,
+            route_call.line,
+        )
+        for expression in (
+            _route_middleware_expressions(
+                route_arguments,
+                framework,
+            )
+        )
+    ]
+
+    protected_receivers: set[str] = set()
+
+    if route_call.receiver:
+        protected_receivers.add(route_call.receiver)
+
+    processed_groups: set[tuple[int, str]] = set()
+
+    changed = True
+
+    while changed:
+        changed = False
+
+        for parsed_call in result.function_calls:
+            if (
+                parsed_call.line > route_call.line
+                or parsed_call.function_name != "Group"
+                or not parsed_call.assigned_to
+                or parsed_call.assigned_to not in protected_receivers
+            ):
+                continue
+
+            group_key = (
+                parsed_call.line,
+                parsed_call.assigned_to,
+            )
+
+            if group_key not in processed_groups:
+                processed_groups.add(group_key)
+
+                group_arguments = _call_arguments(parsed_call.source_snippet or "")
+
+                candidates.extend(
+                    (
+                        expression,
+                        parsed_call.line,
+                    )
+                    for expression in (group_arguments[1:])
+                )
+
+            if parsed_call.receiver and parsed_call.receiver not in protected_receivers:
+                protected_receivers.add(parsed_call.receiver)
+                changed = True
+
+    for parsed_call in result.function_calls:
+        if (
+            parsed_call.line > route_call.line
+            or parsed_call.function_name != "Use"
+            or parsed_call.receiver not in protected_receivers
+        ):
+            continue
+
+        candidates.extend(
+            (
+                expression,
+                parsed_call.line,
+            )
+            for expression in _call_arguments(parsed_call.source_snippet or "")
+        )
+
+    evidence: dict[
+        str,
+        GoHTTPAuthEvidence,
+    ] = {}
+
+    for expression, line in candidates:
+        match = _auth_match(
+            expression,
+            aliases,
+            jwt_variables,
+        )
+
+        if match is None:
+            continue
+
+        auth_type, snippet = match
+
+        evidence.setdefault(
+            auth_type,
+            GoHTTPAuthEvidence(
+                auth_type=auth_type,
+                line=line,
+                snippet=snippet,
+            ),
+        )
+
+    return tuple(evidence.values())
+
+
+def _route_middleware_expressions(
+    arguments: list[str],
+    framework: str,
+) -> list[str]:
+    if framework == "gin":
+        return arguments[1:-1] if len(arguments) > 2 else []
+
+    if framework == "echo":
+        return arguments[2:] if len(arguments) > 2 else []
+
+    return []
+
+
+def _auth_aliases(
+    result: GoParseResult,
+) -> dict[str, set[str]]:
+    aliases: dict[
+        str,
+        set[str],
+    ] = {
+        "gin": set(),
+        "echo_jwt": set(),
+        "echo_middleware": set(),
+        "gin_jwt": set(),
+    }
+
+    for imported in result.imports:
+        key: str | None = None
+        default_alias = ""
+
+        if imported.path == _GIN_MODULE:
+            key, default_alias = (
+                "gin",
+                "gin",
+            )
+
+        elif imported.path in (_ECHO_JWT_MODULES):
+            key, default_alias = (
+                "echo_jwt",
+                "echojwt",
+            )
+
+        elif imported.path in (_ECHO_MIDDLEWARE_MODULES):
+            key, default_alias = (
+                "echo_middleware",
+                "middleware",
+            )
+
+        elif imported.path in (_GIN_JWT_MODULES):
+            key, default_alias = (
+                "gin_jwt",
+                "jwt",
+            )
+
+        if key is None or imported.alias in {
+            "_",
+            ".",
+        }:
+            continue
+
+        aliases[key].add(imported.alias or default_alias)
+
+    return aliases
+
+
+def _jwt_middleware_variables(
+    content: str,
+    result: GoParseResult,
+    aliases: set[str],
+) -> set[str]:
+    variables: set[str] = set()
+
+    for call in result.function_calls:
+        if call.receiver in aliases and call.function_name == "New" and call.assigned_to:
+            variables.add(call.assigned_to)
+
+    masked = _mask_non_code(content)
+
+    for alias in aliases:
+        pattern = re.compile(
+            rf"(?m)^\s*"
+            rf"(?P<variable>"
+            rf"[A-Za-z_][A-Za-z0-9_]*"
+            rf")"
+            rf"(?:\s*,\s*"
+            rf"[A-Za-z_][A-Za-z0-9_]*"
+            rf")*\s*:=\s*"
+            rf"{re.escape(alias)}"
+            rf"\.New\s*\("
+        )
+
+        variables.update(match.group("variable") for match in pattern.finditer(masked))
+
+    return variables
+
+
+def _auth_match(
+    expression: str,
+    aliases: dict[str, set[str]],
+    jwt_variables: set[str],
+) -> tuple[str, str] | None:
+    compact = re.sub(
+        r"\s+",
+        "",
+        expression,
+    )
+
+    for alias in aliases["gin"]:
+        for name in (
+            "BasicAuth",
+            "BasicAuthForRealm",
+        ):
+            if compact.startswith(f"{alias}.{name}("):
+                return (
+                    "basic",
+                    f"{alias}.{name}(...)",
+                )
+
+    for alias in aliases["echo_jwt"]:
+        for name in (
+            "JWT",
+            "JWTWithConfig",
+            "WithConfig",
+        ):
+            if compact.startswith(f"{alias}.{name}("):
+                return (
+                    "jwt",
+                    f"{alias}.{name}(...)",
+                )
+
+    for alias in aliases["echo_middleware"]:
+        for name in (
+            "JWT",
+            "JWTWithConfig",
+        ):
+            if compact.startswith(f"{alias}.{name}("):
+                return (
+                    "jwt",
+                    f"{alias}.{name}(...)",
+                )
+
+        for name in (
+            "BasicAuth",
+            "BasicAuthWithConfig",
+        ):
+            if compact.startswith(f"{alias}.{name}("):
+                return (
+                    "basic",
+                    f"{alias}.{name}(...)",
+                )
+
+    for variable in jwt_variables:
+        if compact.startswith(f"{variable}.MiddlewareFunc("):
+            return (
+                "jwt",
+                f"{variable}.MiddlewareFunc(...)",
+            )
+
+    return None
+
+
+def _call_arguments(
+    source_snippet: str,
+) -> list[str]:
+    open_paren = source_snippet.find("(")
+
+    if open_paren < 0:
+        return []
+
+    close_paren = _find_balanced_end(
+        source_snippet,
+        open_paren,
+        "(",
+        ")",
+    )
+
+    if close_paren is None:
+        return []
+
+    return _split_top_level(source_snippet[open_paren + 1 : close_paren])
+
+
+def _split_top_level(
+    value: str,
+) -> list[str]:
+    arguments: list[str] = []
+    start = 0
+    depths = {
+        "(": 0,
+        "[": 0,
+        "{": 0,
+    }
+    closers = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(value):
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            continue
+
+        if char in {
+            '"',
+            "'",
+            "`",
+        }:
+            quote = char
+
+        elif char in depths:
+            depths[char] += 1
+
+        elif char in closers:
+            depths[closers[char]] = max(
+                0,
+                depths[closers[char]] - 1,
+            )
+
+        elif char == "," and not any(depths.values()):
+            arguments.append(value[start:index].strip())
+            start = index + 1
+
+    tail = value[start:].strip()
+
+    if tail:
+        arguments.append(tail)
+
+    return arguments
+
+
+def _mask_non_code(
+    value: str,
+) -> str:
+    masked = list(value)
+    index = 0
+
+    def blank(
+        start: int,
+        end: int,
+    ) -> None:
+        for position in range(start, end):
+            if masked[position] != "\n":
+                masked[position] = " "
+
+    while index < len(value):
+        if value.startswith("//", index):
+            end = value.find("\n", index)
+            end = len(value) if end == -1 else end
+            blank(index, end)
+            index = end
+            continue
+
+        if value.startswith("/*", index):
+            end = value.find(
+                "*/",
+                index + 2,
+            )
+            end = len(value) if end == -1 else end + 2
+            blank(index, end)
+            index = end
+            continue
+
+        if value[index] in {
+            '"',
+            "'",
+            "`",
+        }:
+            quote = value[index]
+            start = index
+            index += 1
+
+            while index < len(value):
+                if quote != "`" and value[index] == "\\":
+                    index += 2
+                    continue
+
+                if value[index] == quote:
+                    index += 1
+                    break
+
+                index += 1
+
+            blank(
+                start,
+                min(index, len(value)),
+            )
+            continue
+
+        index += 1
+
+    return "".join(masked)
+
+
+def _find_balanced_end(
+    text: str,
+    start: int,
+    opener: str,
+    closer: str,
+) -> int | None:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            continue
+
+        if char in {
+            '"',
+            "'",
+            "`",
+        }:
+            quote = char
+
+        elif char == opener:
+            depth += 1
+
+        elif char == closer:
+            depth -= 1
+
+            if depth == 0:
+                return index
+
+    return None
+
+
+def _strip_line_comment(
+    value: str,
+) -> str:
+    quote: str | None = None
+    escaped = False
+    index = 0
+
+    while index < len(value):
+        char = value[index]
+
+        if quote is not None:
+            if quote != "`" and escaped:
+                escaped = False
+
+            elif quote != "`" and char == "\\":
+                escaped = True
+
+            elif char == quote:
+                quote = None
+
+            index += 1
+            continue
+
+        if char in {
+            '"',
+            "'",
+            "`",
+        }:
+            quote = char
+            index += 1
+            continue
+
+        if value.startswith("//", index):
+            return value[:index]
+
+        index += 1
+
+    return value
+
+
+__all__ = [
+    "GoHTTPAuthEvidence",
+    "GoHTTPRouteAnalysis",
+    "analyze_http_route",
+    "enrich_http_endpoint_detections",
+]

--- a/nuguard/sbom/adapters/go/http_router.py
+++ b/nuguard/sbom/adapters/go/http_router.py
@@ -18,6 +18,7 @@ from ...core.go_parser import GoParseResult, parse_go
 from ...types import ComponentType
 from ..base import ComponentDetection, RelationshipHint
 from ._go_base import GoFrameworkAdapter
+from ._http_endpoint_metadata import enrich_http_endpoint_detections
 
 # Method spellings as they appear in each framework's call sites, mapped to
 # the canonical uppercase HTTP method used in node metadata/canonical names.
@@ -111,7 +112,13 @@ class _GoHTTPVerbRouterAdapter(GoFrameworkAdapter):
             )
             detections.append(endpoint)
 
-        return detections
+        return enrich_http_endpoint_detections(
+            content,
+            result,
+            detections,
+            framework=self.name,
+            verb_names=self.verb_names,
+        )
 
 
 class GinAdapter(_GoHTTPVerbRouterAdapter):

--- a/nuguard/sbom/adapters/go/net_http.py
+++ b/nuguard/sbom/adapters/go/net_http.py
@@ -14,6 +14,7 @@ from ...core.go_parser import GoParseResult, parse_go
 from ...types import ComponentType
 from ..base import ComponentDetection, RelationshipHint
 from ._go_base import GoFrameworkAdapter
+from ._http_endpoint_metadata import enrich_http_endpoint_detections
 
 _MODULE = "net/http"
 _HANDLER_CALLS = {"HandleFunc", "Handle"}
@@ -87,7 +88,16 @@ class NetHTTPAdapter(GoFrameworkAdapter):
             )
             detections.append(endpoint)
 
-        return detections
+        return enrich_http_endpoint_detections(
+            content,
+            result,
+            detections,
+            framework=self.name,
+            verb_names={
+                name: "ANY"
+                for name in _HANDLER_CALLS
+            },
+        )
 
 
 __all__ = ["NetHTTPAdapter"]

--- a/nuguard/sbom/tests/test_go_http_endpoint_metadata.py
+++ b/nuguard/sbom/tests/test_go_http_endpoint_metadata.py
@@ -1,0 +1,437 @@
+"""Tests for Go HTTP request-schema and auth metadata extraction."""
+
+from __future__ import annotations
+
+from nuguard.sbom.adapters.base import ComponentDetection
+from nuguard.sbom.adapters.go import (
+    ChiAdapter,
+    EchoAdapter,
+    GinAdapter,
+    NetHTTPAdapter,
+)
+from nuguard.sbom.core.go_parser import parse_go
+from nuguard.sbom.types import ComponentType
+
+
+def _extract(
+    adapter: (GinAdapter | EchoAdapter | ChiAdapter | NetHTTPAdapter),
+    source: str,
+    file_path: str = "main.go",
+) -> list[ComponentDetection]:
+    return adapter.extract(
+        source,
+        file_path,
+        parse_go(source, file_path),
+    )
+
+
+def _by_type(
+    detections: list[ComponentDetection],
+    component_type: ComponentType,
+) -> list[ComponentDetection]:
+    return [detection for detection in detections if detection.component_type == component_type]
+
+
+def _endpoint(
+    detections: list[ComponentDetection],
+) -> ComponentDetection:
+    endpoints = _by_type(
+        detections,
+        ComponentType.API_ENDPOINT,
+    )
+
+    assert len(endpoints) == 1
+
+    return endpoints[0]
+
+
+def test_gin_infers_schema_chat_key_and_route_basic_auth() -> None:
+    source = """package main
+
+import web "github.com/gin-gonic/gin"
+
+type ChatRequest struct {
+    Message string        `json:"message"`
+    History []ChatMessage `json:"history,omitempty"`
+    Secret  string        `json:"-"`
+}
+
+func chatHandler(c *web.Context) {
+    var request ChatRequest
+    _ = c.ShouldBindJSON(&request)
+}
+
+func main() {
+    router := web.New()
+    router.POST(
+        "/chat",
+        web.BasicAuth(web.Accounts{"admin": "do-not-copy"}),
+        chatHandler,
+    )
+}
+"""
+
+    detections = _extract(
+        GinAdapter(),
+        source,
+    )
+    endpoint = _endpoint(detections)
+    auth = _by_type(
+        detections,
+        ComponentType.AUTH,
+    )
+
+    assert endpoint.metadata["request_body_schema"] == {
+        "message": "string",
+        "history": "[]ChatMessage",
+    }
+    assert endpoint.metadata["chat_payload_key"] == "message"
+    assert endpoint.metadata["chat_payload_list"] is False
+    assert endpoint.metadata["accepts_user_input"] is True
+    assert endpoint.metadata["auth_required"] is True
+    assert endpoint.metadata["auth_type"] == "basic"
+
+    assert len(auth) == 1
+    assert auth[0].metadata["auth_type"] == "basic"
+    assert auth[0].metadata["auth_detail"] == {
+        "protocols": ["basic"],
+        "enforcement_strict": True,
+    }
+    assert auth[0].snippet == "web.BasicAuth(...)"
+    assert "do-not-copy" not in auth[0].snippet
+    assert len(auth[0].relationships) == 1
+    assert auth[0].relationships[0].relationship_type == "PROTECTS"
+    assert auth[0].relationships[0].target_canonical == endpoint.canonical_name
+
+
+def test_gin_group_middleware_is_applied_to_group_route() -> None:
+    source = """package main
+
+import "github.com/gin-gonic/gin"
+
+type ChatRequest struct {
+    Prompt string `json:"prompt"`
+}
+
+func chatHandler(c *gin.Context) {
+    request := ChatRequest{}
+    _ = c.BindJSON(&request)
+}
+
+func main() {
+    router := gin.New()
+    protected := router.Group(
+        "/api",
+        gin.BasicAuth(gin.Accounts{"admin": "secret"}),
+    )
+    protected.POST("/chat", chatHandler)
+}
+"""
+
+    endpoint = _endpoint(
+        _extract(
+            GinAdapter(),
+            source,
+        )
+    )
+
+    assert endpoint.metadata["chat_payload_key"] == "prompt"
+    assert endpoint.metadata["auth_required"] is True
+    assert endpoint.metadata["auth_type"] == "basic"
+
+
+def test_echo_infers_message_list_and_global_jwt_middleware() -> None:
+    source = """package main
+
+import (
+    "github.com/labstack/echo-jwt/v4"
+    "github.com/labstack/echo/v4"
+)
+
+type ChatMessage struct {
+    Role    string `json:"role"`
+    Content string `json:"content"`
+}
+
+type ChatRequest struct {
+    Messages []ChatMessage `json:"messages"`
+}
+
+func chatHandler(c echo.Context) error {
+    request := new(ChatRequest)
+    return c.Bind(request)
+}
+
+func main() {
+    app := echo.New()
+    app.Use(echojwt.WithConfig(echojwt.Config{}))
+    app.POST("/chat", chatHandler)
+}
+"""
+
+    detections = _extract(
+        EchoAdapter(),
+        source,
+    )
+    endpoint = _endpoint(detections)
+    auth = _by_type(
+        detections,
+        ComponentType.AUTH,
+    )
+
+    assert endpoint.metadata["request_body_schema"] == {
+        "messages": "[]ChatMessage",
+    }
+    assert endpoint.metadata["chat_payload_key"] == "messages"
+    assert endpoint.metadata["chat_payload_list"] is True
+    assert endpoint.metadata["auth_required"] is True
+    assert endpoint.metadata["auth_type"] == "jwt"
+
+    assert len(auth) == 1
+    assert auth[0].metadata["auth_type"] == "jwt"
+    assert auth[0].snippet == "echojwt.WithConfig(...)"
+
+
+def test_net_http_infers_schema_from_json_decoder() -> None:
+    source = """package main
+
+import (
+    "encoding/json"
+    "net/http"
+)
+
+type ChatRequest struct {
+    Query     string `json:"query"`
+    SessionID string `json:"session_id,omitempty"`
+}
+
+func chatHandler(w http.ResponseWriter, r *http.Request) {
+    request := ChatRequest{}
+    _ = json.NewDecoder(r.Body).Decode(&request)
+}
+
+func main() {
+    mux := http.NewServeMux()
+    mux.Handle("/chat", http.HandlerFunc(chatHandler))
+}
+"""
+
+    detections = _extract(
+        NetHTTPAdapter(),
+        source,
+    )
+    endpoint = _endpoint(detections)
+
+    assert endpoint.metadata["request_body_schema"] == {
+        "query": "string",
+        "session_id": "string",
+    }
+    assert endpoint.metadata["chat_payload_key"] == "query"
+    assert endpoint.metadata["chat_payload_list"] is False
+    assert endpoint.metadata["auth_required"] is False
+    assert endpoint.metadata["accepts_user_input"] is True
+    assert (
+        _by_type(
+            detections,
+            ComponentType.AUTH,
+        )
+        == []
+    )
+
+
+def test_chi_infers_schema_from_json_decoder() -> None:
+    source = """package main
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "github.com/go-chi/chi/v5"
+)
+
+type ChatRequest struct {
+    Input string `json:"input"`
+}
+
+func chatHandler(w http.ResponseWriter, r *http.Request) {
+    request := ChatRequest{}
+    _ = json.NewDecoder(r.Body).Decode(&request)
+}
+
+func main() {
+    router := chi.NewRouter()
+    router.Post("/chat", chatHandler)
+}
+"""
+
+    endpoint = _endpoint(
+        _extract(
+            ChiAdapter(),
+            source,
+        )
+    )
+
+    assert endpoint.metadata["request_body_schema"] == {
+        "input": "string",
+    }
+    assert endpoint.metadata["chat_payload_key"] == "input"
+    assert endpoint.metadata["auth_required"] is False
+
+
+def test_inline_gin_handler_is_supported() -> None:
+    source = """package main
+
+import "github.com/gin-gonic/gin"
+
+type ChatRequest struct {
+    UserMessage string `json:"user_message"`
+}
+
+func main() {
+    router := gin.New()
+    router.POST("/chat", func(c *gin.Context) {
+        request := &ChatRequest{}
+        _ = c.ShouldBind(request)
+    })
+}
+"""
+
+    endpoint = _endpoint(
+        _extract(
+            GinAdapter(),
+            source,
+        )
+    )
+
+    assert endpoint.metadata["request_body_schema"] == {
+        "user_message": "string",
+    }
+    assert endpoint.metadata["chat_payload_key"] == "user_message"
+    assert endpoint.metadata["auth_required"] is False
+
+
+def test_gin_jwt_middleware_variable_protects_later_route() -> None:
+    source = """package main
+
+import (
+    jwt "github.com/appleboy/gin-jwt/v2"
+    "github.com/gin-gonic/gin"
+)
+
+func main() {
+    authMiddleware, _ := jwt.New(
+        &jwt.GinJWTMiddleware{},
+    )
+    router := gin.New()
+    router.Use(
+        authMiddleware.MiddlewareFunc(),
+    )
+    router.POST("/chat", chatHandler)
+}
+"""
+
+    detections = _extract(
+        GinAdapter(),
+        source,
+    )
+    endpoint = _endpoint(detections)
+    auth = _by_type(
+        detections,
+        ComponentType.AUTH,
+    )
+
+    assert endpoint.metadata["auth_required"] is True
+    assert endpoint.metadata["auth_type"] == "jwt"
+    assert len(auth) == 1
+    assert auth[0].snippet == "authMiddleware.MiddlewareFunc(...)"
+
+
+def test_unrecognized_middleware_and_external_handler_are_conservative() -> None:
+    source = """package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+    router := gin.New()
+    router.Use(custom.BasicAuth())
+    router.POST(
+        "/chat",
+        external.ChatHandler,
+    )
+}
+"""
+
+    detections = _extract(
+        GinAdapter(),
+        source,
+    )
+    endpoint = _endpoint(detections)
+
+    assert endpoint.metadata["request_body_schema"] == {}
+    assert endpoint.metadata["chat_payload_key"] is None
+    assert endpoint.metadata["chat_payload_list"] is False
+    assert endpoint.metadata["auth_required"] is False
+    assert (
+        _by_type(
+            detections,
+            ComponentType.AUTH,
+        )
+        == []
+    )
+
+
+def test_middleware_after_route_does_not_retroactively_protect_it() -> None:
+    source = """package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+    router := gin.New()
+    router.POST("/chat", chatHandler)
+    router.Use(
+        gin.BasicAuth(
+            gin.Accounts{"admin": "secret"},
+        ),
+    )
+}
+"""
+
+    detections = _extract(
+        GinAdapter(),
+        source,
+    )
+    endpoint = _endpoint(detections)
+
+    assert endpoint.metadata["auth_required"] is False
+    assert (
+        _by_type(
+            detections,
+            ComponentType.AUTH,
+        )
+        == []
+    )
+
+
+def test_simple_routes_keep_empty_metadata_fields() -> None:
+    source = """package main
+
+import "github.com/labstack/echo/v4"
+
+func main() {
+    app := echo.New()
+    app.GET("/health", healthHandler)
+}
+"""
+
+    endpoint = _endpoint(
+        _extract(
+            EchoAdapter(),
+            source,
+        )
+    )
+
+    assert endpoint.metadata["request_body_schema"] == {}
+    assert endpoint.metadata["chat_payload_key"] is None
+    assert endpoint.metadata["chat_payload_list"] is False
+    assert endpoint.metadata["auth_required"] is False
+    assert "accepts_user_input" not in endpoint.metadata


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [x] Feature

## What

- Extended the existing Gin, Echo, Chi, and `net/http` route adapters instead of adding a duplicate HTTP adapter.
- Added same-file JSON request-schema inference for:
  - Gin binding calls such as `ShouldBindJSON(...)`, `BindJSON(...)`, and `ShouldBind(...)`;
  - Echo `Bind(...)`;
  - `net/http` and Chi handlers using JSON decoder `Decode(...)` calls.
- Added endpoint metadata:
  - `request_body_schema`;
  - `chat_payload_key`;
  - `chat_payload_list`;
  - `accepts_user_input`;
  - `auth_required`;
  - `auth_type`;
  - `auth_types`.
- Added recognized authentication detection for:
  - Gin `BasicAuth(...)` and `BasicAuthForRealm(...)`;
  - Gin JWT middleware created through `appleboy/gin-jwt`;
  - Echo JWT middleware;
  - Echo Basic Auth middleware.
- Supports route-level middleware, router-level `Use(...)`, and middleware attached during `Group(...)` creation.
- Emits `AUTH` components for recognized Basic and JWT middleware.
- Emits `AUTH -[PROTECTS]-> API_ENDPOINT` relationships.
- Redacts middleware configuration and credential arguments from authentication evidence snippets.
- Does not retroactively apply middleware declared after a route.
- Added conservative handling for unknown middleware and external handlers.
- Added ten focused parser-backed tests.

## Why

This addresses the remaining implementation gap in #178.

Go route detection for Gin, Echo, Chi, and `net/http` already exists on `develop`, but the emitted endpoint components do not describe request payloads or recognized authentication protection.

Without this metadata, an AI-BOM can identify that an endpoint exists while omitting:

- the request fields accepted by the handler;
- which field contains the conversational payload;
- whether that payload is a single value or a message list;
- whether recognized Basic or JWT middleware protects the endpoint;
- the relationship between authentication and the protected endpoint.

## How

- Added a private shared metadata helper used by the existing HTTP route adapters.
- Preserved the existing route-detection and endpoint canonical-name behavior.
- Correlated parsed route calls with existing `API_ENDPOINT` detections.
- Resolved named and inline same-file handler bodies.
- Identified request variables passed to supported binding and decoder calls.
- Recovered exported Go struct fields and their JSON tags.
- Selected conversational payload fields from conservative known names such as:
  - `message`;
  - `messages`;
  - `prompt`;
  - `query`;
  - `input`;
  - `user_message`;
  - `history`.
- Built authentication alias maps from parsed imports rather than matching arbitrary identifiers.
- Considered middleware only when it appears before the route and originates from a recognized package.
- Followed known router and group receivers without guessing arbitrary middleware behavior.
- Used source-specific authentication canonical names so unrelated middleware instances are not collapsed into one global node.
- Attached `PROTECTS` relationships to emitted authentication components.

## Test Steps

- [x] `python3 -m py_compile nuguard/sbom/adapters/go/_http_endpoint_metadata.py nuguard/sbom/adapters/go/http_router.py nuguard/sbom/adapters/go/net_http.py nuguard/sbom/tests/test_go_http_endpoint_metadata.py`
- [x] `uv run ruff format --check nuguard/sbom/adapters/go/_http_endpoint_metadata.py nuguard/sbom/tests/test_go_http_endpoint_metadata.py`
- [x] `uv run ruff check nuguard/sbom/adapters/go/_http_endpoint_metadata.py nuguard/sbom/adapters/go/http_router.py nuguard/sbom/adapters/go/net_http.py nuguard/sbom/tests/test_go_http_endpoint_metadata.py`
- [x] `uv run mypy nuguard/sbom/adapters/go/_http_endpoint_metadata.py nuguard/sbom/adapters/go/http_router.py nuguard/sbom/adapters/go/net_http.py`
- [x] Confirmed `HAS_TREE_SITTER=True` and `used_tree_sitter=True`
- [x] `uv run pytest -q nuguard/sbom/tests/test_go_http_endpoint_metadata.py`
- [x] `uv run pytest -q nuguard/sbom/tests/test_go_http_router_adapters.py`
- [x] `uv run pytest -q nuguard/sbom/tests/test_go_parser.py nuguard/sbom/tests/test_go_adapter_base.py`
- [x] `uv run pytest -q nuguard/sbom/tests`
- [x] `make lint`
- [x] `uv run pytest tests/contracts/test_public_api_schema_contract.py -q`
- [x] `uv run pytest nuguard/ -q`
- [x] `make test`
- [x] `uv run pytest tests/ --ignore=tests/apps/contact-center-ai-samples -v`
- [x] `make precommit-run`

## Checks

- [x] `make test` passes (`uv run pytest tests/ -v`)
- [x] `make lint` passes (`ruff check` + `mypy`)
- [x] `make fmt` applied, no diff
- [x] Added/updated tests covering this change

## Other Notes

- This PR extends `http_router.py` and `net_http.py`; it does not introduce the duplicate `http_server.py` originally proposed in #178.
- Request-schema resolution is deliberately limited to handlers and named structs in the same source file.
- Handlers defined in other packages are not guessed.
- Unknown middleware does not set `auth_required=true`.
- Chi request-schema enrichment uses its standard `net/http` handler pattern.
- Authentication inference is limited to recognized Gin and Echo middleware.
- General `net/http` and Chi authentication-wrapper inference remains out of scope.
- Route-prefix composition is unchanged and remains outside this PR.
- Authentication snippets identify middleware functions without copying credential or configuration arguments.
- Global `make fmt` is intentionally not used because it currently reformats unrelated baseline files. New modules are formatted using targeted Ruff commands, and all changed files are checked with focused Ruff linting.

## Release note

Go Gin, Echo, Chi, and `net/http` endpoint detections can now include same-file request schemas, conversational payload fields, and recognized Basic/JWT authentication relationships.

Closes #178