### PR TITLE
fix(target-verify): support cookie_file auth and custom headers in public API

### DIFF
--- a/nuguard/common/target_verify_public_api.py
+++ b/nuguard/common/target_verify_public_api.py
@@ -45,6 +45,7 @@ class TargetVerifyRequest(BaseModel):
     auth_username: str | None = None
     auth_password: str | None = None
     login_flow: LoginFlowConfig | None = None
+    headers: dict[str, str] | None = None
     chat_payload_key: str = "message"
     chat_payload_list: bool = False
     chat_response_key: str | None = None
@@ -56,6 +57,11 @@ class TargetVerifyRequest(BaseModel):
     def _validate_login_flow(self) -> "TargetVerifyRequest":
         if self.auth_type.strip().lower() == "login_flow" and self.login_flow is None:
             raise ValueError("auth_type=login_flow requires login_flow configuration")
+        if self.auth_type.strip().lower() == "cookie_file" and not self.auth_value:
+            raise ValueError(
+                "auth_type=cookie_file requires auth_value to be the path to a "
+                "Netscape-format cookies.txt"
+            )
         return self
 
 
@@ -87,6 +93,7 @@ class TargetSessionResolveRequest(BaseModel):
     auth_username: str | None = None
     auth_password: str | None = None
     login_flow: LoginFlowConfig | None = None
+    headers: dict[str, str] | None = None
     chat_payload_key: str = "message"
     chat_payload_list: bool = False
     chat_response_key: str | None = None
@@ -97,6 +104,11 @@ class TargetSessionResolveRequest(BaseModel):
     def _validate_login_flow(self) -> "TargetSessionResolveRequest":
         if self.auth_type.strip().lower() == "login_flow" and self.login_flow is None:
             raise ValueError("auth_type=login_flow requires login_flow configuration")
+        if self.auth_type.strip().lower() == "cookie_file" and not self.auth_value:
+            raise ValueError(
+                "auth_type=cookie_file requires auth_value to be the path to a "
+                "Netscape-format cookies.txt"
+            )
         return self
 
 
@@ -139,7 +151,26 @@ def _build_auth_config(request: TargetVerifyRequest | TargetSessionResolveReques
         value = request.auth_value or ""
         header = value if ":" in value else f"X-API-Key: {value}"
         return AuthConfig(type="api_key", header=header)
+    if auth_type == "cookie_file":
+        return AuthConfig(type="cookie_file", cookie_file=request.auth_value or "")
     return AuthConfig(type="none")
+
+
+def _merge_headers(
+    request: "TargetVerifyRequest | TargetSessionResolveRequest",
+    *header_dicts: dict[str, str] | None,
+) -> dict[str, str]:
+    """Merge request.headers underneath the given auth/bootstrap headers.
+
+    Custom headers apply to every request; auth-derived headers win on any
+    key conflict, mirroring how BehaviorConfig.headers is merged in
+    ``BehaviorRunner._build_client``.
+    """
+    merged: dict[str, str] = dict(request.headers or {})
+    for headers in header_dicts:
+        if headers:
+            merged.update(headers)
+    return merged
 
 
 def _check_from_health(check: CredentialCheckResult) -> TargetVerifyCheck:
@@ -210,7 +241,7 @@ async def verify_target(
     endpoint, payload_key, payload_list, response_key, endpoint_source = await _resolve_endpoint_plan(
         target_url=resolved_url,
         sbom=sbom,
-        auth_headers=auth_config.to_headers() or None,
+        auth_headers=_merge_headers(request, auth_config.to_headers()) or None,
         chat_path=request.chat_path,
         chat_payload_key=request.chat_payload_key,
         chat_payload_list=request.chat_payload_list,
@@ -240,7 +271,10 @@ async def verify_target(
             payload_list=payload_list,
             response_key=response_key,
             timeout=request.request_timeout,
-            auth_headers=bootstrapper.session.headers() or auth_config.to_headers() or None,
+            auth_headers=_merge_headers(
+                request, auth_config.to_headers(), bootstrapper.session.headers()
+            )
+            or None,
             sbom=sbom,
             payload_extras=request.chat_payload_extras or None,
         )
@@ -289,7 +323,7 @@ async def resolve_target_session_public(
         endpoint, payload_key, payload_list, response_key, endpoint_source = await _resolve_endpoint_plan(
             target_url=resolved_url,
             sbom=sbom,
-            auth_headers=auth_config.to_headers() or None,
+            auth_headers=_merge_headers(request, auth_config.to_headers()) or None,
             chat_path=request.chat_path,
             chat_payload_key=request.chat_payload_key,
             chat_payload_list=request.chat_payload_list,
@@ -300,7 +334,7 @@ async def resolve_target_session_public(
             target_url=resolved_url,
             sbom=sbom,
             auth_config=auth_config,
-            extra_headers={},
+            extra_headers=dict(request.headers or {}),
             chat_path=endpoint,
             chat_payload_key=payload_key,
             chat_payload_list=payload_list,

--- a/tests/common/test_target_verify_public_api.py
+++ b/tests/common/test_target_verify_public_api.py
@@ -65,6 +65,79 @@ def test_public_target_requests_require_login_flow_config(request_type) -> None:
         request_type(target_url="http://target", auth_type="login_flow")
 
 
+@pytest.mark.parametrize(
+    "request_type",
+    [TargetVerifyRequest, TargetSessionResolveRequest],
+)
+def test_public_target_requests_build_cookie_file_auth_config(request_type, tmp_path) -> None:
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.write_text(
+        "example.com\tFALSE\t/\tFALSE\t0\tmosaic_session\tabc.def.ghi\n",
+        encoding="utf-8",
+    )
+
+    auth_config = _build_auth_config(
+        request_type(
+            target_url="http://target",
+            auth_type="cookie_file",
+            auth_value=str(cookie_file),
+        )
+    )
+
+    assert auth_config.type == "cookie_file"
+    assert auth_config.cookie_file == str(cookie_file)
+    assert auth_config.to_headers() == {"Cookie": "mosaic_session=abc.def.ghi"}
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [TargetVerifyRequest, TargetSessionResolveRequest],
+)
+def test_public_target_requests_require_cookie_file_path(request_type) -> None:
+    with pytest.raises(ValidationError, match="requires auth_value"):
+        request_type(target_url="http://target", auth_type="cookie_file")
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_session_public_threads_custom_headers_to_sbom_session(monkeypatch):
+    from nuguard.common.session_resolver import TargetSessionConfig
+
+    captured_extra_headers = []
+
+    async def _fake_resolve_target_session(**kwargs):
+        captured_extra_headers.append(kwargs["extra_headers"])
+        report = TargetHealthReport(target_url="http://target", endpoint="/chat", run_id="r-hdr", checks=[])
+        return (
+            TargetSessionConfig(
+                base_url="http://target",
+                chat_path="/chat",
+                chat_payload_key="message",
+                chat_payload_list=False,
+                chat_payload_extras={},
+                chat_response_key=None,
+                auth_session=_FakeAuthSession(),
+                resolution_notes=[],
+            ),
+            report,
+        )
+
+    monkeypatch.setattr(
+        "nuguard.common.target_verify_public_api.discover_chat_config_from_sbom",
+        lambda *args, **kwargs: ("/chat", "message", False, None),
+    )
+    monkeypatch.setattr("nuguard.common.target_verify_public_api.resolve_target_session", _fake_resolve_target_session)
+
+    await resolve_target_session_public(
+        TargetSessionResolveRequest(
+            target_url="http://target",
+            headers={"X-Tenant-Id": "acme"},
+        ),
+        sbom=object(),
+    )
+
+    assert captured_extra_headers == [{"X-Tenant-Id": "acme"}]
+
+
 @pytest.mark.asyncio
 async def test_verify_target_passes_login_flow_to_auth_bootstrap(monkeypatch) -> None:
     login_flow = LoginFlowConfig(

--- a/tests/contracts/public_api.schema.json
+++ b/tests/contracts/public_api.schema.json
@@ -4069,6 +4069,21 @@
         ],
         "default": null
       },
+      "headers": {
+        "anyOf": [
+          {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Headers"
+      },
       "chat_payload_key": {
         "default": "message",
         "title": "Chat Payload Key",
@@ -4381,6 +4396,21 @@
           }
         ],
         "default": null
+      },
+      "headers": {
+        "anyOf": [
+          {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Headers"
       },
       "chat_payload_key": {
         "default": "message",


### PR DESCRIPTION
## Summary
- `TargetVerifyRequest`/`TargetSessionResolveRequest` only accepted `auth_type` in `{none, bearer, api_key, basic, login_flow}`, so a target authenticated via a session cookie (e.g. captured by `nuguard target discover-browser` against an Auth0 redirect flow) could never pass pre-scan verification through the public API — only through the CLI's own `nuguard.yaml`-driven `target verify` path.
- Adds `auth_type: cookie_file` (with `auth_value` as the cookies.txt path) to both request models, plus a generic `headers: dict[str, str]` field merged underneath auth-derived headers everywhere headers are built (endpoint discovery probing, live client construction, and session resolution).

Fixes #494

## Test plan
- [x] `uv run pytest tests/common/test_target_verify_public_api.py tests/contracts/ -q`
- [x] `uv run ruff check` / `uv run mypy` on the changed module
- [x] Live-verified against the kscope test app (`tests/apps/kscope`, the exact Auth0/`mosaic_session` cookie scenario from the issue): calling `verify_target(TargetVerifyRequest(auth_type="cookie_file", auth_value=".../cookies.txt", ...))` against `https://getmosaiccare.com/api/chat` returns `all_ok=True` / HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gt5YoGPkiMeeWvmpUq43Q