### PR TITLE
fix(api): complete and secure public Pydantic interfaces

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,7 @@ NuGuard is a security tool — hold all code to a high security bar:
 - **LLM enrichment**: optional everywhere. Pass `--llm` or set `llm: true` in config. Default model: `gemini/gemini-2.0-flash`. API key: `LITELLM_API_KEY`.
 - **Configuration precedence**: CLI flags > `nuguard.yaml` > environment variables > built-in defaults.
 - **Shared SBOM enrichment**: both `nuguard behavior` and `nuguard redteam` call `enrich_sbom_for_run()` from `nuguard/cli/common.py` before scenario generation. Prefer this shared helper over duplicating enrichment logic.
+- **Public Pydantic interfaces**: for functionality changes or bug fixes that affect public Python or platform consumers, load and follow `.github/skills/pydantic-interface/SKILL.md`. Keep models, exports, schema snapshots, tests, docs, compatibility, and secret redaction synchronized.
 
 ## CLI Surface
 

--- a/.github/skills/pydantic-interface/SKILL.md
+++ b/.github/skills/pydantic-interface/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: pydantic-interface
+description: >
+  Use when adding, changing, fixing, or removing NuGuard package functionality that has a
+  public Python or platform-facing interface. Keeps public Pydantic request/result models,
+  streaming events and reducers, exports, JSON Schema snapshots, documentation, redaction,
+  and compatibility tests synchronized with implementation changes.
+user-invocable: false
+---
+
+# Pydantic Interface Maintenance
+
+Keep NuGuard's supported Pydantic boundary synchronized with functional changes.
+
+## Workflow
+
+1. Identify whether the changed behavior is callable by library, CLI, MCP, plugin, or platform
+   consumers. Inspect the nearest `public_api.py`, existing exports, and contract tests before
+   editing.
+2. Reuse or extend public `BaseModel` request, result, configuration, event, and reducer types.
+   Do not expose implementation dataclasses, private helpers, unresolved credentials, raw target
+   responses, or mutable internal state.
+3. Preserve existing public call signatures and import paths unless a breaking change is
+   explicitly approved. Add normalization at the public boundary when an existing public model
+   must interoperate with an internal model.
+4. Ensure every public model is JSON-safe with `model_dump(mode="json")`, round-trips through
+   validation, and has stable field names and constrained values. Use `SecretStr` for required
+   credential inputs and omit secrets from results, events, cache metadata, logs, and errors.
+5. For streaming changes, use `StreamEvent` and the public reducer. Preserve monotonic sequence
+   and progress values, exactly one terminal event, settled cancellation, and sanitized stable
+   failures.
+6. Add focused tests for success, validation failure, serialization, backwards compatibility,
+   side effects, and credential leakage. Public wrappers must not add filesystem or network side
+   effects by default.
+7. Register new public models in `tests/contracts/test_public_api_schema_contract.py`, regenerate
+   `tests/contracts/public_api.schema.json`, and inspect the diff for accidental contract churn.
+8. Update relevant library and platform-integration documentation, including cancellation,
+   caching, persistence, authentication, and error behavior where applicable.
+
+## Validation
+
+Run the narrowest affected tests first, then complete these checks before finishing:
+
+```powershell
+uv run pytest tests/contracts/test_public_api_schema_contract.py -q
+uv run ruff check nuguard/ tests/
+uv run mypy nuguard/
+uv run pytest tests/ -q
+```
+
+Search serialized results, events, logs, and public exception messages for fixture secrets when
+the change handles repository URLs, API keys, authorization headers, cookies, or target output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# NuGuard Agent Guidance
+
+Follow [CLAUDE.md](CLAUDE.md) for repository architecture, development commands, and coding
+standards.
+
+For any functionality change or bug fix that affects a public Python or platform-facing
+interface, load and follow
+[the Pydantic interface skill](.github/skills/pydantic-interface/SKILL.md). Keep exported models,
+schemas, tests, documentation, compatibility behavior, and credential redaction synchronized.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ Makefile shortcuts: `make dev`, `make test`, `make lint`, `make fmt`.
 
 Use `tmp/` for scratch scripts and one-off experiments rather than streaming commands in the terminal.
 
+For functionality changes or bug fixes that affect public Python or platform-facing interfaces,
+follow [the Pydantic interface skill](.github/skills/pydantic-interface/SKILL.md). It defines the
+required model, schema, compatibility, documentation, and credential-redaction workflow.
+
 ## Architecture
 
 NuGuard is an AI application security package with five capabilities:

--- a/documentation/docs/library-reference.md
+++ b/documentation/docs/library-reference.md
@@ -230,6 +230,8 @@ result = await run_behavior_scenarios(
 
 Module: `nuguard.redteam.public_api`
 
+- `RedteamAuthConfig`
+- `RedteamLoginFlowConfig`
 - `RedteamRunRequest`
 - `RedteamRunResult`
 - `RedteamExecutionResult`
@@ -251,9 +253,12 @@ result = await run_redteam(
 )
 ```
 
-`RedteamRunRequest.auth_config` accepts the canonical public `AuthConfig` and remains compatible
-with `AppAuthConfig`. Bearer, API-key, basic, login-flow, cookie-file, and no-auth configurations
-are normalized without placing resolved credentials in result models.
+`RedteamRunRequest.auth_config` uses the secret-safe public `RedteamAuthConfig` and remains
+compatible with internal `AuthConfig` and application `AppAuthConfig` inputs. Bearer, API-key,
+basic, login-flow, cookie-file, and no-auth configurations are normalized without placing
+resolved credentials in serialized requests or result models. Request JSON dumps are redacted
+diagnostic representations and must not be persisted or replayed as executable credential
+transport. Platforms should resolve secret references server-side before constructing a request.
 
 `RedteamRunResult.scan_outcome` is one of:
 

--- a/documentation/docs/library-reference.md
+++ b/documentation/docs/library-reference.md
@@ -75,10 +75,15 @@ Module: `nuguard.sbom.public_api`
 - `SbomRenderResult`
 - `SbomExportRequest`
 - `SbomExportResult`
+- `SbomEnrichmentLlmConfig`
+- `SbomProbeAuthConfig`
+- `SbomEnrichmentRequest`
+- `SbomEnrichmentResult`
 - `generate_sbom(request)`
 - `parse_sbom_json(request)`
 - `render_sbom(request, *, sbom)`
 - `export_sbom(request, *, sbom)`
+- `enrich_sbom(request)`
 
 `SbomRenderRequest.format` supports:
 
@@ -95,6 +100,25 @@ from nuguard.sbom.public_api import SbomGenerateRequest, SbomRenderRequest, gene
 generated = await generate_sbom(SbomGenerateRequest(source_path="./my_app"))
 rendered = await render_sbom(SbomRenderRequest(format="json"), sbom=generated.sbom)
 ```
+
+`enrich_sbom()` accepts an existing validated `AiSbomDocument`, operates on a deep copy, and
+performs no filesystem writes unless `output_path` is set. Its cache fingerprint excludes LLM
+API keys and probe authorization values; use the caller-controlled opaque `cache_version` when
+auth or external state must invalidate a platform-managed cache. Secret inputs use `SecretStr`
+and are never copied into the result.
+
+## Cognitive policy API
+
+Module: `nuguard.policy.public_api`
+
+- `CognitivePolicyParseRequest`
+- `CognitivePolicyParseDetail`
+- `CognitivePolicyParseResult`
+- `parse_cognitive_policy(request)`
+
+The parse result contains a validated policy or stable sanitized errors. Pass a successful result
+directly as `policy=` to public behavior and red-team entry points. The existing
+`parse_policy(text)` API remains supported.
 
 ## SBOM toolbox APIs
 
@@ -154,6 +178,7 @@ Module: `nuguard.behavior.public_api`
 - `run_behavior_scenarios(request, *, sbom=None, policy=None, intent=None, llm_client=None, remediation_llm_client=None, judge_cache=None)`
 - `discover_behavior_profile(config, *, sbom=None, policy=None, intent=None, llm_client=None)`
 - `analyze_behavior_stream(...)`
+- `analyze_behavior_analysis_stream(...)`
 
 Example (full analysis):
 
@@ -172,6 +197,10 @@ result = await analyze_behavior(
     llm_client=llm_client,
 )
 ```
+
+Use `analyze_behavior_analysis_stream(BehaviorAnalysisRequest(...))` for the same complete
+intent, policy, discovery, planning, execution, remediation, and final-result lifecycle with
+incremental events. Its `final_result()` is a `BehaviorAnalysisResult`.
 
 Example (scenario-level run):
 
@@ -222,6 +251,10 @@ result = await run_redteam(
 )
 ```
 
+`RedteamRunRequest.auth_config` accepts the canonical public `AuthConfig` and remains compatible
+with `AppAuthConfig`. Bearer, API-key, basic, login-flow, cookie-file, and no-auth configurations
+are normalized without placing resolved credentials in result models.
+
 `RedteamRunResult.scan_outcome` is one of:
 
 - `critical_findings`
@@ -244,9 +277,18 @@ Module: `nuguard.common.streaming_models`
 
 Behavior and redteam streaming APIs return a typed `StreamRunHandle` that emits `StreamEvent` envelopes and resolves to the final result model.
 
-Streams emit `scenario_plan_ready`, `scenario_started`, and `scenario_progress` while scenarios execute. Progress payloads include the scenario ID, title, type, terminal status, and monotonic completion counts. `findings_delta` contains redteam findings and behavior turn reports as scenarios complete. When concurrency is greater than one, event sequence reflects execution completion order rather than scenario-plan order. The final result remains authoritative when scan-level aggregation or deduplication changes the final finding set. Under bounded queue pressure, low-priority progress updates may be dropped so lifecycle and terminal events can be delivered.
+Streams emit `run_started`, `scenario_plan_ready`, `scenario_started`, `scenario_progress`,
+`findings_delta`, optional idle `heartbeat` events, and exactly one terminal `completed` or
+`failed` event. Progress payloads contain monotonic sequence and completion counts. Apply every
+event through the matching shared reducer; the final result remains authoritative. Under bounded
+queue pressure, heartbeats and progress updates may be dropped, but lifecycle and terminal events
+are retained.
 
-Call `handle.cancel()` to request non-blocking cancellation, then `await handle.wait_closed(timeout=5.0)` to wait for worker shutdown without cancelling the worker if the wait expires. Cancellation emits a terminal `failed` event with `failure_stage="cancelled"`; `await handle.final_result()` raises `asyncio.CancelledError`.
+Call `handle.cancel()` to request non-blocking cancellation, then
+`await handle.wait_closed(timeout=5.0)` to wait for shutdown without cancelling the worker if the
+wait expires. Cancellation emits sanitized stable metadata and `final_result()` raises an
+`asyncio.CancelledError` subclass. Other worker failures emit only stable public error metadata
+and raise `StreamExecutionError`; raw target responses and credentials are not exposed.
 
 ## Target verify and session APIs
 

--- a/documentation/docs/platform-public-api-integration.md
+++ b/documentation/docs/platform-public-api-integration.md
@@ -18,6 +18,7 @@ Use these files as the canonical public API surface:
 - `nuguard/analysis/public_api.py`
 - `nuguard/behavior/public_api.py`
 - `nuguard/redteam/public_api.py`
+- `nuguard/policy/public_api.py`
 - `nuguard/sbom/public_api.py`
 - `nuguard/sbom/toolbox/public_api.py`
 - `nuguard/output/public_api.py`
@@ -34,9 +35,10 @@ Schema lock for platform-facing models:
 | Domain | Public module | Entry points |
 |---|---|---|
 | Static analysis | `nuguard.analysis.public_api` | `run_analysis` |
-| Behavior | `nuguard.behavior.public_api` | `analyze_behavior`, `run_behavior_scenarios`, `discover_behavior_profile`, `analyze_behavior_stream`, `analyze_behavior_static` |
+| Behavior | `nuguard.behavior.public_api` | `analyze_behavior`, `analyze_behavior_analysis_stream`, `run_behavior_scenarios`, `discover_behavior_profile`, `analyze_behavior_stream`, `analyze_behavior_static` |
 | Redteam (v1) | `nuguard.redteam.public_api` | `run_redteam`, `run_redteam_stream` |
-| SBOM generation/serialization | `nuguard.sbom.public_api` | `generate_sbom`, `parse_sbom_json`, `render_sbom`, `export_sbom` |
+| Cognitive policy | `nuguard.policy.public_api` | `parse_cognitive_policy` |
+| SBOM generation/serialization | `nuguard.sbom.public_api` | `generate_sbom`, `parse_sbom_json`, `render_sbom`, `export_sbom`, `enrich_sbom` |
 | SBOM toolbox | `nuguard.sbom.toolbox.public_api` | `list_toolbox_plugins`, `run_toolbox_plugin`, `run_toolbox_all` |
 | Report rendering/export | `nuguard.output.public_api` | `render_redteam_report`, `render_behavior_report`, `export_validation_report` |
 | Target verification/session | `nuguard.common.target_verify_public_api` | `verify_target`, `resolve_target_session_public` |
@@ -74,6 +76,10 @@ Entry points:
 - `await run_behavior_scenarios(request, sbom=..., policy=..., intent=..., llm_client=...)`
 - `await discover_behavior_profile(config, sbom=..., policy=..., intent=..., llm_client=...)`
 - `await analyze_behavior_stream(request, ...)` (returns `StreamRunHandle[BehaviorRunResult]`)
+- `await analyze_behavior_analysis_stream(request, ...)` (returns `StreamRunHandle[BehaviorAnalysisResult]`)
+
+The analysis stream invokes the same complete orchestration as `analyze_behavior` exactly once;
+callers do not need to plan scenarios or combine internal results.
 
 ### Redteam (v1 engine)
 
@@ -92,6 +98,20 @@ Entry points:
 
 Note:
 - This public API wraps redteam v1 orchestration. v2 is out of scope for this contract.
+- `RedteamRunRequest.auth_config` uses public `AuthConfig` and also accepts `AppAuthConfig`.
+    Bearer, API-key, basic, login-flow, cookie-file, and no-auth variants remain JSON-serializable.
+
+### Cognitive policy parsing
+
+Module: `nuguard.policy.public_api`
+
+- Request: `CognitivePolicyParseRequest`
+- Result: `CognitivePolicyParseResult`, with `CognitivePolicyParseDetail` diagnostics
+- Entry point: `parse_cognitive_policy(request)`
+
+Successful parse results can be passed directly as `policy=` to behavior and red-team entry
+points. Failures contain stable sanitized details rather than source Markdown or raw validation
+exceptions.
 
 ### SBOM generation/serialization contracts
 
@@ -102,18 +122,27 @@ Request models:
 - `SbomParseRequest`
 - `SbomRenderRequest`
 - `SbomExportRequest`
+- `SbomEnrichmentRequest`, with `SbomEnrichmentLlmConfig` and `SbomProbeAuthConfig`
 
 Response models:
 - `SbomGenerateResult`
 - `SbomParseResult`
 - `SbomRenderResult`
 - `SbomExportResult`
+- `SbomEnrichmentResult`
 
 Entry points:
 - `await generate_sbom(request)`
 - `await parse_sbom_json(request)`
 - `await render_sbom(request, sbom=...)`
 - `await export_sbom(request, sbom=...)`
+- `await enrich_sbom(request)`
+
+Enrichment validates input and output, operates copy-on-write, and writes only when
+`output_path` is explicitly supplied. The deterministic `cache_fingerprint` supports
+platform-managed caching and excludes API keys and authorization values. Set the opaque
+`cache_version` to invalidate cached work when secret-dependent or external state changes.
+Computed and externally cached values use the same `SbomEnrichmentResult` schema.
 
 Supported render/export formats:
 - `json`
@@ -184,15 +213,22 @@ Handle contract from `nuguard.common.stream_runtime`:
 - `StreamRunHandle[T]` with stream iterator, final result retrieval, non-blocking `cancel()`, and `await wait_closed(timeout=...)`.
 
 Redteam and behavior streams emit typed events while scenarios execute:
+- `run_started` identifies the accepted run.
 - `scenario_plan_ready` establishes the initial scenario total and can revise it upward when redteam adds an escalation pass.
 - `scenario_started` identifies the scenario being executed.
 - `scenario_progress` identifies the completed scenario and reports monotonic completion counts.
 - `findings_delta` emits redteam findings and behavior turn reports as scenarios complete.
+- `heartbeat` may be emitted during idle long-running phases.
 - `completed` or `failed` is emitted once as the terminal event.
 
 `StreamProgressPayload` includes `scenario_id`, `scenario_title`, `scenario_status`, `current_scenario_type`, and progress counts. With concurrent execution, event order reflects runtime completion order rather than planned scenario order. Apply every event with the matching shared reducer; the final result remains authoritative if scan-level aggregation refines findings.
 
-Call `handle.cancel()` to request cancellation. A cancelled stream emits `failed` with `failure_stage="cancelled"`; `await handle.final_result()` raises `asyncio.CancelledError`. Use `await handle.wait_closed(timeout=...)` to bound only the caller's wait; a timeout does not cancel the underlying scan.
+Call `handle.cancel()` to request cancellation. A cancelled stream emits `failed` with stable
+sanitized metadata and `final_result()` raises an `asyncio.CancelledError` subclass. Generic
+worker failures raise `StreamExecutionError` and expose no raw exception message, target response,
+or credentials. Use `await handle.wait_closed(timeout=...)` to bound only the caller's wait; a
+timeout does not cancel the underlying scan. Heartbeats and progress updates may be dropped under
+queue pressure, while lifecycle and terminal events are retained.
 
 ## Migration map: internal calls to public contracts
 
@@ -203,6 +239,8 @@ Call `handle.cancel()` to request cancellation. A cancelled stream emits `failed
 | Constructing `BehaviorRunner` directly for external integration orchestration | Build `BehaviorRunRequest` and call `run_behavior_scenarios` |
 | Calling redteam orchestrator internals from platform code | Build `RedteamRunRequest` and call `run_redteam` |
 | Calling `SbomGenerator` or extractor internals directly from platform code | Build `SbomGenerateRequest` and call `generate_sbom` |
+| Calling `maybe_auto_enrich_sbom` or private credential resolvers | Build `SbomEnrichmentRequest` and call `enrich_sbom` |
+| Calling `parse_policy` from an implementation module | Build `CognitivePolicyParseRequest` and call `parse_cognitive_policy` |
 | Parsing/rendering SBOMs with direct serializer internals | Use `parse_sbom_json`, `render_sbom`, and `export_sbom` |
 | Running toolbox plugins through CLI wrappers | Use `list_toolbox_plugins`, `run_toolbox_plugin`, or `run_toolbox_all` |
 | Building custom report payloads via internal report modules | Use `render_redteam_report`, `render_behavior_report`, or `export_validation_report` |

--- a/documentation/docs/platform-public-api-integration.md
+++ b/documentation/docs/platform-public-api-integration.md
@@ -87,6 +87,7 @@ Module: `nuguard.redteam.public_api`
 
 Request model:
 - `RedteamRunRequest`
+- `RedteamAuthConfig`, with `RedteamLoginFlowConfig` for login-based authentication
 
 Response models:
 - `RedteamRunResult`
@@ -98,8 +99,12 @@ Entry points:
 
 Note:
 - This public API wraps redteam v1 orchestration. v2 is out of scope for this contract.
-- `RedteamRunRequest.auth_config` uses public `AuthConfig` and also accepts `AppAuthConfig`.
-    Bearer, API-key, basic, login-flow, cookie-file, and no-auth variants remain JSON-serializable.
+- `RedteamRunRequest.auth_config` uses secret-safe public `RedteamAuthConfig` and also accepts
+    internal `AuthConfig` and application `AppAuthConfig` values for compatibility. Bearer,
+    API-key, basic, login-flow, cookie-file, and no-auth variants remain JSON-safe, but ordinary
+    request dumps redact credentials and are diagnostic rather than replayable transport. Resolve
+    platform secret references before constructing the request; runtime values are revealed only
+    when the public wrapper invokes the internal orchestrator.
 
 ### Cognitive policy parsing
 

--- a/nuguard/behavior/analyzer.py
+++ b/nuguard/behavior/analyzer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from nuguard.behavior.alignment import check_alignment
 from nuguard.behavior.intent import extract_intent
@@ -49,6 +49,7 @@ class BehaviorAnalyzer:
         controls: "list[PolicyControl] | None" = None,
         llm_client: "LLMClient | None" = None,
         remediation_llm_client: "LLMClient | None" = None,
+        progress_sink: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self._config = config
         self._sbom = sbom
@@ -57,7 +58,19 @@ class BehaviorAnalyzer:
         self._controls = controls
         self._llm = llm_client
         self._remediation_llm = remediation_llm_client or llm_client
+        self._progress_sink = progress_sink
+        self._scenario_plan_emitted = False
         self._rec_engine = RecommendationEngine()
+
+    def _emit_progress(self, update: dict[str, Any]) -> None:
+        if self._progress_sink is None:
+            return
+        if update.get("kind") == "plan":
+            self._scenario_plan_emitted = True
+        try:
+            self._progress_sink(update)
+        except Exception as exc:  # noqa: BLE001
+            _log.debug("BehaviorAnalyzer progress sink failed: %s", exc)
 
     async def analyze(
         self,
@@ -72,6 +85,7 @@ class BehaviorAnalyzer:
             Complete BehaviorAnalysisResult.
         """
         _log.info("BehaviorAnalyzer.analyze: mode=%s", mode)
+        self._scenario_plan_emitted = False
 
         # Step 1: Extract intent
         intent = await extract_intent(
@@ -79,6 +93,7 @@ class BehaviorAnalyzer:
             sbom=self._sbom,
             llm_client=self._llm,
         ) if self._policy is not None else IntentProfile(app_purpose="AI application")
+        self._emit_progress({"kind": "phase", "phase": "intent"})
 
         # Step 2: Static alignment checks
         static_findings_objs = []
@@ -87,6 +102,15 @@ class BehaviorAnalyzer:
             _log.info("BehaviorAnalyzer.analyze: %d static findings", len(static_findings_objs))
 
         static_findings = [f.model_dump(mode="json") for f in static_findings_objs]
+        self._emit_progress({"kind": "phase", "phase": "alignment"})
+        if static_findings:
+            self._emit_progress(
+                {
+                    "kind": "findings",
+                    "phase": "alignment",
+                    "findings_added": [_finding_progress_view(f) for f in static_findings],
+                }
+            )
 
         # Step 3: Dynamic analysis
         dynamic_findings: list[dict] = []
@@ -102,6 +126,7 @@ class BehaviorAnalyzer:
             if not target_url:
                 _log.warning("BehaviorAnalyzer.analyze: no target URL for dynamic mode")
             else:
+                self._emit_progress({"kind": "phase", "phase": "discovery"})
                 # ----------------------------------------------------------------
                 # v3: scenario prompt cache — skip LLM generation on warm runs
                 # ----------------------------------------------------------------
@@ -250,16 +275,19 @@ class BehaviorAnalyzer:
                 # Discovery happens BEFORE scenario generation so the
                 # discovered user profile (name + IDs) can be injected into
                 # the LLM prompts that generate scenario messages.
-                runner = BehaviorRunner(
-                    config=self._config,
-                    sbom=self._sbom,
-                    sbom_path=self._sbom_path,
-                    policy=self._policy,
-                    intent=intent,
-                    llm_client=self._llm,
-                    judge_cache=judge_cache,
-                    endpoint_explicitly_set=_user_had_explicit_endpoint,
-                )
+                runner_kwargs: dict[str, Any] = {
+                    "config": self._config,
+                    "sbom": self._sbom,
+                    "sbom_path": self._sbom_path,
+                    "policy": self._policy,
+                    "intent": intent,
+                    "llm_client": self._llm,
+                    "judge_cache": judge_cache,
+                    "endpoint_explicitly_set": _user_had_explicit_endpoint,
+                }
+                if self._progress_sink is not None:
+                    runner_kwargs["progress_sink"] = self._emit_progress
+                runner = BehaviorRunner(**runner_kwargs)
                 pre_scan_profile = await runner.discover()
 
                 # ── Optional tool-family reachability probe ──────────────
@@ -338,6 +366,14 @@ class BehaviorAnalyzer:
                 dynamic_findings = run_result.findings
                 coverage = run_result.coverage
                 scenario_results = run_result.scenario_results
+                if dynamic_findings:
+                    self._emit_progress(
+                        {
+                            "kind": "findings",
+                            "phase": "execution",
+                            "findings_added": [_finding_progress_view(f) for f in dynamic_findings],
+                        }
+                    )
 
                 # FP-2: Downgrade BA-008 HITL static findings to LOW when the
                 # corresponding dynamic guardrail probe passed.  A passing probe
@@ -360,6 +396,11 @@ class BehaviorAnalyzer:
                                 sf.get("description", "")
                                 + " [Downgraded: dynamic HITL probe passed, confirming runtime handling.]"
                             )
+
+        if not self._scenario_plan_emitted:
+            self._emit_progress(
+                {"kind": "plan", "scenarios_total": 0, "scenarios_completed": 0}
+            )
 
         # Step 4: Build analysis result
         result = BehaviorAnalysisResult(
@@ -430,6 +471,7 @@ class BehaviorAnalyzer:
         from nuguard.remediation.deviation import enrich_deviation_remediations_async
         from nuguard.remediation.synthesizer import RemediationSynthesizer
 
+        self._emit_progress({"kind": "phase", "phase": "remediation"})
         all_findings = static_findings + dynamic_findings
         result.remediation_plan = await RemediationSynthesizer(
             sbom=self._sbom,
@@ -522,4 +564,15 @@ class BehaviorAnalyzer:
             result.overall_risk_score,
             result.coverage_percentage * 100,
         )
+        self._emit_progress({"kind": "phase", "phase": "result"})
         return result
+
+
+def _finding_progress_view(finding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "finding_id": finding.get("finding_id"),
+        "title": finding.get("title"),
+        "severity": finding.get("severity"),
+        "goal_type": finding.get("goal_type"),
+        "scenario_type": finding.get("scenario_type"),
+    }

--- a/nuguard/behavior/public_api.py
+++ b/nuguard/behavior/public_api.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from nuguard.behavior.models import IntentProfile
     from nuguard.common.llm_client import LLMClient
     from nuguard.models.policy import CognitivePolicy, PolicyControl
+    from nuguard.policy.public_api import CognitivePolicyParseResult
     from nuguard.sbom.models import AiSbomDocument
 
 _log = get_logger(__name__)
@@ -62,10 +63,11 @@ async def analyze_behavior(
     *,
     sbom: "AiSbomDocument | None" = None,
     sbom_path: "Path | None" = None,
-    policy: "CognitivePolicy | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
     controls: "list[PolicyControl] | None" = None,
     llm_client: "LLMClient | None" = None,
     remediation_llm_client: "LLMClient | None" = None,
+    _progress_sink: Callable[[dict[str, Any]], None] | None = None,
 ) -> BehaviorAnalysisResult:
     """Run static+dynamic behavior analysis from a JSON-safe request.
 
@@ -75,15 +77,21 @@ async def analyze_behavior(
     or live/stateful collaborators, not run configuration.
     """
     _log.debug("analyze_behavior: mode=%s", request.mode)
-    analyzer = BehaviorAnalyzer(
-        config=request.config,
-        sbom=sbom,
-        sbom_path=sbom_path,
-        policy=policy,
-        controls=controls,
-        llm_client=llm_client,
-        remediation_llm_client=remediation_llm_client,
-    )
+    from nuguard.policy.public_api import normalize_cognitive_policy  # noqa: PLC0415
+
+    normalized_policy = normalize_cognitive_policy(policy)
+    analyzer_kwargs: dict[str, Any] = {
+        "config": request.config,
+        "sbom": sbom,
+        "sbom_path": sbom_path,
+        "policy": normalized_policy,
+        "controls": controls,
+        "llm_client": llm_client,
+        "remediation_llm_client": remediation_llm_client,
+    }
+    if _progress_sink is not None:
+        analyzer_kwargs["progress_sink"] = _progress_sink
+    analyzer = BehaviorAnalyzer(**analyzer_kwargs)
     return await analyzer.analyze(mode=request.mode)
 
 
@@ -127,7 +135,7 @@ async def run_behavior_scenarios(
     *,
     sbom: "AiSbomDocument | None" = None,
     sbom_path: "Path | None" = None,
-    policy: "CognitivePolicy | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
     intent: "IntentProfile | None" = None,
     llm_client: "LLMClient | None" = None,
     remediation_llm_client: "LLMClient | None" = None,
@@ -145,11 +153,14 @@ async def run_behavior_scenarios(
     never raises, and simply leaves ``remediation_plan`` empty on failure.
     """
     _log.debug("run_behavior_scenarios: %d scenario(s)", len(request.scenarios))
+    from nuguard.policy.public_api import normalize_cognitive_policy  # noqa: PLC0415
+
+    normalized_policy = normalize_cognitive_policy(policy)
     runner_kwargs: dict[str, Any] = {
         "config": request.config,
         "sbom": sbom,
         "sbom_path": sbom_path,
-        "policy": policy,
+        "policy": normalized_policy,
         "intent": intent,
         "llm_client": llm_client,
         "judge_cache": judge_cache,
@@ -159,7 +170,10 @@ async def run_behavior_scenarios(
     runner = BehaviorRunner(**runner_kwargs)
     result = await runner.run(request.scenarios, pre_scan_profile=request.pre_scan_profile)
     result.remediation_plan = await _synthesize_behavior_remediation_plan(
-        result.findings, sbom=sbom, policy=policy, llm_client=remediation_llm_client or llm_client
+        result.findings,
+        sbom=sbom,
+        policy=normalized_policy,
+        llm_client=remediation_llm_client or llm_client,
     )
     backfill_finding_remediation(result.findings, result.remediation_plan)
     return result
@@ -170,7 +184,7 @@ async def discover_behavior_profile(
     *,
     sbom: "AiSbomDocument | None" = None,
     sbom_path: "Path | None" = None,
-    policy: "CognitivePolicy | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
     intent: "IntentProfile | None" = None,
     llm_client: "LLMClient | None" = None,
 ) -> DiscoveredProfile | None:
@@ -178,8 +192,15 @@ async def discover_behavior_profile(
 
     Thin wrapper around ``BehaviorRunner(...).discover()``.
     """
+    from nuguard.policy.public_api import normalize_cognitive_policy  # noqa: PLC0415
+
     runner = BehaviorRunner(
-        config=config, sbom=sbom, sbom_path=sbom_path, policy=policy, intent=intent, llm_client=llm_client,
+        config=config,
+        sbom=sbom,
+        sbom_path=sbom_path,
+        policy=normalize_cognitive_policy(policy),
+        intent=intent,
+        llm_client=llm_client,
     )
     return await runner.discover()
 
@@ -192,6 +213,63 @@ def _stream_finding_view(f: dict[str, Any]) -> dict[str, Any]:
         "goal_type": f.get("goal_type"),
         "scenario_type": f.get("scenario_type"),
     }
+
+
+def _publish_behavior_progress(controller: Any, update: dict[str, Any]) -> None:
+    kind = update.get("kind")
+    phase = str(update.get("phase") or "execution")
+    total = int(update.get("scenarios_total") or 0)
+    completed = int(update.get("scenarios_completed") or 0)
+    payload = {
+        "scenarios_total": total,
+        "scenarios_completed": completed,
+        "progress_pct": completed / total if total else 0.0,
+        "current_scenario_type": update.get("scenario_type"),
+        "scenario_id": update.get("scenario_id"),
+        "scenario_title": update.get("scenario_title"),
+        "scenario_status": update.get("scenario_status"),
+    }
+    if kind == "plan":
+        controller.publish(
+            event_type="scenario_plan_ready",
+            phase="planning",
+            payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
+        )
+    elif kind == "scenario_started":
+        controller.publish(
+            event_type="scenario_started",
+            phase="execution",
+            payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
+        )
+    elif kind == "scenario_finished":
+        controller.publish(
+            event_type="scenario_progress",
+            phase="execution",
+            payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
+        )
+        turn_report_added = update.get("turn_report_added") or []
+        if turn_report_added:
+            controller.publish(
+                event_type="findings_delta",
+                phase="execution",
+                payload=StreamDeltaPayload(
+                    turn_report_added=turn_report_added,
+                ).model_dump(mode="json"),
+            )
+    elif kind == "findings":
+        controller.publish(
+            event_type="findings_delta",
+            phase=phase,
+            payload=StreamDeltaPayload(
+                findings_added=update.get("findings_added") or [],
+            ).model_dump(mode="json"),
+        )
+    elif kind == "phase":
+        controller.publish(
+            event_type="scenario_progress",
+            phase=phase,
+            payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
+        )
 
 
 def analyze_behavior_static(result: BehaviorAnalysisResult) -> BehaviorAnalysisResult:
@@ -207,7 +285,7 @@ async def analyze_behavior_stream(
     request: BehaviorRunRequest,
     *,
     sbom: "AiSbomDocument | None" = None,
-    policy: "CognitivePolicy | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
     intent: "IntentProfile | None" = None,
     llm_client: "LLMClient | None" = None,
     remediation_llm_client: "LLMClient | None" = None,
@@ -218,45 +296,7 @@ async def analyze_behavior_stream(
 
     async def _worker(controller):
         def _publish_progress(update: dict[str, Any]) -> None:
-            kind = update.get("kind")
-            total = int(update.get("scenarios_total") or 0)
-            completed = int(update.get("scenarios_completed") or 0)
-            payload = {
-                "scenarios_total": total,
-                "scenarios_completed": completed,
-                "progress_pct": completed / total if total else 0.0,
-                "current_scenario_type": update.get("scenario_type"),
-                "scenario_id": update.get("scenario_id"),
-                "scenario_title": update.get("scenario_title"),
-                "scenario_status": update.get("scenario_status"),
-            }
-            if kind == "plan":
-                controller.publish(
-                    event_type="scenario_plan_ready",
-                    phase="planning",
-                    payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
-                )
-            elif kind == "scenario_started":
-                controller.publish(
-                    event_type="scenario_started",
-                    phase="execution",
-                    payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
-                )
-            elif kind == "scenario_finished":
-                controller.publish(
-                    event_type="scenario_progress",
-                    phase="execution",
-                    payload=StreamProgressPayload.model_validate(payload).model_dump(mode="json"),
-                )
-                turn_report_added = update.get("turn_report_added") or []
-                if turn_report_added:
-                    controller.publish(
-                        event_type="findings_delta",
-                        phase="execution",
-                        payload=StreamDeltaPayload(
-                            turn_report_added=turn_report_added,
-                        ).model_dump(mode="json"),
-                    )
+            _publish_behavior_progress(controller, update)
 
         controller.publish(
             event_type="run_started",
@@ -294,32 +334,57 @@ async def analyze_behavior_stream(
                 ).model_dump(mode="json"),
             )
             controller.set_final_result(result)
-        except asyncio.CancelledError as exc:
-            controller.publish_terminal(
-                event_type="failed",
-                phase="finalize",
-                payload=StreamTerminalPayload(
-                    status="failed",
-                    failure_stage="cancelled",
-                    error_type=type(exc).__name__,
-                    error_message="Behavior stream cancelled",
-                ).model_dump(mode="json"),
-            )
-            controller.set_final_exception(exc)
+        except asyncio.CancelledError:
             raise
-        except Exception as exc:  # noqa: BLE001
-            controller.publish_terminal(
-                event_type="failed",
-                phase="finalize",
-                payload=StreamTerminalPayload(
-                    status="failed",
-                    summary={},
-                    is_retryable=False,
-                    failure_stage="run_behavior_scenarios",
-                    error_type=type(exc).__name__,
-                    error_message=str(exc),
-                ).model_dump(mode="json"),
-            )
-            controller.set_final_exception(exc)
 
     return create_stream_handle(run_id, _worker)
+
+
+async def analyze_behavior_analysis_stream(
+    request: BehaviorAnalysisRequest,
+    *,
+    sbom: "AiSbomDocument | None" = None,
+    sbom_path: "Path | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
+    controls: "list[PolicyControl] | None" = None,
+    llm_client: "LLMClient | None" = None,
+    remediation_llm_client: "LLMClient | None" = None,
+) -> StreamRunHandle[BehaviorAnalysisResult]:
+    """Run the complete behavior-analysis lifecycle with typed progress events."""
+    run_id = str(uuid.uuid4())
+
+    async def _worker(controller: Any) -> None:
+        controller.publish(
+            event_type="run_started",
+            phase="init",
+            payload={"mode": request.mode},
+        )
+
+        def _publish_progress(update: dict[str, Any]) -> None:
+            _publish_behavior_progress(controller, update)
+
+        result = await analyze_behavior(
+            request,
+            sbom=sbom,
+            sbom_path=sbom_path,
+            policy=policy,
+            controls=controls,
+            llm_client=llm_client,
+            remediation_llm_client=remediation_llm_client,
+            _progress_sink=_publish_progress,
+        )
+        controller.publish_terminal(
+            event_type="completed",
+            phase="finalize",
+            payload=StreamTerminalPayload(
+                status="completed",
+                summary={
+                    "scan_outcome": result.scan_outcome,
+                    "findings_count": len(result.static_findings) + len(result.dynamic_findings),
+                    "scenarios_executed": len(result.scenario_results),
+                },
+            ).model_dump(mode="json"),
+        )
+        controller.set_final_result(result)
+
+    return create_stream_handle(run_id, _worker, heartbeat_interval=15.0)

--- a/nuguard/cli/commands/redteam.py
+++ b/nuguard/cli/commands/redteam.py
@@ -812,9 +812,11 @@ async def _run_orchestrator(  # noqa: C901
     mode: str = "concurrent",
     progressive_halt_on_severity: str = "none",
 ) -> "tuple[list, list, str, list[str], Any, int, int, Any, Any, str, str, list]":
+    from pydantic import SecretStr
+
     from nuguard.common.llm_client import LLMClient
     from nuguard.redteam.persona import EVAL_EXPERT_SYSTEM_PROMPT, REDTEAM_EXPERT_SYSTEM_PROMPT
-    from nuguard.redteam.public_api import RedteamRunRequest, run_redteam
+    from nuguard.redteam.public_api import RedteamAuthConfig, RedteamRunRequest, run_redteam
 
     redteam_llm: LLMClient | None = None
     if redteam_llm_model:
@@ -848,14 +850,26 @@ async def _run_orchestrator(  # noqa: C901
         guided_mutation_mode=guided_mutation_mode,
         tree_breadth=tree_breadth,
         tree_max_depth=tree_max_depth,
-        extra_headers=extra_headers,
+        extra_headers=(
+            {name: SecretStr(value) for name, value in extra_headers.items()}
+            if extra_headers
+            else None
+        ),
         strict_outcome=strict_outcome,
         scenario_filter=scenario_filter,
         canary_config=canary_config,  # type: ignore[arg-type]
-        auth_config=auth_config,
+        auth_config=(
+            RedteamAuthConfig.model_validate(auth_config.model_dump())
+            if auth_config
+            else None
+        ),
         finding_triggers=finding_triggers,
         verbose=verbose,
-        credentials=credentials,
+        credentials=(
+            {name: SecretStr(value) for name, value in credentials.items()}
+            if credentials
+            else None
+        ),
         scenario_timeout=scenario_timeout,
         turn_delay_seconds=turn_delay_seconds,
         scenario_delay_seconds=scenario_delay_seconds,

--- a/nuguard/common/stream_runtime.py
+++ b/nuguard/common/stream_runtime.py
@@ -11,6 +11,18 @@ from nuguard.common.streaming_models import StreamEvent
 T = TypeVar("T")
 
 
+class StreamExecutionError(RuntimeError):
+    """Sanitized public error raised when a stream worker fails."""
+
+    def __init__(self, error_code: str, message: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class StreamCancelledError(asyncio.CancelledError):
+    """Sanitized cancellation error preserving CancelledError compatibility."""
+
+
 @dataclass
 class _StreamController:
     run_id: str
@@ -85,6 +97,10 @@ class _StreamController:
         if not self._final_result.done():
             self._final_result.set_exception(exc)
 
+    @property
+    def final_result_settled(self) -> bool:
+        return self._final_result.done()
+
     async def final_result(self) -> Any:
         return await self._final_result
 
@@ -119,8 +135,78 @@ class StreamRunHandle(Generic[T]):
 def create_stream_handle(
     run_id: str,
     task_coro: Callable[[_StreamController], Coroutine[Any, Any, None]],
+    *,
+    heartbeat_interval: float | None = None,
 ) -> StreamRunHandle[Any]:
     """Create a stream controller and schedule the worker coroutine."""
     controller = _StreamController(run_id=run_id)
-    task = asyncio.create_task(task_coro(controller))
+
+    async def _heartbeat() -> None:
+        assert heartbeat_interval is not None
+        while True:
+            await asyncio.sleep(heartbeat_interval)
+            controller.publish(event_type="heartbeat", phase="runtime", payload={})
+
+    async def _run() -> None:
+        heartbeat_task = (
+            asyncio.create_task(_heartbeat())
+            if heartbeat_interval is not None and heartbeat_interval > 0
+            else None
+        )
+        try:
+            await task_coro(controller)
+        except asyncio.CancelledError as exc:
+            if not controller.final_result_settled:
+                controller.publish_terminal(
+                    event_type="failed",
+                    phase="finalize",
+                    payload={
+                        "status": "failed",
+                        "failure_stage": "cancelled",
+                        "error_type": "stream_cancelled",
+                        "error_message": "Stream execution cancelled",
+                    },
+                )
+                controller.set_final_exception(StreamCancelledError("Stream execution cancelled"))
+            raise exc
+        except Exception:
+            if not controller.final_result_settled:
+                controller.publish_terminal(
+                    event_type="failed",
+                    phase="finalize",
+                    payload={
+                        "status": "failed",
+                        "failure_stage": "runtime",
+                        "error_type": "stream_execution_failed",
+                        "error_message": "Stream execution failed",
+                    },
+                )
+                controller.set_final_exception(
+                    StreamExecutionError("stream_execution_failed", "Stream execution failed")
+                )
+        finally:
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+
+    task = asyncio.create_task(_run())
+
+    def _settle_unstarted_task(completed_task: asyncio.Task[None]) -> None:
+        if completed_task.cancelled() and not controller.final_result_settled:
+            controller.publish_terminal(
+                event_type="failed",
+                phase="finalize",
+                payload={
+                    "status": "failed",
+                    "failure_stage": "cancelled",
+                    "error_type": "stream_cancelled",
+                    "error_message": "Stream execution cancelled",
+                },
+            )
+            controller.set_final_exception(StreamCancelledError("Stream execution cancelled"))
+
+    task.add_done_callback(_settle_unstarted_task)
     return StreamRunHandle(controller, task)

--- a/nuguard/common/url_sanitization.py
+++ b/nuguard/common/url_sanitization.py
@@ -1,0 +1,80 @@
+"""Utilities for removing credentials from repository URLs and diagnostics."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
+
+_SENSITIVE_QUERY_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth",
+        "authorization",
+        "github_token",
+        "key",
+        "password",
+        "private_token",
+        "secret",
+        "token",
+    }
+)
+_REDACTED = "REDACTED"
+
+
+def sanitize_repository_url(url: str) -> str:
+    """Return *url* without userinfo or sensitive query-parameter values."""
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return _strip_userinfo_fallback(url)
+
+    netloc = parsed.netloc.rsplit("@", 1)[-1]
+    query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    sanitized_query = urlencode(
+        [
+            (key, _REDACTED if key.casefold() in _SENSITIVE_QUERY_KEYS else value)
+            for key, value in query_items
+        ],
+        doseq=True,
+    )
+    return urlunsplit((parsed.scheme, netloc, parsed.path, sanitized_query, parsed.fragment))
+
+
+def redact_repository_url_from_text(text: str, url: str) -> str:
+    """Remove credentials from diagnostics that may contain *url* or its parts."""
+    sanitized_url = sanitize_repository_url(url)
+    redacted = text.replace(url, sanitized_url)
+
+    try:
+        parsed = urlsplit(url)
+        secrets = [parsed.username, parsed.password]
+        secrets.extend(
+            value
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            if key.casefold() in _SENSITIVE_QUERY_KEYS
+        )
+    except ValueError:
+        secrets = []
+
+    for secret in filter(None, secrets):
+        for candidate in {secret, quote(secret, safe=""), unquote(secret)}:
+            if candidate:
+                redacted = redacted.replace(candidate, _REDACTED)
+    return redacted
+
+
+def _strip_userinfo_fallback(url: str) -> str:
+    scheme_separator = url.find("://")
+    if scheme_separator < 0:
+        return url
+    authority_start = scheme_separator + 3
+    authority_end = len(url)
+    for separator in ("/", "?", "#"):
+        index = url.find(separator, authority_start)
+        if index >= 0:
+            authority_end = min(authority_end, index)
+    authority = url[authority_start:authority_end]
+    if "@" not in authority:
+        return url
+    return url[:authority_start] + authority.rsplit("@", 1)[-1] + url[authority_end:]

--- a/nuguard/policy/__init__.py
+++ b/nuguard/policy/__init__.py
@@ -38,6 +38,12 @@ from nuguard.models.policy import (
     PolicyAssessmentResult,
 )
 from nuguard.policy.parser import parse_policy
+from nuguard.policy.public_api import (
+    CognitivePolicyParseDetail,
+    CognitivePolicyParseRequest,
+    CognitivePolicyParseResult,
+    parse_cognitive_policy,
+)
 from nuguard.policy.validator import LintIssue, lint_policy
 
 
@@ -77,10 +83,14 @@ __all__ = [
     "PolicyGap",
     "PolicyControl",
     "PolicyCheckResult",
+    "CognitivePolicyParseDetail",
+    "CognitivePolicyParseRequest",
+    "CognitivePolicyParseResult",
     # Functions
     "build_aibom_snapshot",
     "check_policy_against_sbom",
     "lint_policy",
     "parse_policy",
+    "parse_cognitive_policy",
     "run_compliance_assessment",
 ]

--- a/nuguard/policy/public_api.py
+++ b/nuguard/policy/public_api.py
@@ -1,0 +1,63 @@
+"""Public Pydantic contracts for parsing cognitive-policy Markdown."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from nuguard.models.policy import CognitivePolicy
+from nuguard.policy.parser import parse_policy
+
+
+class CognitivePolicyParseRequest(BaseModel):
+    """JSON-safe cognitive-policy Markdown input."""
+
+    markdown: str
+
+
+class CognitivePolicyParseDetail(BaseModel):
+    """Stable sanitized parser diagnostic."""
+
+    code: str
+    message: str
+    severity: Literal["error", "warning"]
+
+
+class CognitivePolicyParseResult(BaseModel):
+    """Validated policy and stable parser diagnostics."""
+
+    success: bool
+    policy: CognitivePolicy | None = None
+    errors: list[CognitivePolicyParseDetail] = Field(default_factory=list)
+    warnings: list[CognitivePolicyParseDetail] = Field(default_factory=list)
+
+
+def parse_cognitive_policy(request: CognitivePolicyParseRequest) -> CognitivePolicyParseResult:
+    """Parse Markdown without exposing source text through validation details."""
+    try:
+        policy = parse_policy(request.markdown)
+    except ValidationError:
+        detail = CognitivePolicyParseDetail(
+            code="policy_validation_failed",
+            message="The parsed cognitive policy is invalid",
+            severity="error",
+        )
+        return CognitivePolicyParseResult(success=False, errors=[detail])
+    except Exception:  # noqa: BLE001
+        detail = CognitivePolicyParseDetail(
+            code="policy_parse_failed",
+            message="The cognitive policy could not be parsed",
+            severity="error",
+        )
+        return CognitivePolicyParseResult(success=False, errors=[detail])
+    return CognitivePolicyParseResult(success=True, policy=policy)
+
+
+def normalize_cognitive_policy(value: Any) -> Any:
+    """Unwrap a public parse result while preserving existing collaborators."""
+    if isinstance(value, CognitivePolicyParseResult):
+        if value.success and value.policy is not None:
+            return value.policy
+        raise ValueError("Cognitive policy parsing did not produce a valid policy")
+    return value

--- a/nuguard/redteam/public_api.py
+++ b/nuguard/redteam/public_api.py
@@ -1,6 +1,8 @@
 """Pydantic-only public entry point for the redteam package (v1 engine only).
 
 A thin async wrapper around :class:`RedteamOrchestrator` for callers outside
+    except asyncio.CancelledError:
+        raise
 the CLI: a plain, JSON-serializable request model in, a JSON-serializable
 result model out. ``RedteamOrchestrator`` itself and its constructor and
 ``run()`` are untouched — everything here is additive. The CLI's
@@ -23,7 +25,7 @@ import dataclasses
 import uuid
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from nuguard.common.auth import AuthConfig
 from nuguard.common.logging import get_logger
@@ -33,7 +35,7 @@ from nuguard.common.streaming_models import (
     StreamProgressPayload,
     StreamTerminalPayload,
 )
-from nuguard.config import RedteamFindingTriggers
+from nuguard.config import AppAuthConfig, RedteamFindingTriggers
 from nuguard.models.finding import Finding
 from nuguard.models.health_report import TargetHealthReport
 from nuguard.models.token_usage import TokenUsage
@@ -50,6 +52,7 @@ if TYPE_CHECKING:
 
     from nuguard.common.llm_client import LLMClient
     from nuguard.models.policy import CognitivePolicy
+    from nuguard.policy.public_api import CognitivePolicyParseResult
     from nuguard.redteam.catalog.coverage import CoverageReport
     from nuguard.redteam.target.log_reader import BufferLogReader, FileLogReader
     from nuguard.sbom.models import AiSbomDocument
@@ -108,6 +111,15 @@ class RedteamRunRequest(BaseModel):
     golden_data: dict[str, Any] | None = None
     suppress_spa_html_auth_bypass: bool = True
     codegen_escalation_enabled: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_public_auth_config(cls, data: Any) -> Any:
+        if isinstance(data, dict) and isinstance(data.get("auth_config"), AppAuthConfig):
+            normalized = dict(data)
+            normalized["auth_config"] = data["auth_config"].model_dump()
+            return normalized
+        return data
     mode: str = "concurrent"
     progressive_halt_on_severity: str = "none"
 
@@ -227,7 +239,7 @@ async def run_redteam(
     *,
     sbom: "AiSbomDocument",
     sbom_path: "Path | None" = None,
-    policy: "CognitivePolicy | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
     policy_controls: "list | None" = None,
     redteam_llm: "LLMClient | None" = None,
     eval_llm: "LLMClient | None" = None,
@@ -247,11 +259,14 @@ async def run_redteam(
     the CLI file untouched by this change).
     """
     _log.debug("run_redteam: target_url=%s profile=%s", request.target_url, request.profile)
+    from nuguard.policy.public_api import normalize_cognitive_policy  # noqa: PLC0415
+
+    normalized_policy = normalize_cognitive_policy(policy)
     orchestrator = RedteamOrchestrator(
         sbom=sbom,
         target_url=request.target_url,
         sbom_path=sbom_path,
-        policy=policy,
+        policy=normalized_policy,
         policy_controls=policy_controls,
         canary_config=request.canary_config,
         profile=request.profile,
@@ -326,7 +341,10 @@ async def run_redteam(
         findings = [f for f in findings if finding_matches_scenario_filter(f, _filters)]
 
     remediation_plan = await _build_remediation_plan(
-        findings, sbom=sbom, policy=policy, llm_client=remediation_llm_client or eval_llm
+        findings,
+        sbom=sbom,
+        policy=normalized_policy,
+        llm_client=remediation_llm_client or eval_llm,
     )
     backfill_finding_remediation(findings, remediation_plan)
 
@@ -377,7 +395,7 @@ async def run_redteam_stream(
     request: RedteamRunRequest,
     *,
     sbom: "AiSbomDocument",
-    policy: "CognitivePolicy | None" = None,
+    policy: "CognitivePolicy | CognitivePolicyParseResult | None" = None,
     policy_controls: "list | None" = None,
     redteam_llm: "LLMClient | None" = None,
     eval_llm: "LLMClient | None" = None,
@@ -473,32 +491,7 @@ async def run_redteam_stream(
                 ).model_dump(mode="json"),
             )
             controller.set_final_result(RedteamExecutionResult.model_validate(result.model_dump(mode="json")))
-        except asyncio.CancelledError as exc:
-            controller.publish_terminal(
-                event_type="failed",
-                phase="finalize",
-                payload=StreamTerminalPayload(
-                    status="failed",
-                    failure_stage="cancelled",
-                    error_type=type(exc).__name__,
-                    error_message="Redteam stream cancelled",
-                ).model_dump(mode="json"),
-            )
-            controller.set_final_exception(exc)
+        except asyncio.CancelledError:
             raise
-        except Exception as exc:  # noqa: BLE001
-            controller.publish_terminal(
-                event_type="failed",
-                phase="finalize",
-                payload=StreamTerminalPayload(
-                    status="failed",
-                    summary={},
-                    is_retryable=False,
-                    failure_stage="run_redteam",
-                    error_type=type(exc).__name__,
-                    error_message=str(exc),
-                ).model_dump(mode="json"),
-            )
-            controller.set_final_exception(exc)
 
     return create_stream_handle(run_id, _worker)

--- a/nuguard/redteam/public_api.py
+++ b/nuguard/redteam/public_api.py
@@ -25,9 +25,9 @@ import dataclasses
 import uuid
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
-from nuguard.common.auth import AuthConfig
+from nuguard.common.auth import AuthConfig, LoginFlowConfig
 from nuguard.common.logging import get_logger
 from nuguard.common.stream_runtime import StreamRunHandle, create_stream_handle
 from nuguard.common.streaming_models import (
@@ -60,6 +60,91 @@ if TYPE_CHECKING:
 _log = get_logger(__name__)
 
 
+def _protect_secret_strings(value: Any) -> Any:
+    if isinstance(value, str):
+        return SecretStr(value)
+    if isinstance(value, dict):
+        return {key: _protect_secret_strings(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_protect_secret_strings(item) for item in value]
+    return value
+
+
+def _reveal_secret_strings(value: Any) -> Any:
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    if isinstance(value, dict):
+        return {key: _reveal_secret_strings(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_reveal_secret_strings(item) for item in value]
+    return value
+
+
+class RedteamLoginFlowConfig(BaseModel):
+    """Secret-safe public login-flow configuration."""
+
+    endpoint: str = "/login"
+    method: Literal["POST", "GET"] = "POST"
+    base_url: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    token_response_key: str = "access_token"
+    token_header: str = "Authorization: Bearer"
+    refresh_on_401: bool = True
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def _protect_payload(cls, value: Any) -> Any:
+        return _protect_secret_strings(value)
+
+    def to_internal(self) -> LoginFlowConfig:
+        """Convert to the runtime model immediately before target access."""
+        return LoginFlowConfig(
+            endpoint=self.endpoint,
+            method=self.method,
+            base_url=self.base_url,
+            payload=_reveal_secret_strings(self.payload),
+            token_response_key=self.token_response_key,
+            token_header=self.token_header,
+            refresh_on_401=self.refresh_on_401,
+        )
+
+
+class RedteamAuthConfig(BaseModel):
+    """Secret-safe public authentication configuration for red-team runs."""
+
+    type: Literal["bearer", "api_key", "basic", "none", "login_flow", "cookie_file"] = "none"
+    header: SecretStr = Field(default_factory=lambda: SecretStr(""))
+    username: SecretStr = Field(default_factory=lambda: SecretStr(""))
+    password: SecretStr = Field(default_factory=lambda: SecretStr(""))
+    login_flow: RedteamLoginFlowConfig | None = None
+    cookie_file: str = ""
+
+    @model_validator(mode="after")
+    def _validate_fields(self) -> "RedteamAuthConfig":
+        if self.type in ("bearer", "api_key") and not self.header.get_secret_value():
+            raise ValueError(f"auth.type={self.type} requires auth.header")
+        if self.type == "basic" and not (
+            self.username.get_secret_value() and self.password.get_secret_value()
+        ):
+            raise ValueError("auth.type=basic requires auth.username and auth.password")
+        if self.type == "login_flow" and self.login_flow is None:
+            raise ValueError("auth.type=login_flow requires auth.login_flow block")
+        if self.type == "cookie_file" and not self.cookie_file:
+            raise ValueError("auth.type=cookie_file requires auth.cookie_file")
+        return self
+
+    def to_internal(self) -> AuthConfig:
+        """Convert to the existing runtime model without retaining a plaintext dump."""
+        return AuthConfig(
+            type=self.type,
+            header=self.header.get_secret_value(),
+            username=self.username.get_secret_value(),
+            password=self.password.get_secret_value(),
+            login_flow=self.login_flow.to_internal() if self.login_flow else None,
+            cookie_file=self.cookie_file,
+        )
+
+
 class RedteamRunRequest(BaseModel):
     """JSON-safe input for :func:`run_redteam`.
 
@@ -88,14 +173,14 @@ class RedteamRunRequest(BaseModel):
     guided_mutation_mode: str = "hard"
     tree_breadth: int = 0
     tree_max_depth: int = 0
-    extra_headers: dict[str, str] | None = None
+    extra_headers: dict[str, SecretStr] | None = None
     strict_outcome: bool = False
     scenario_filter: list[str] | None = None
     canary_config: CanaryConfig | None = None
-    auth_config: AuthConfig | None = None
+    auth_config: RedteamAuthConfig | None = None
     finding_triggers: RedteamFindingTriggers | None = None
     verbose: bool = False
-    credentials: dict[str, str] | None = None
+    credentials: dict[str, SecretStr] | None = None
     scenario_timeout: float = 180.0
     turn_delay_seconds: float = 5.0
     scenario_delay_seconds: float = 0.0
@@ -115,7 +200,9 @@ class RedteamRunRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _normalize_public_auth_config(cls, data: Any) -> Any:
-        if isinstance(data, dict) and isinstance(data.get("auth_config"), AppAuthConfig):
+        if isinstance(data, dict) and isinstance(
+            data.get("auth_config"), (AppAuthConfig, AuthConfig)
+        ):
             normalized = dict(data)
             normalized["auth_config"] = data["auth_config"].model_dump()
             return normalized
@@ -288,13 +375,13 @@ async def run_redteam(
         guided_mutation_mode=request.guided_mutation_mode,
         tree_breadth=request.tree_breadth,
         tree_max_depth=request.tree_max_depth,
-        extra_headers=request.extra_headers,
+        extra_headers=_reveal_secret_strings(request.extra_headers),
         strict_outcome=request.strict_outcome,
         scenario_filter=request.scenario_filter,
-        auth_config=request.auth_config,
+        auth_config=request.auth_config.to_internal() if request.auth_config else None,
         finding_triggers=request.finding_triggers,
         verbose=request.verbose,
-        credentials=request.credentials,
+        credentials=_reveal_secret_strings(request.credentials),
         scenario_timeout=request.scenario_timeout,
         turn_delay_seconds=request.turn_delay_seconds,
         scenario_delay_seconds=request.scenario_delay_seconds,

--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -32,8 +32,13 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
+from urllib.parse import urlsplit
 
 from nuguard.common.logging import get_logger
+from nuguard.common.url_sanitization import (
+    redact_repository_url_from_text,
+    sanitize_repository_url,
+)
 
 from ..adapters.base import (
     AdapterMatch,
@@ -2136,8 +2141,9 @@ class AiSbomExtractor:
             for f in (cache / "repo" / app_name).rglob("*.py"):
                 print(f)
         """
-        app_name = url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git") or "repo"
-        display_url = source_ref or url
+        display_url = sanitize_repository_url(source_ref or url)
+        repository_path = urlsplit(display_url).path.rstrip("/")
+        app_name = PurePosixPath(repository_path).name.removesuffix(".git") or "repo"
 
         if cache_dir is not None:
             repo_dir = Path(cache_dir) / "repo" / app_name
@@ -3161,17 +3167,22 @@ class AiSbomExtractor:
         if ref is not None:
             cmd += ["--branch", ref]
         cmd += ["--", url, str(dest)]
-        _log.debug("running: %s", " ".join(cmd))
+        display_url = sanitize_repository_url(url)
+        display_cmd = [display_url if item == url else item for item in cmd]
+        _log.debug("running: %s", " ".join(display_cmd))
         try:
             result = subprocess.run(cmd, check=True, capture_output=True)
+            stderr = result.stderr.decode(errors="replace").strip()[:200] if result.stderr else ""
             _log.debug(
                 "git clone succeeded (stderr: %s)",
-                result.stderr.decode(errors="replace").strip()[:200] or "(none)",
+                redact_repository_url_from_text(stderr, url) or "(none)",
             )
         except subprocess.CalledProcessError as exc:
             stderr = exc.stderr.decode(errors="replace").strip() if exc.stderr else ""
+            stderr = redact_repository_url_from_text(stderr, url)
             raise RuntimeError(
-                f"git clone failed for {url!r} @ {ref!r}" + (f": {stderr}" if stderr else "")
+                f"git clone failed for {display_url!r} @ {ref!r}"
+                + (f": {stderr}" if stderr else "")
             ) from exc
 
     @staticmethod

--- a/nuguard/sbom/generator.py
+++ b/nuguard/sbom/generator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from nuguard.common.url_sanitization import sanitize_repository_url
+
 from .config import AiSbomConfig
 from .extractor import AiSbomExtractor
 from .models import AiSbomDocument
@@ -26,7 +28,12 @@ class SbomGenerator:
 
     def from_repo(self, url: str, ref: str = "main", output: Path | None = None) -> AiSbomDocument:
         """Clone *url* at *ref* and return an AiSbomDocument."""
-        doc = self._extractor.extract_from_repo(url, ref, self.config)
+        doc = self._extractor.extract_from_repo(
+            url,
+            ref,
+            self.config,
+            source_ref=sanitize_repository_url(url),
+        )
         if output is not None:
             from .serializer import AiSbomSerializer
             output.write_text(AiSbomSerializer.to_json(doc), encoding="utf-8")

--- a/nuguard/sbom/public_api.py
+++ b/nuguard/sbom/public_api.py
@@ -1,12 +1,14 @@
 """Public Pydantic APIs for SBOM generation, parsing, rendering, and export."""
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
+from nuguard.common.url_sanitization import sanitize_repository_url
 from nuguard.sbom.config import AiSbomConfig
 from nuguard.sbom.generator import SbomGenerator
 from nuguard.sbom.models import AiSbomDocument
@@ -88,6 +90,117 @@ class SbomExportResult(BaseModel):
     bytes_written: int
 
 
+class SbomEnrichmentLlmConfig(BaseModel):
+    """Optional LLM configuration for SBOM enrichment."""
+
+    enabled: bool = False
+    model: str | None = None
+    api_key: SecretStr | None = None
+    api_base: str | None = None
+
+
+class SbomProbeAuthConfig(BaseModel):
+    """Secret HTTP header used only for bounded target probing."""
+
+    header_name: str
+    header_value: SecretStr
+
+    @field_validator("header_name")
+    @classmethod
+    def _validate_header_name(cls, value: str) -> str:
+        if not value.strip() or ":" in value or "\r" in value or "\n" in value:
+            raise ValueError("header_name must be a valid HTTP header name")
+        return value
+
+
+class SbomEnrichmentRequest(BaseModel):
+    """Validated input for enriching an existing SBOM."""
+
+    sbom: AiSbomDocument
+    target_url: str | None = None
+    llm_config: SbomEnrichmentLlmConfig = Field(default_factory=SbomEnrichmentLlmConfig)
+    probe_auth: SbomProbeAuthConfig | None = None
+    cache_version: str | None = None
+    output_path: str | None = None
+
+
+class SbomEnrichmentResult(BaseModel):
+    """Validated enrichment result without credentials or target responses."""
+
+    sbom: AiSbomDocument
+    enriched: bool
+    confidence_before: float = Field(ge=0.0, le=1.0)
+    confidence_after: float = Field(ge=0.0, le=1.0)
+    reasons: list[str] = Field(default_factory=list)
+    probe_attempted: bool
+    probe_requests: int = Field(ge=0)
+    cache_fingerprint: str
+    artifact_path: str | None = None
+
+
+def _enrichment_cache_fingerprint(request: SbomEnrichmentRequest) -> str:
+    sbom_payload = request.sbom.model_dump(mode="json")
+    sbom_payload["target"] = sanitize_repository_url(request.sbom.target)
+    fingerprint_input = {
+        "sbom": sbom_payload,
+        "target_url": sanitize_repository_url(request.target_url) if request.target_url else None,
+        "llm_enabled": request.llm_config.enabled,
+        "llm_model": request.llm_config.model,
+        "cache_version": request.cache_version,
+    }
+    payload = json.dumps(fingerprint_input, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+async def enrich_sbom(request: SbomEnrichmentRequest) -> SbomEnrichmentResult:
+    """Enrich an existing SBOM without mutating it or writing by default."""
+    from nuguard.common.auto_sbom_enricher import (  # noqa: PLC0415
+        maybe_auto_enrich_sbom,
+    )
+
+    llm_api_key = (
+        request.llm_config.api_key.get_secret_value() if request.llm_config.api_key else None
+    )
+    probe_auth_header = None
+    if request.probe_auth is not None:
+        probe_auth_header = (
+            f"{request.probe_auth.header_name}: "
+            f"{request.probe_auth.header_value.get_secret_value()}"
+        )
+
+    enrichment_input = request.sbom.model_copy(deep=True)
+    enrichment_input.target = sanitize_repository_url(enrichment_input.target)
+    enrichment = await maybe_auto_enrich_sbom(
+        sbom=enrichment_input,
+        sbom_path=None,
+        target_url=request.target_url,
+        llm_enabled=request.llm_config.enabled,
+        llm_model=request.llm_config.model,
+        llm_api_key=llm_api_key,
+        llm_api_base=request.llm_config.api_base,
+        probe_auth_header=probe_auth_header,
+    )
+
+    artifact_path = None
+    if request.output_path is not None:
+        output_path = Path(request.output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(AiSbomSerializer.to_json(enrichment.sbom), encoding="utf-8")
+        artifact_path = str(output_path)
+
+    return SbomEnrichmentResult(
+        sbom=enrichment.sbom,
+        enriched=enrichment.enriched,
+        confidence_before=enrichment.confidence_before,
+        confidence_after=enrichment.confidence_after,
+        reasons=enrichment.reasons,
+        probe_attempted=enrichment.probe_attempted,
+        probe_requests=enrichment.probe_requests,
+        cache_fingerprint=_enrichment_cache_fingerprint(request),
+        artifact_path=artifact_path,
+    )
+
+
 def _render_markdown(sbom: "AiSbomDocument") -> str:
     from nuguard.sbom.toolbox.plugins.markdown_exporter import (  # noqa: PLC0415
         MarkdownExporterPlugin,
@@ -109,7 +222,7 @@ async def generate_sbom(request: SbomGenerateRequest) -> SbomGenerateResult:
     else:
         assert request.repo_url is not None
         doc = generator.from_repo(request.repo_url, ref=request.repo_ref)
-        source_ref = request.repo_url
+        source_ref = sanitize_repository_url(request.repo_url)
 
     return SbomGenerateResult(
         sbom=doc,

--- a/tests/behavior/test_public_api.py
+++ b/tests/behavior/test_public_api.py
@@ -17,22 +17,24 @@ from pydantic import ValidationError
 
 from nuguard.behavior.models import (
     BehaviorAnalysisResult,
-    IntentProfile,
     BehaviorRunResult,
     BehaviorScenario,
     BehaviorScenarioType,
+    IntentProfile,
 )
 from nuguard.behavior.public_api import (
     BehaviorAnalysisRequest,
     BehaviorRunRequest,
+    analyze_behavior,
     analyze_behavior_static,
     analyze_behavior_stream,
-    analyze_behavior,
     discover_behavior_profile,
     run_behavior_scenarios,
 )
 from nuguard.common.discovery import DiscoveredProfile
 from nuguard.config import BehaviorConfig
+from nuguard.models.policy import CognitivePolicy
+from nuguard.policy import CognitivePolicyParseResult
 
 
 def _scenario(name: str = "s1") -> BehaviorScenario:
@@ -93,10 +95,12 @@ def test_behavior_run_request_pre_scan_profile_defaults_none():
 
 @pytest.mark.asyncio
 async def test_analyze_behavior_constructs_analyzer_and_forwards_mode():
+    """The analyzer receives the policy model unwrapped from a public parse result."""
     sentinel_result = MagicMock(spec=BehaviorAnalysisResult)
     config = BehaviorConfig(target="http://localhost:9999")
     sbom = MagicMock()
-    policy = MagicMock()
+    policy = CognitivePolicy(allowed_topics=["Support"])
+    parsed_policy = CognitivePolicyParseResult(success=True, policy=policy)
     controls = [MagicMock()]
     llm_client = MagicMock()
 
@@ -106,7 +110,11 @@ async def test_analyze_behavior_constructs_analyzer_and_forwards_mode():
 
         request = BehaviorAnalysisRequest(config=config, mode="dynamic")
         result = await analyze_behavior(
-            request, sbom=sbom, policy=policy, controls=controls, llm_client=llm_client
+            request,
+            sbom=sbom,
+            policy=parsed_policy,
+            controls=controls,
+            llm_client=llm_client,
         )
 
     mock_cls.assert_called_once_with(
@@ -148,7 +156,8 @@ async def test_run_behavior_scenarios_constructs_runner_and_forwards_args():
     scenarios = [_scenario("a")]
     profile = DiscoveredProfile(customer_name="Bob", source="config")
     sbom = MagicMock()
-    policy = MagicMock()
+    policy = CognitivePolicy(allowed_topics=["Support"])
+    parsed_policy = CognitivePolicyParseResult(success=True, policy=policy)
     intent = MagicMock()
     llm_client = MagicMock()
     judge_cache = MagicMock()
@@ -161,7 +170,7 @@ async def test_run_behavior_scenarios_constructs_runner_and_forwards_args():
         result = await run_behavior_scenarios(
             request,
             sbom=sbom,
-            policy=policy,
+            policy=parsed_policy,
             intent=intent,
             llm_client=llm_client,
             judge_cache=judge_cache,

--- a/tests/behavior/test_public_stream_api.py
+++ b/tests/behavior/test_public_stream_api.py
@@ -12,10 +12,13 @@ from nuguard.behavior.models import (
     IntentProfile,
 )
 from nuguard.behavior.public_api import (
+    BehaviorAnalysisRequest,
     BehaviorRunRequest,
+    analyze_behavior_analysis_stream,
     analyze_behavior_static,
     analyze_behavior_stream,
 )
+from nuguard.common.streaming_models import BehaviorProgressState, apply_event_to_behavior_state
 from nuguard.config import BehaviorConfig
 
 
@@ -107,3 +110,50 @@ async def test_behavior_stream_emits_scenario_events_before_run_completes(monkey
     turn_delta = next(event for event in remaining if event.event_type == "findings_delta")
     assert turn_delta.payload["turn_report_added"] == [{"turn": 1, "verdict": "PASS"}]
     assert (await handle.final_result()).scenarios_executed == 1
+
+
+@pytest.mark.asyncio
+async def test_full_analysis_stream_reuses_analysis_lifecycle_and_reducer(monkeypatch):
+    expected = BehaviorAnalysisResult(
+        intent=IntentProfile(app_purpose="Support"),
+        static_findings=[{"finding_id": "s1", "title": "Static", "severity": "low"}],
+        dynamic_findings=[{"finding_id": "d1", "title": "Dynamic", "severity": "high"}],
+        scan_outcome="high_findings",
+    )
+    calls = 0
+
+    async def _fake_analyze(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        sink = kwargs["_progress_sink"]
+        sink({"kind": "phase", "phase": "intent"})
+        sink({"kind": "findings", "phase": "alignment", "findings_added": [expected.static_findings[0]]})
+        sink({"kind": "plan", "scenarios_total": 0, "scenarios_completed": 0})
+        sink({"kind": "phase", "phase": "remediation"})
+        return expected
+
+    monkeypatch.setattr("nuguard.behavior.public_api.analyze_behavior", _fake_analyze)
+    request = BehaviorAnalysisRequest(
+        config=BehaviorConfig(target="http://localhost:9999"),
+        mode="static+dynamic",
+    )
+    handle = await analyze_behavior_analysis_stream(request)
+    events = [event async for event in handle.events]
+    result = await handle.final_result()
+
+    state = BehaviorProgressState(run_id=events[0].run_id)
+    for event in events:
+        state = apply_event_to_behavior_state(state, event)
+
+    assert calls == 1
+    assert result is expected
+    assert [event.event_type for event in events] == [
+        "run_started",
+        "scenario_progress",
+        "findings_delta",
+        "scenario_plan_ready",
+        "scenario_progress",
+        "completed",
+    ]
+    assert state.findings_count == 1
+    assert state.terminal_status == "completed"

--- a/tests/common/test_stream_runtime.py
+++ b/tests/common/test_stream_runtime.py
@@ -4,7 +4,11 @@ import asyncio
 
 import pytest
 
-from nuguard.common.stream_runtime import create_stream_handle
+from nuguard.common.stream_runtime import (
+    StreamCancelledError,
+    StreamExecutionError,
+    create_stream_handle,
+)
 from nuguard.common.streaming_models import (
     BehaviorProgressState,
     RedteamProgressState,
@@ -55,13 +59,7 @@ async def test_stream_runtime_cancellation_emits_terminal_event_and_settles_resu
         started.set()
         try:
             await asyncio.Event().wait()
-        except asyncio.CancelledError as exc:
-            controller.publish_terminal(
-                event_type="failed",
-                phase="finalize",
-                payload={"status": "failed", "failure_stage": "cancelled"},
-            )
-            controller.set_final_exception(exc)
+        except asyncio.CancelledError:
             raise
 
     handle = create_stream_handle("run-cancel", _worker)
@@ -69,12 +67,74 @@ async def test_stream_runtime_cancellation_emits_terminal_event_and_settles_resu
     handle.cancel()
 
     events = [event async for event in handle.events]
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(StreamCancelledError):
         await handle.final_result()
     await handle.wait_closed()
 
     assert events[-1].event_type == "failed"
     assert events[-1].payload["failure_stage"] == "cancelled"
+    assert events[-1].payload["error_type"] == "stream_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_stream_runtime_immediate_cancellation_settles_result() -> None:
+    async def _worker(controller) -> None:
+        await asyncio.Event().wait()
+
+    handle = create_stream_handle("run-immediate-cancel", _worker)
+    handle.cancel()
+
+    events = [event async for event in handle.events]
+    with pytest.raises(StreamCancelledError):
+        await handle.final_result()
+    await handle.wait_closed()
+
+    assert [event.event_type for event in events] == ["failed"]
+    assert events[0].payload["error_type"] == "stream_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_stream_runtime_emits_opt_in_heartbeats() -> None:
+    release_worker = asyncio.Event()
+
+    async def _worker(controller) -> None:
+        controller.publish(event_type="run_started", phase="init", payload={})
+        await release_worker.wait()
+        controller.publish_terminal(
+            event_type="completed",
+            phase="finalize",
+            payload={"status": "completed"},
+        )
+        controller.set_final_result({"ok": True})
+
+    handle = create_stream_handle("run-heartbeat", _worker, heartbeat_interval=0.001)
+    event_iterator = handle.events
+    assert (await anext(event_iterator)).event_type == "run_started"
+    assert (await anext(event_iterator)).event_type == "heartbeat"
+    release_worker.set()
+    remaining_events = [event async for event in event_iterator]
+
+    assert remaining_events[-1].event_type == "completed"
+    assert await handle.final_result() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_stream_runtime_sanitizes_unhandled_failure() -> None:
+    secret = "secret-target-response"
+
+    async def _worker(controller) -> None:
+        raise ValueError(secret)
+
+    handle = create_stream_handle("run-failure", _worker)
+    events = [event async for event in handle.events]
+
+    with pytest.raises(StreamExecutionError) as exc_info:
+        await handle.final_result()
+    await handle.wait_closed()
+
+    assert secret not in str(exc_info.value)
+    assert secret not in events[-1].model_dump_json()
+    assert events[-1].payload["error_type"] == "stream_execution_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/contracts/public_api.schema.json
+++ b/tests/contracts/public_api.schema.json
@@ -5261,6 +5261,115 @@
     "title": "CognitivePolicyParseResult",
     "type": "object"
   },
+  "redteam.RedteamAuthConfig": {
+    "$defs": {
+      "RedteamLoginFlowConfig": {
+        "description": "Secret-safe public login-flow configuration.",
+        "properties": {
+          "endpoint": {
+            "default": "/login",
+            "title": "Endpoint",
+            "type": "string"
+          },
+          "method": {
+            "default": "POST",
+            "enum": [
+              "POST",
+              "GET"
+            ],
+            "title": "Method",
+            "type": "string"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Base Url"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "token_response_key": {
+            "default": "access_token",
+            "title": "Token Response Key",
+            "type": "string"
+          },
+          "token_header": {
+            "default": "Authorization: Bearer",
+            "title": "Token Header",
+            "type": "string"
+          },
+          "refresh_on_401": {
+            "default": true,
+            "title": "Refresh On 401",
+            "type": "boolean"
+          }
+        },
+        "title": "RedteamLoginFlowConfig",
+        "type": "object"
+      }
+    },
+    "description": "Secret-safe public authentication configuration for red-team runs.",
+    "properties": {
+      "type": {
+        "default": "none",
+        "enum": [
+          "bearer",
+          "api_key",
+          "basic",
+          "none",
+          "login_flow",
+          "cookie_file"
+        ],
+        "title": "Type",
+        "type": "string"
+      },
+      "header": {
+        "format": "password",
+        "title": "Header",
+        "type": "string",
+        "writeOnly": true
+      },
+      "username": {
+        "format": "password",
+        "title": "Username",
+        "type": "string",
+        "writeOnly": true
+      },
+      "password": {
+        "format": "password",
+        "title": "Password",
+        "type": "string",
+        "writeOnly": true
+      },
+      "login_flow": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/RedteamLoginFlowConfig"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "cookie_file": {
+        "default": "",
+        "title": "Cookie File",
+        "type": "string"
+      }
+    },
+    "title": "RedteamAuthConfig",
+    "type": "object"
+  },
   "redteam.RedteamExecutionResult": {
     "$defs": {
       "CredentialCheckResult": {
@@ -6107,59 +6216,61 @@
     "title": "RedteamExecutionResult",
     "type": "object"
   },
-  "redteam.RedteamRunRequest": {
-    "$defs": {
-      "AuthConfig": {
-        "description": "Structured auth configuration parsed from nuguard.yaml auth block.",
-        "properties": {
-          "type": {
-            "default": "none",
-            "enum": [
-              "bearer",
-              "api_key",
-              "basic",
-              "none",
-              "login_flow",
-              "cookie_file"
-            ],
-            "title": "Type",
+  "redteam.RedteamLoginFlowConfig": {
+    "description": "Secret-safe public login-flow configuration.",
+    "properties": {
+      "endpoint": {
+        "default": "/login",
+        "title": "Endpoint",
+        "type": "string"
+      },
+      "method": {
+        "default": "POST",
+        "enum": [
+          "POST",
+          "GET"
+        ],
+        "title": "Method",
+        "type": "string"
+      },
+      "base_url": {
+        "anyOf": [
+          {
             "type": "string"
           },
-          "header": {
-            "default": "",
-            "title": "Header",
-            "type": "string"
-          },
-          "username": {
-            "default": "",
-            "title": "Username",
-            "type": "string"
-          },
-          "password": {
-            "default": "",
-            "title": "Password",
-            "type": "string"
-          },
-          "login_flow": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/LoginFlowConfig"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null
-          },
-          "cookie_file": {
-            "default": "",
-            "title": "Cookie File",
-            "type": "string"
+          {
+            "type": "null"
           }
-        },
-        "title": "AuthConfig",
+        ],
+        "default": null,
+        "title": "Base Url"
+      },
+      "payload": {
+        "additionalProperties": true,
+        "title": "Payload",
         "type": "object"
       },
+      "token_response_key": {
+        "default": "access_token",
+        "title": "Token Response Key",
+        "type": "string"
+      },
+      "token_header": {
+        "default": "Authorization: Bearer",
+        "title": "Token Header",
+        "type": "string"
+      },
+      "refresh_on_401": {
+        "default": true,
+        "title": "Refresh On 401",
+        "type": "boolean"
+      }
+    },
+    "title": "RedteamLoginFlowConfig",
+    "type": "object"
+  },
+  "redteam.RedteamRunRequest": {
+    "$defs": {
       "CanaryConfig": {
         "properties": {
           "global_watch_values": {
@@ -6235,8 +6346,94 @@
         "title": "CanaryTenant",
         "type": "object"
       },
-      "LoginFlowConfig": {
-        "description": "Configuration for apps that require a login request to obtain a JWT.\n\nExample nuguard.yaml block::\n\n    auth:\n      type: login_flow\n      login_flow:\n        endpoint: /login\n        payload:\n          username: ${APP_USERNAME}\n          password: ${APP_PASSWORD}\n        token_response_key: access_token\n        token_header: \"Authorization: Bearer\"\n        refresh_on_401: true",
+      "RedteamAuthConfig": {
+        "description": "Secret-safe public authentication configuration for red-team runs.",
+        "properties": {
+          "type": {
+            "default": "none",
+            "enum": [
+              "bearer",
+              "api_key",
+              "basic",
+              "none",
+              "login_flow",
+              "cookie_file"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "header": {
+            "format": "password",
+            "title": "Header",
+            "type": "string",
+            "writeOnly": true
+          },
+          "username": {
+            "format": "password",
+            "title": "Username",
+            "type": "string",
+            "writeOnly": true
+          },
+          "password": {
+            "format": "password",
+            "title": "Password",
+            "type": "string",
+            "writeOnly": true
+          },
+          "login_flow": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RedteamLoginFlowConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "cookie_file": {
+            "default": "",
+            "title": "Cookie File",
+            "type": "string"
+          }
+        },
+        "title": "RedteamAuthConfig",
+        "type": "object"
+      },
+      "RedteamFindingTriggers": {
+        "description": "Configurable controls for when redteam findings are emitted.",
+        "properties": {
+          "canary_hits": {
+            "default": true,
+            "title": "Canary Hits",
+            "type": "boolean"
+          },
+          "policy_violations": {
+            "default": true,
+            "title": "Policy Violations",
+            "type": "boolean"
+          },
+          "critical_success_hits": {
+            "default": true,
+            "title": "Critical Success Hits",
+            "type": "boolean"
+          },
+          "any_inject_success": {
+            "default": false,
+            "title": "Any Inject Success",
+            "type": "boolean"
+          },
+          "tool_trace_hits": {
+            "default": true,
+            "title": "Tool Trace Hits",
+            "type": "boolean"
+          }
+        },
+        "title": "RedteamFindingTriggers",
+        "type": "object"
+      },
+      "RedteamLoginFlowConfig": {
+        "description": "Secret-safe public login-flow configuration.",
         "properties": {
           "endpoint": {
             "default": "/login",
@@ -6285,39 +6482,7 @@
             "type": "boolean"
           }
         },
-        "title": "LoginFlowConfig",
-        "type": "object"
-      },
-      "RedteamFindingTriggers": {
-        "description": "Configurable controls for when redteam findings are emitted.",
-        "properties": {
-          "canary_hits": {
-            "default": true,
-            "title": "Canary Hits",
-            "type": "boolean"
-          },
-          "policy_violations": {
-            "default": true,
-            "title": "Policy Violations",
-            "type": "boolean"
-          },
-          "critical_success_hits": {
-            "default": true,
-            "title": "Critical Success Hits",
-            "type": "boolean"
-          },
-          "any_inject_success": {
-            "default": false,
-            "title": "Any Inject Success",
-            "type": "boolean"
-          },
-          "tool_trace_hits": {
-            "default": true,
-            "title": "Tool Trace Hits",
-            "type": "boolean"
-          }
-        },
-        "title": "RedteamFindingTriggers",
+        "title": "RedteamLoginFlowConfig",
         "type": "object"
       }
     },
@@ -6408,7 +6573,9 @@
         "anyOf": [
           {
             "additionalProperties": {
-              "type": "string"
+              "format": "password",
+              "type": "string",
+              "writeOnly": true
             },
             "type": "object"
           },
@@ -6453,7 +6620,7 @@
       "auth_config": {
         "anyOf": [
           {
-            "$ref": "#/$defs/AuthConfig"
+            "$ref": "#/$defs/RedteamAuthConfig"
           },
           {
             "type": "null"
@@ -6481,7 +6648,9 @@
         "anyOf": [
           {
             "additionalProperties": {
-              "type": "string"
+              "format": "password",
+              "type": "string",
+              "writeOnly": true
             },
             "type": "object"
           },

--- a/tests/contracts/public_api.schema.json
+++ b/tests/contracts/public_api.schema.json
@@ -5061,6 +5061,206 @@
     "title": "ValidationReportMetaModel",
     "type": "object"
   },
+  "policy.CognitivePolicyParseDetail": {
+    "description": "Stable sanitized parser diagnostic.",
+    "properties": {
+      "code": {
+        "title": "Code",
+        "type": "string"
+      },
+      "message": {
+        "title": "Message",
+        "type": "string"
+      },
+      "severity": {
+        "enum": [
+          "error",
+          "warning"
+        ],
+        "title": "Severity",
+        "type": "string"
+      }
+    },
+    "required": [
+      "code",
+      "message",
+      "severity"
+    ],
+    "title": "CognitivePolicyParseDetail",
+    "type": "object"
+  },
+  "policy.CognitivePolicyParseRequest": {
+    "description": "JSON-safe cognitive-policy Markdown input.",
+    "properties": {
+      "markdown": {
+        "title": "Markdown",
+        "type": "string"
+      }
+    },
+    "required": [
+      "markdown"
+    ],
+    "title": "CognitivePolicyParseRequest",
+    "type": "object"
+  },
+  "policy.CognitivePolicyParseResult": {
+    "$defs": {
+      "CognitivePolicy": {
+        "description": "Parsed cognitive policy for an AI application.",
+        "properties": {
+          "allowed_topics": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Topics",
+            "type": "array"
+          },
+          "restricted_topics": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Restricted Topics",
+            "type": "array"
+          },
+          "restricted_actions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Restricted Actions",
+            "type": "array"
+          },
+          "hitl_triggers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Hitl Triggers",
+            "type": "array"
+          },
+          "hitl_tool_conditions": {
+            "description": "Structured tool-scoped HITL conditions parsed from 'tool_name: condition' bullet items in the HITL Triggers section.",
+            "items": {
+              "$ref": "#/$defs/HitlToolCondition"
+            },
+            "title": "Hitl Tool Conditions",
+            "type": "array"
+          },
+          "data_classification": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Data Classification",
+            "type": "array"
+          },
+          "rate_limits": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Rate Limits",
+            "type": "object"
+          },
+          "raw_sections": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": "Unrecognised Markdown sections preserved verbatim",
+            "title": "Raw Sections",
+            "type": "object"
+          }
+        },
+        "title": "CognitivePolicy",
+        "type": "object"
+      },
+      "CognitivePolicyParseDetail": {
+        "description": "Stable sanitized parser diagnostic.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "error",
+              "warning"
+            ],
+            "title": "Severity",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "severity"
+        ],
+        "title": "CognitivePolicyParseDetail",
+        "type": "object"
+      },
+      "HitlToolCondition": {
+        "description": "A tool-scoped HITL condition parsed from a structured bullet item.\n\nSupports the format ``tool_name: condition description`` inside a HITL\nTriggers section, e.g.::\n\n    ## HITL Triggers\n    - Potentially harmful instructions\n    - discount_tool: discount percentage exceeds 10%\n    - payment_tool: transaction amount exceeds $500\n\nThe ``tool_name`` is matched (case-insensitive substring) against the\nnames of tool calls observed at runtime.  The ``condition`` is a\nhuman-readable description used in violation evidence.",
+        "properties": {
+          "tool_name": {
+            "description": "Tool name keyword to match against executed tool calls",
+            "title": "Tool Name",
+            "type": "string"
+          },
+          "condition": {
+            "description": "Human-readable condition that requires HITL approval",
+            "title": "Condition",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool_name",
+          "condition"
+        ],
+        "title": "HitlToolCondition",
+        "type": "object"
+      }
+    },
+    "description": "Validated policy and stable parser diagnostics.",
+    "properties": {
+      "success": {
+        "title": "Success",
+        "type": "boolean"
+      },
+      "policy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/CognitivePolicy"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "errors": {
+        "items": {
+          "$ref": "#/$defs/CognitivePolicyParseDetail"
+        },
+        "title": "Errors",
+        "type": "array"
+      },
+      "warnings": {
+        "items": {
+          "$ref": "#/$defs/CognitivePolicyParseDetail"
+        },
+        "title": "Warnings",
+        "type": "array"
+      }
+    },
+    "required": [
+      "success"
+    ],
+    "title": "CognitivePolicyParseResult",
+    "type": "object"
+  },
   "redteam.RedteamExecutionResult": {
     "$defs": {
       "CredentialCheckResult": {
@@ -7244,6 +7444,6049 @@
       "resolved_chat_path_source"
     ],
     "title": "RedteamRunResult",
+    "type": "object"
+  },
+  "sbom.SbomEnrichmentLlmConfig": {
+    "description": "Optional LLM configuration for SBOM enrichment.",
+    "properties": {
+      "enabled": {
+        "default": false,
+        "title": "Enabled",
+        "type": "boolean"
+      },
+      "model": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Model"
+      },
+      "api_key": {
+        "anyOf": [
+          {
+            "format": "password",
+            "type": "string",
+            "writeOnly": true
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Api Key"
+      },
+      "api_base": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Api Base"
+      }
+    },
+    "title": "SbomEnrichmentLlmConfig",
+    "type": "object"
+  },
+  "sbom.SbomEnrichmentRequest": {
+    "$defs": {
+      "AccessType": {
+        "description": "Access direction on ``ACCESSES`` edges.",
+        "enum": [
+          "read",
+          "write",
+          "readwrite"
+        ],
+        "title": "AccessType",
+        "type": "string"
+      },
+      "AiSbomDocument": {
+        "$id": "https://nuguard.ai/schemas/aibom/1.5.0/aibom.schema.json",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "AI Bill of Materials document produced by NuGuard.\n\nThis is the canonical output format.  Use ``AiSbomSerializer.to_json()``\nto serialise and ``AiSbomDocument.model_validate()`` to parse and validate.",
+        "properties": {
+          "schema_version": {
+            "default": "1.5.0",
+            "description": "AIBOM schema version (semver); bump when format changes",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "generated_at": {
+            "description": "ISO 8601 UTC timestamp when this document was generated",
+            "format": "date-time",
+            "title": "Generated At",
+            "type": "string"
+          },
+          "generator": {
+            "default": "nuguard",
+            "description": "Tool that produced this document",
+            "title": "Generator",
+            "type": "string"
+          },
+          "target": {
+            "description": "Repository URL or local path that was scanned",
+            "title": "Target",
+            "type": "string"
+          },
+          "nodes": {
+            "description": "Detected AI components",
+            "items": {
+              "$ref": "#/$defs/Node"
+            },
+            "title": "Nodes",
+            "type": "array"
+          },
+          "edges": {
+            "description": "Directed relationships between components",
+            "items": {
+              "$ref": "#/$defs/Edge"
+            },
+            "title": "Edges",
+            "type": "array"
+          },
+          "deps": {
+            "description": "Package dependencies from manifests (pyproject.toml, requirements*.txt, package.json, \u2026)",
+            "items": {
+              "$ref": "#/$defs/PackageDep"
+            },
+            "title": "Deps",
+            "type": "array"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ScanSummary"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scan-level metadata: use-case summary, frameworks, modalities, API endpoints, and IaC/deployment context"
+          },
+          "relationship_graph_md": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Markdown section containing a Mermaid flowchart of key component relationships (AGENT \u2192 TOOL \u2192 DATASTORE, guardrail coverage, etc.) plus an LLM-written plain-English narrative. Only populated when enable_llm=True during SBOM generation.",
+            "title": "Relationship Graph Md"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "title": "AiSbomDocument",
+        "type": "object"
+      },
+      "AuthDetail": {
+        "description": "Detailed authentication and authorization posture for a component.",
+        "properties": {
+          "protocols": {
+            "description": "Auth protocols in use, e.g. ['oauth2', 'bearer', 'api_key', 'basic']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Protocols",
+            "type": "array"
+          },
+          "token_expiry_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Token TTL in seconds when detectable",
+            "title": "Token Expiry Seconds"
+          },
+          "mfa_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when MFA is required for access",
+            "title": "Mfa Required"
+          },
+          "credential_rotation_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Rotation policy description, e.g. '90-day', 'on-demand'",
+            "title": "Credential Rotation Policy"
+          },
+          "enforcement_strict": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when auth is enforced on every request with no opt-out",
+            "title": "Enforcement Strict"
+          },
+          "auth_roles": {
+            "description": "Roles or scopes required for access, e.g. ['admin', 'read:users']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Auth Roles",
+            "type": "array"
+          },
+          "jwt_algorithm_restricted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a JWT verification call site pins an explicit expected algorithm (e.g. `algorithms: ['HS256']`); False when a verify call was found with no such restriction, which admits alg-confusion attacks (a forged token can switch the algorithm, e.g. to `none`, and be accepted); None when no verification call site was found.",
+            "title": "Jwt Algorithm Restricted"
+          }
+        },
+        "title": "AuthDetail",
+        "type": "object"
+      },
+      "ComponentType": {
+        "enum": [
+          "AGENT",
+          "GUARDRAIL",
+          "FRAMEWORK",
+          "MODEL",
+          "TOOL",
+          "DATASTORE",
+          "AUTH",
+          "PRIVILEGE",
+          "API_ENDPOINT",
+          "DEPLOYMENT",
+          "PROMPT",
+          "CONTAINER_IMAGE",
+          "IAM",
+          "DEVELOPER_TOOL_CONFIG",
+          "LIFECYCLE_SCRIPT",
+          "GITHUB_WORKFLOW",
+          "MCP_SERVER"
+        ],
+        "title": "ComponentType",
+        "type": "string"
+      },
+      "CorsPolicyDetail": {
+        "description": "CORS configuration extracted from code or IaC.",
+        "properties": {
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Configured allowed origin(s), e.g. '*' or 'https://example.com'",
+            "title": "Origin"
+          },
+          "allow_credentials": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the CORS policy allows credentialed cross-origin requests",
+            "title": "Allow Credentials"
+          },
+          "wildcard_with_credentials": {
+            "default": false,
+            "description": "True when origin is wildcarded AND credentials are allowed \u2014 the dangerous combination",
+            "title": "Wildcard With Credentials",
+            "type": "boolean"
+          }
+        },
+        "title": "CorsPolicyDetail",
+        "type": "object"
+      },
+      "DataHandlingDetail": {
+        "description": "Data retention, backup, anonymization, and consent configuration.",
+        "properties": {
+          "retention_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Data retention period in days",
+            "title": "Retention Days"
+          },
+          "purge_schedule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Schedule or trigger for data purge, e.g. 'weekly', 'on-account-deletion'",
+            "title": "Purge Schedule"
+          },
+          "backup_frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Backup frequency, e.g. 'daily', 'hourly', '7-day-retention'",
+            "title": "Backup Frequency"
+          },
+          "backup_encrypted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when backups are encrypted",
+            "title": "Backup Encrypted"
+          },
+          "anonymization_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Anonymization or pseudonymization technique, e.g. 'tokenization', 'k-anonymity'",
+            "title": "Anonymization Method"
+          },
+          "consent_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when user consent is required before processing data",
+            "title": "Consent Required"
+          },
+          "cross_border_transfer": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when data is transferred across jurisdictional borders",
+            "title": "Cross Border Transfer"
+          }
+        },
+        "title": "DataHandlingDetail",
+        "type": "object"
+      },
+      "Edge": {
+        "description": "A directed relationship between two Nodes.",
+        "properties": {
+          "source": {
+            "description": "ID of the source Node",
+            "format": "uuid",
+            "title": "Source",
+            "type": "string"
+          },
+          "target": {
+            "description": "ID of the target Node",
+            "format": "uuid",
+            "title": "Target",
+            "type": "string"
+          },
+          "relationship_type": {
+            "$ref": "#/$defs/RelationshipType"
+          },
+          "access_type": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AccessType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Access direction on ACCESSES edges: read | write | readwrite"
+          },
+          "derivation": {
+            "default": "hint",
+            "description": "'hint': backed by an adapter-emitted RelationshipHint (explicit code evidence). 'fallback_heuristic': synthesized by structural fallback rules with no direct evidence.",
+            "enum": [
+              "hint",
+              "fallback_heuristic"
+            ],
+            "title": "Derivation",
+            "type": "string"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Set only for fallback_heuristic edges \u2014 a rough strength score for the guess. None for hint edges (evidence-backed, no separate score needed).",
+            "title": "Confidence"
+          }
+        },
+        "required": [
+          "source",
+          "target",
+          "relationship_type"
+        ],
+        "title": "Edge",
+        "type": "object"
+      },
+      "EncryptionDetail": {
+        "description": "Encryption and redaction posture for a component.",
+        "properties": {
+          "in_transit": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when data is encrypted in transit (TLS/SSL)",
+            "title": "In Transit"
+          },
+          "at_rest": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when data is encrypted at rest",
+            "title": "At Rest"
+          },
+          "algorithm": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Encryption algorithm, e.g. 'AES256', 'aws:kms', 'RSA-4096'",
+            "title": "Algorithm"
+          },
+          "tls_min_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Minimum TLS version enforced, e.g. 'TLS1.2', 'TLS1.3'",
+            "title": "Tls Min Version"
+          },
+          "redacted_fields": {
+            "description": "Field names whose values are redacted before logging or storage",
+            "items": {
+              "type": "string"
+            },
+            "title": "Redacted Fields",
+            "type": "array"
+          },
+          "log_redaction_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when sensitive fields are masked/redacted in logs",
+            "title": "Log Redaction Enabled"
+          },
+          "key_management": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Key management service, e.g. 'aws_kms', 'gcp_cmek', 'azure_key_vault', 'hashicorp_vault'",
+            "title": "Key Management"
+          }
+        },
+        "title": "EncryptionDetail",
+        "type": "object"
+      },
+      "Evidence": {
+        "description": "A single piece of detection evidence supporting a Node.",
+        "properties": {
+          "kind": {
+            "description": "Detection method: 'ast', 'regex', 'config', 'iac', 'inferred'",
+            "title": "Kind",
+            "type": "string"
+          },
+          "confidence": {
+            "description": "Evidence-level confidence [0, 1]",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence",
+            "type": "number"
+          },
+          "detail": {
+            "description": "Detection description: '<adapter>: <evidence_kind>' for PROMPT nodes (full content is in metadata.extras.content); '<adapter>: <snippet>' (up to 500 chars) for all other node types.",
+            "title": "Detail",
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/$defs/SourceLocation"
+          }
+        },
+        "required": [
+          "kind",
+          "confidence",
+          "detail",
+          "location"
+        ],
+        "title": "Evidence",
+        "type": "object"
+      },
+      "InstrumentationDetail": {
+        "description": "Observability and monitoring tooling configured for a component or application.",
+        "properties": {
+          "tools": {
+            "description": "Observability tools detected, e.g. ['opentelemetry', 'datadog', 'prometheus', 'sentry']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tools",
+            "type": "array"
+          },
+          "log_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Configured log level, e.g. 'DEBUG', 'INFO', 'WARNING'",
+            "title": "Log Level"
+          },
+          "tracing_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when distributed tracing is configured",
+            "title": "Tracing Enabled"
+          },
+          "metrics_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when metrics collection is configured",
+            "title": "Metrics Enabled"
+          },
+          "sampling_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Trace or log sampling rate [0.0, 1.0] when detectable",
+            "title": "Sampling Rate"
+          }
+        },
+        "title": "InstrumentationDetail",
+        "type": "object"
+      },
+      "Node": {
+        "description": "A detected AI component (agent, model, tool, prompt, datastore, etc.).",
+        "properties": {
+          "id": {
+            "description": "Stable UUID for edge references",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the component",
+            "title": "Name",
+            "type": "string"
+          },
+          "component_type": {
+            "$ref": "#/$defs/ComponentType"
+          },
+          "confidence": {
+            "description": "Extraction confidence [0, 1]",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence",
+            "type": "number"
+          },
+          "metadata": {
+            "$ref": "#/$defs/NodeMetadata"
+          },
+          "evidence": {
+            "description": "Detection evidence supporting this node",
+            "items": {
+              "$ref": "#/$defs/Evidence"
+            },
+            "title": "Evidence",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "component_type",
+          "confidence"
+        ],
+        "title": "Node",
+        "type": "object"
+      },
+      "NodeMetadata": {
+        "description": "Typed + open-ended metadata attached to a Node.",
+        "properties": {
+          "framework": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Agentic framework (e.g. 'langgraph', 'crewai', 'mcp-server')",
+            "title": "Framework"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM / embedding model name if applicable",
+            "title": "Model Name"
+          },
+          "datastore_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Datastore technology, e.g. 'redis', 'postgres', 'pinecone'",
+            "title": "Datastore Type"
+          },
+          "auth_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Authentication mechanism, e.g. 'oauth2', 'bearer', 'api_key', 'jwt'",
+            "title": "Auth Type"
+          },
+          "auth_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Auth provider class name, e.g. 'BearerAuthProvider', 'OAuth2ClientCredentialsProvider'",
+            "title": "Auth Class"
+          },
+          "privilege_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Privilege or permission scope label, e.g. 'db_write', 'filesystem_read'",
+            "title": "Privilege Scope"
+          },
+          "endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "API endpoint address, e.g. '0.0.0.0:8080 (sse)' for MCP or '/chat' for REST",
+            "title": "Endpoint"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "HTTP method, e.g. 'GET', 'POST'",
+            "title": "Method"
+          },
+          "transport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Transport protocol for API/MCP nodes, e.g. 'sse', 'streamable-http', 'stdio'",
+            "title": "Transport"
+          },
+          "server_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Server display name (MCP FastMCP name kwarg, or inferred service name)",
+            "title": "Server Name"
+          },
+          "deployment_target": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cloud or container deployment target, e.g. 'aws', 'gcp', 'kubernetes'",
+            "title": "Deployment Target"
+          },
+          "data_classification": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "PII/PHI classification labels detected in schemas stored in this datastore, e.g. ['PHI', 'PII'].  Null when no classified fields were found.",
+            "title": "Data Classification"
+          },
+          "classified_tables": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "SQL table or Python model names within this datastore that carry PII/PHI fields.",
+            "title": "Classified Tables"
+          },
+          "classified_fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Per-table/-model mapping of sensitive field names to their classification labels, e.g. {'patients': ['name', 'dob'], 'users': ['email', 'password']}.",
+            "title": "Classified Fields"
+          },
+          "image_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Container image name, e.g. 'python'",
+            "title": "Image Name"
+          },
+          "image_tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Image tag, e.g. '3.12-slim'",
+            "title": "Image Tag"
+          },
+          "image_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Image digest, e.g. 'sha256:abc\u2026'",
+            "title": "Image Digest"
+          },
+          "registry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Registry host, e.g. 'docker.io', 'gcr.io'",
+            "title": "Registry"
+          },
+          "base_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Full base image reference, e.g. 'python:3.12-slim'",
+            "title": "Base Image"
+          },
+          "cloud_region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cloud region, e.g. 'us-east-1', 'eastus', 'us-central1'",
+            "title": "Cloud Region"
+          },
+          "availability_zones": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Availability zones configured, e.g. ['us-east-1a', 'us-east-1b']",
+            "title": "Availability Zones"
+          },
+          "secret_store": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Secret management service in use, e.g. 'aws_secrets_manager', 'azure_key_vault', 'gcp_secret_manager', 'hashicorp_vault', 'k8s_secret'",
+            "title": "Secret Store"
+          },
+          "encryption_at_rest": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when encryption-at-rest is explicitly configured in IaC",
+            "title": "Encryption At Rest"
+          },
+          "encryption_key_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "KMS key ARN, Key Vault URI, or CMEK resource reference",
+            "title": "Encryption Key Ref"
+          },
+          "runs_as_root": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the container is configured to run as root (UID 0); False = non-root",
+            "title": "Runs As Root"
+          },
+          "has_health_check": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a HEALTHCHECK instruction (Dockerfile) or liveness/readiness probe (K8s) is present",
+            "title": "Has Health Check"
+          },
+          "has_resource_limits": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when Kubernetes resource limits are defined for the workload container",
+            "title": "Has Resource Limits"
+          },
+          "ha_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "High-availability topology: 'multi-az', 'replicated', or 'single'",
+            "title": "Ha Mode"
+          },
+          "iam_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "IAM entity kind: 'role', 'policy', 'service_account', 'managed_identity', 'role_binding'",
+            "title": "Iam Type"
+          },
+          "principal": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ARN, email, or object ID of the IAM principal",
+            "title": "Principal"
+          },
+          "permissions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Actions or scopes granted by this IAM entity (up to 20 entries)",
+            "title": "Permissions"
+          },
+          "iam_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scope of the IAM binding: 'project', 'subscription', 'cluster', 'namespace', 'resource'",
+            "title": "Iam Scope"
+          },
+          "trust_principals": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Principals trusted to assume this role (AWS trust policy subjects, K8s binding subjects)",
+            "title": "Trust Principals"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Human-readable description of this component. For TOOL nodes: extracted from function docstring; used by the redteam test generator to craft context-authentic parameter injection payloads. For AGENT nodes: extracted from the agent's purpose/role description.",
+            "title": "Description"
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/$defs/ToolParameter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "For TOOL nodes: list of parameters accepted by this tool, extracted from the function signature and docstring. Used by TOOL_ABUSE test scenarios to craft parameter-injection payloads targeting each parameter.",
+            "title": "Parameters"
+          },
+          "injection_risk_score": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "For AGENT nodes: pre-computed injection risk score in [0, 1] set by the graph enricher. Derived from: number of tools with no_auth_required or high_privilege, presence of unguarded paths, reachable PII datastores, and unguarded HITL triggers. Used by ScenarioGenerator to sort generated test scenarios by expected impact.",
+            "title": "Injection Risk Score"
+          },
+          "mcp_server_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "URL of the MCP server this tool belongs to, e.g. 'http://mcp.example.com'",
+            "title": "Mcp Server Url"
+          },
+          "trust_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MCP server trust classification set by the graph enricher: 'trusted' | 'untrusted' | 'n/a'. All external MCP servers are 'untrusted' unless listed in redteam.mcp_trusted_servers in nuguard.yaml.",
+            "title": "Trust Level"
+          },
+          "no_auth_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool or endpoint is invocable without authentication",
+            "title": "No Auth Required"
+          },
+          "high_privilege": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool has access to administrative or cross-tenant resources",
+            "title": "High Privilege"
+          },
+          "sql_injectable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool constructs SQL queries from agent-provided string parameters",
+            "title": "Sql Injectable"
+          },
+          "ssrf_possible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool accepts URL parameters that are fetched server-side (SSRF surface)",
+            "title": "Ssrf Possible"
+          },
+          "accepts_external_url": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool has a URL/endpoint parameter that is passed to an outbound request",
+            "title": "Accepts External Url"
+          },
+          "reads_external_content": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool fetches or reads content from an external source (web, email, GitHub, etc.)",
+            "title": "Reads External Content"
+          },
+          "system_prompt_excerpt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "First 500 characters of the agent's system prompt / instructions / backstory. Used by the red-team scenario generator to craft context-authentic payloads.",
+            "title": "System Prompt Excerpt"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Prompt role, e.g. 'system', 'user'. PROMPT nodes only.",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Full prompt/instructions text. PROMPT nodes only.",
+            "title": "Content"
+          },
+          "char_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Character count of the prompt content. PROMPT nodes only.",
+            "title": "Char Count"
+          },
+          "is_template": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the prompt content contains '{variable}' placeholders. PROMPT nodes only.",
+            "title": "Is Template"
+          },
+          "template_variables": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Template variable names found in the prompt content, e.g. ['user_name']. PROMPT nodes only.",
+            "title": "Template Variables"
+          },
+          "prompt_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Prompt kind set by some adapters, e.g. 'instructions', 'agent_input'. PROMPT nodes only.",
+            "title": "Prompt Type"
+          },
+          "rules_excerpt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Short description of the guardrail's rules, validator class, or blocking logic",
+            "title": "Rules Excerpt"
+          },
+          "blocked_topics": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Topics this guardrail is known to block (extracted by enricher or adapter)",
+            "title": "Blocked Topics"
+          },
+          "blocked_actions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Actions this guardrail is known to block (extracted by enricher or adapter)",
+            "title": "Blocked Actions"
+          },
+          "refusal_style": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How this guardrail normally refuses: 'hard_block', 'redirect', 'warn', etc.",
+            "title": "Refusal Style"
+          },
+          "auth_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this API endpoint requires authentication",
+            "title": "Auth Required"
+          },
+          "auth_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "OAuth2 scope or role required to call this endpoint: 'user' | 'admin' | 'none'",
+            "title": "Auth Scope"
+          },
+          "accepts_user_input": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this endpoint accepts user-controlled input in body or query params",
+            "title": "Accepts User Input"
+          },
+          "returns_sensitive_data": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this endpoint returns PII, PHI, or other sensitive data",
+            "title": "Returns Sensitive Data"
+          },
+          "rate_limited": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when rate limiting is configured for this endpoint",
+            "title": "Rate Limited"
+          },
+          "idor_surface": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this endpoint has user- or tenant-scoped path parameters such as {user_id} or {tenant_id}",
+            "title": "Idor Surface"
+          },
+          "path_params": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Path parameter names extracted from the endpoint URL template, e.g. ['user_id', 'tenant_id']",
+            "title": "Path Params"
+          },
+          "path_param_sources": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maps each entry in path_params to the API_ENDPOINT path that creates the identified resource, e.g. {'id': '/chat/conversations'} for a chat endpoint at '/chat/conversations/:id/messages'",
+            "title": "Path Param Sources"
+          },
+          "request_body_schema": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Pydantic/dataclass field map for the request body: {field_name: type_string}",
+            "title": "Request Body Schema",
+            "type": "object"
+          },
+          "chat_payload_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inferred primary prompt field in the request body (e.g. 'message', 'query')",
+            "title": "Chat Payload Key"
+          },
+          "chat_payload_list": {
+            "default": false,
+            "description": "True when the chat payload key is typed as a list (e.g. list[str])",
+            "title": "Chat Payload List",
+            "type": "boolean"
+          },
+          "response_text_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inferred primary response text field in the response body",
+            "title": "Response Text Key"
+          },
+          "context_payload_fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Non-chat context fields detected in the POST request body schema, mapping field_name \u2192 kind. kind='identity': static per user (user_id, tenant_id, account_id\u2026) \u2014 auto-injected from login response or requires explicit config. kind='session': dynamic per conversation (session_id, thread_id\u2026) \u2014 auto-generated as UUID for the first request per scenario.",
+            "title": "Context Payload Fields"
+          },
+          "pii_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Flat list of general PII field names in this datastore, e.g. ['name', 'email', 'phone', 'address', 'date_of_birth']. Derived from classified_fields by the graph enricher. Financial identifiers (card numbers, bank accounts) belong in pfi_fields.",
+            "title": "Pii Fields"
+          },
+          "phi_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Flat list of PHI field names in this datastore (HIPAA-regulated), e.g. ['diagnosis', 'medication', 'lab_result', 'patient_id']. Derived from classified_fields by the graph enricher.",
+            "title": "Phi Fields"
+          },
+          "pfi_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Flat list of Personal Financial Information field names (PCI-DSS / GLBA), e.g. ['card_number', 'bank_account', 'routing_number', 'cvv', 'ssn', 'tax_id', 'account_balance', 'iban', 'swift_code']. Derived from classified_fields by the graph enricher.",
+            "title": "Pfi Fields"
+          },
+          "access_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Datastore access mode inferred from ACCESSES edge: 'read' | 'write' | 'readwrite'",
+            "title": "Access Type"
+          },
+          "descriptive_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM-generated human-readable label, e.g. 'User Authentication API'",
+            "title": "Descriptive Name"
+          },
+          "security_headers_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SecurityHeaderDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "HTTP security-header posture extracted from code or IaC"
+          },
+          "cors_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/CorsPolicyDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "CORS configuration extracted from code or IaC"
+          },
+          "debug_error_leak": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the app runs in a debug/verbose-error mode that leaks stack traces",
+            "title": "Debug Error Leak"
+          },
+          "rate_limit_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RateLimitDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Structured rate limit configuration extracted from code or IaC"
+          },
+          "auth_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AuthDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Detailed authentication and authorization posture"
+          },
+          "encryption_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/EncryptionDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Encryption and redaction posture; supersedes encryption_at_rest for new consumers"
+          },
+          "data_handling": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/DataHandlingDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Data retention, backup, anonymization, and consent configuration"
+          },
+          "dependency_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package names from the manifest that appear in this component's source files",
+            "title": "Dependency Names"
+          },
+          "instrumentation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InstrumentationDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Observability and monitoring tooling detected for this component"
+          },
+          "testing": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TestingDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Test coverage and CI/CD posture for this component"
+          },
+          "loc": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total lines of source code across the files where this component is defined",
+            "title": "Loc"
+          },
+          "request_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Request body JSON schema for API endpoints, keyed by Pydantic model class name",
+            "title": "Request Schema"
+          },
+          "response_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response body JSON schema for API endpoints, keyed by Pydantic model class name",
+            "title": "Response Schema"
+          },
+          "has_network_policy": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "K8s workload: True when covered by a NetworkPolicy resource in the same namespace",
+            "title": "Has Network Policy"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model artifact origin URL (HuggingFace repo, local path, or API base endpoint)",
+            "title": "Source Url"
+          },
+          "integrity_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model artifact SHA-256 or git revision hash for supply-chain verification",
+            "title": "Integrity Hash"
+          },
+          "checksum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model artifact checksum (md5, sha1, sha256) as a hex string",
+            "title": "Checksum"
+          },
+          "tool_config_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "AI-agent or editor config sub-type, e.g. 'claude-settings', 'mcp-config', 'cursor-config', 'vscode-config', 'gemini-config', 'smithery-config'",
+            "title": "Tool Config Type"
+          },
+          "permissions_granted": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Permission patterns granted in this config, e.g. ['Bash(*:*)', 'Read', 'Write']",
+            "title": "Permissions Granted"
+          },
+          "permissions_denied": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Permission patterns denied in this config, e.g. ['Bash(rm:*)']",
+            "title": "Permissions Denied"
+          },
+          "auto_execute": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when auto-run or auto-approve mode is enabled in this config",
+            "title": "Auto Execute"
+          },
+          "permission_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scope at which this config grants permissions: 'repo' | 'user' | 'global'",
+            "title": "Permission Scope"
+          },
+          "file_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Raw file size in bytes of this config file (for SC-017: large file detection)",
+            "title": "File Size Bytes"
+          },
+          "content_entropy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Shannon entropy (bits/byte) of the file content computed at extraction time (for SC-018: high-entropy blob detection). Typical text is ~4\u20135; encrypted/base64 is >6.5.",
+            "title": "Content Entropy"
+          },
+          "script_phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package lifecycle phase this script runs at, e.g. 'postinstall', 'preinstall', 'prepare', 'build-backend', 'publish-hook'",
+            "title": "Script Phase"
+          },
+          "script_body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Lifecycle script body, truncated to 2000 chars",
+            "title": "Script Body"
+          },
+          "invokes_network": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script contains network download commands (curl, wget, fetch, etc.)",
+            "title": "Invokes Network"
+          },
+          "invokes_shell": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script pipes into a shell (| bash, | sh, | node, etc.)",
+            "title": "Invokes Shell"
+          },
+          "downloads_binary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script downloads and executes a binary (Bun, node, etc.)",
+            "title": "Downloads Binary"
+          },
+          "references_credentials": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script references credential paths or env vars: /proc/*/environ, .npmrc, AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN, etc.",
+            "title": "References Credentials"
+          },
+          "workflow_has_unpinned_global_install": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when any step in this workflow runs an unpinned global npm install or npx",
+            "title": "Workflow Has Unpinned Global Install"
+          },
+          "workflow_has_cred_access": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when any step in this workflow accesses credential paths or env vars",
+            "title": "Workflow Has Cred Access"
+          },
+          "workflow_triggers": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "GitHub Actions trigger event names parsed from the 'on:' block",
+            "title": "Workflow Triggers"
+          },
+          "workflow_permissions": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Top-level permissions block, e.g. {'id-token': 'write', 'contents': 'read'}",
+            "title": "Workflow Permissions"
+          },
+          "publishes_to": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Publish targets detected in workflow steps, e.g. ['pypi', 'npm', 'smithery']",
+            "title": "Publishes To"
+          },
+          "uses_oidc": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when any job has permissions.id-token: write (OIDC publishing)",
+            "title": "Uses Oidc"
+          },
+          "action_refs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "All 'uses: owner/action@ref' strings found in this workflow. Unpinned refs (branch or tag, not full SHA) indicate a supply-chain risk.",
+            "title": "Action Refs"
+          },
+          "mcp_server_trusted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this MCP server is explicitly listed as trusted in nuguard.yaml",
+            "title": "Mcp Server Trusted"
+          },
+          "mcp_transport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MCP transport protocol declared in .mcp.json: 'stdio' | 'http' | 'sse'",
+            "title": "Mcp Transport"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "description": "Adapter-specific key/value pairs (provider, model_family, version, \u2026)",
+            "title": "Extras",
+            "type": "object"
+          }
+        },
+        "title": "NodeMetadata",
+        "type": "object"
+      },
+      "PackageDep": {
+        "description": "A single declared package dependency.",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "version_spec": {
+            "title": "Version Spec",
+            "type": "string"
+          },
+          "purl": {
+            "title": "Purl",
+            "type": "string"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "source_file": {
+            "title": "Source File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "version_spec",
+          "purl",
+          "group",
+          "source_file"
+        ],
+        "title": "PackageDep",
+        "type": "object"
+      },
+      "RateLimitDetail": {
+        "description": "Structured rate limit configuration extracted from code or IaC.",
+        "properties": {
+          "requests_per_minute": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum requests allowed per minute",
+            "title": "Requests Per Minute"
+          },
+          "requests_per_hour": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum requests allowed per hour",
+            "title": "Requests Per Hour"
+          },
+          "requests_per_day": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum requests allowed per day",
+            "title": "Requests Per Day"
+          },
+          "burst_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Burst/concurrency limit above the steady-state rate",
+            "title": "Burst Size"
+          },
+          "window_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Duration of the rate limit window in seconds",
+            "title": "Window Seconds"
+          },
+          "enforcement_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How the rate limit is enforced, e.g. 'decorator', 'middleware', 'api_gateway'",
+            "title": "Enforcement Type"
+          }
+        },
+        "title": "RateLimitDetail",
+        "type": "object"
+      },
+      "RelationshipType": {
+        "enum": [
+          "USES",
+          "CALLS",
+          "ACCESSES",
+          "PROTECTS",
+          "DEPLOYS",
+          "DELEGATES_TO",
+          "CONTAINS"
+        ],
+        "title": "RelationshipType",
+        "type": "string"
+      },
+      "SbomEnrichmentLlmConfig": {
+        "description": "Optional LLM configuration for SBOM enrichment.",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Model"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "format": "password",
+                "type": "string",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Api Key"
+          },
+          "api_base": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Api Base"
+          }
+        },
+        "title": "SbomEnrichmentLlmConfig",
+        "type": "object"
+      },
+      "SbomProbeAuthConfig": {
+        "description": "Secret HTTP header used only for bounded target probing.",
+        "properties": {
+          "header_name": {
+            "title": "Header Name",
+            "type": "string"
+          },
+          "header_value": {
+            "format": "password",
+            "title": "Header Value",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "header_name",
+          "header_value"
+        ],
+        "title": "SbomProbeAuthConfig",
+        "type": "object"
+      },
+      "ScanSummary": {
+        "description": "Deterministic scan-level summary populated on every extraction.",
+        "properties": {
+          "use_case": {
+            "default": "",
+            "description": "Human-readable description of the application's AI use cases",
+            "title": "Use Case",
+            "type": "string"
+          },
+          "frameworks": {
+            "description": "Agentic framework names detected (e.g. ['langgraph', 'crewai'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Frameworks",
+            "type": "array"
+          },
+          "modalities": {
+            "description": "Supported I/O modalities in upper-case (e.g. ['TEXT', 'VOICE'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Modalities",
+            "type": "array"
+          },
+          "modality_support": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "description": "Detailed modality flags, e.g. {'text': true, 'voice': false}",
+            "title": "Modality Support",
+            "type": "object"
+          },
+          "api_endpoints": {
+            "description": "API route paths extracted from source (e.g. ['/chat', '/health'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Api Endpoints",
+            "type": "array"
+          },
+          "deployment_platforms": {
+            "description": "Cloud/CI platforms inferred from IaC files (e.g. ['AWS', 'GCP'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Deployment Platforms",
+            "type": "array"
+          },
+          "regions": {
+            "description": "Cloud regions referenced in IaC/config (e.g. ['us-east-1'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Regions",
+            "type": "array"
+          },
+          "environments": {
+            "description": "Deployment environments inferred from config (e.g. ['prod', 'staging'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Environments",
+            "type": "array"
+          },
+          "deployment_urls": {
+            "description": "Canonical deployment URLs found in IaC/workflow files",
+            "items": {
+              "type": "string"
+            },
+            "title": "Deployment Urls",
+            "type": "array"
+          },
+          "iac_accounts": {
+            "description": "Cloud account IDs / subscription IDs / project IDs found in IaC",
+            "items": {
+              "type": "string"
+            },
+            "title": "Iac Accounts",
+            "type": "array"
+          },
+          "node_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+            "title": "Node Counts",
+            "type": "object"
+          },
+          "secret_stores": {
+            "description": "Deduped secret management services referenced across all IaC files",
+            "items": {
+              "type": "string"
+            },
+            "title": "Secret Stores",
+            "type": "array"
+          },
+          "availability_zones": {
+            "description": "All cloud availability zones referenced in IaC files",
+            "items": {
+              "type": "string"
+            },
+            "title": "Availability Zones",
+            "type": "array"
+          },
+          "encryption_at_rest_coverage": {
+            "default": false,
+            "description": "True when at least one IaC resource has encryption-at-rest configured",
+            "title": "Encryption At Rest Coverage",
+            "type": "boolean"
+          },
+          "security_findings": {
+            "description": "Notable security / resilience findings across IaC and container config, e.g. ['container_runs_as_root', 'missing_health_check', 'no_resource_limits', 'secrets_in_env_vars', 'overly_permissive_iam']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Security Findings",
+            "type": "array"
+          },
+          "iam_principals": {
+            "description": "IAM role ARNs, GCP service account emails, and Azure managed identity names",
+            "items": {
+              "type": "string"
+            },
+            "title": "Iam Principals",
+            "type": "array"
+          },
+          "service_accounts": {
+            "description": "K8s ServiceAccount names and GCP/Azure service account identifiers",
+            "items": {
+              "type": "string"
+            },
+            "title": "Service Accounts",
+            "type": "array"
+          },
+          "iac_security_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM-generated security briefing for practitioners covering deployment posture, IAM configuration, secret management, encryption, HA, and CI/CD risks across all detected IaC and GitHub Actions workflows.",
+            "title": "Iac Security Summary"
+          },
+          "data_classification": {
+            "description": "Union of all data classification labels detected across the repository, e.g. ['PHI', 'PII'].  Empty list when no classified fields are found.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Data Classification",
+            "type": "array"
+          },
+          "classified_tables": {
+            "description": "Names of SQL tables or Python models that contain classified data fields (PII or PHI).  Sorted alphabetically.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Classified Tables",
+            "type": "array"
+          },
+          "startup_commands": {
+            "description": "Startup commands discovered from package.json, Makefile, Procfile, pyproject.toml, or inferred entry points.  Each entry is {command, source, label} where label is 'dev' or 'start'.",
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Startup Commands",
+            "type": "array"
+          },
+          "env_files": {
+            "description": "Relative paths to .env / dotenv files found in the repository.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Env Files",
+            "type": "array"
+          },
+          "env_var_keys": {
+            "description": "Sorted list of environment variable *keys* found across all dotenv files. Values are intentionally omitted from the SBOM.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Env Var Keys",
+            "type": "array"
+          },
+          "local_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inferred local dev URL (e.g. 'http://localhost:8000') derived from PORT env var or startup command hints.  None when not determinable.",
+            "title": "Local Url"
+          },
+          "staging_urls": {
+            "description": "Staging / QA deployment URLs discovered from env files or config.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Staging Urls",
+            "type": "array"
+          },
+          "production_urls": {
+            "description": "Production deployment URLs discovered from env files or config.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Production Urls",
+            "type": "array"
+          },
+          "log_paths": {
+            "description": "Log file paths discovered during scanning (relative to app root).",
+            "items": {
+              "type": "string"
+            },
+            "title": "Log Paths",
+            "type": "array"
+          },
+          "uses_streaming": {
+            "default": false,
+            "description": "True when the application exposes one or more streaming output endpoints (SSE, StreamingResponse, or framework-native streaming such as Google ADK /run_sse).  The behavior step reads this to enable streaming-aware turn execution instead of buffered HTTP requests.",
+            "title": "Uses Streaming",
+            "type": "boolean"
+          },
+          "streaming_endpoints": {
+            "description": "API endpoint paths confirmed to serve streaming output (e.g. ['/run_sse', '/chat/stream']).  Populated from FastAPI StreamingResponse return types, SSE route patterns, ADK /run_sse, and similar source-code evidence.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Streaming Endpoints",
+            "type": "array"
+          },
+          "total_loc": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total lines of source code scanned across all files in the repository",
+            "title": "Total Loc"
+          },
+          "tokens_used_for_enrichment": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total LLM tokens consumed (prompt + completion) during SBOM enrichment",
+            "title": "Tokens Used For Enrichment"
+          },
+          "input_tokens_used": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM prompt tokens consumed during SBOM enrichment",
+            "title": "Input Tokens Used"
+          },
+          "output_tokens_used": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM completion tokens consumed during SBOM enrichment",
+            "title": "Output Tokens Used"
+          },
+          "llm_model_used": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM model string used for SBOM enrichment, e.g. 'gemini/gemini-2.0-flash'",
+            "title": "Llm Model Used"
+          },
+          "instrumentation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InstrumentationDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "App-wide observability and monitoring tooling summary"
+          },
+          "testing": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TestingDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "App-wide testing and CI/CD posture summary"
+          },
+          "github_actions_content": {
+            "default": "",
+            "description": "Raw concatenation of all detected GitHub Actions workflow YAML files, separated by '\n---\n'. Used by NGA-010/011/014 regex rules as a fallback when structured workflow_security_findings are not available.",
+            "title": "Github Actions Content",
+            "type": "string"
+          },
+          "workflow_security_findings": {
+            "description": "Structured security findings emitted by GitHubActionsAdapter during SBOM extraction. Each dict has keys: {rule_signal, path, line, snippet, confidence}.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Workflow Security Findings",
+            "type": "array"
+          },
+          "k8s_network_policy_namespaces": {
+            "description": "Kubernetes namespaces that have at least one NetworkPolicy resource detected. Populated by K8sAdapter. Used by NGA-013 to assert cross-file coverage.",
+            "items": {
+              "type": "string"
+            },
+            "title": "K8S Network Policy Namespaces",
+            "type": "array"
+          },
+          "has_package_json": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a package.json file was found at the repo root during SBOM extraction. Used by supply-chain scanner to check lockfile coverage (SC-024) without requiring a live filesystem.",
+            "title": "Has Package Json"
+          },
+          "has_lockfile": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when at least one npm lockfile (package-lock.json, pnpm-lock.yaml, or yarn.lock) was found at the repo root during SBOM extraction. Used by supply-chain scanner (SC-024) without requiring a live filesystem.",
+            "title": "Has Lockfile"
+          },
+          "minified_js_files": {
+            "description": "Relative paths to JavaScript files that contain a single line exceeding 5000 characters \u2014 a reliable indicator of minified/bundled code. Populated by the extractor during the main JS scanning pass. Used by supply-chain scanner (SC-019) without requiring a live filesystem.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Minified Js Files",
+            "type": "array"
+          }
+        },
+        "title": "ScanSummary",
+        "type": "object"
+      },
+      "SecurityHeaderDetail": {
+        "description": "HTTP security-header posture extracted from code or IaC.",
+        "properties": {
+          "csp": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a Content-Security-Policy header is set",
+            "title": "Csp"
+          },
+          "x_frame_options": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when an X-Frame-Options header is set",
+            "title": "X Frame Options"
+          },
+          "hsts": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a Strict-Transport-Security header is set",
+            "title": "Hsts"
+          },
+          "missing": {
+            "description": "Security headers confirmed absent, e.g. ['csp', 'x_frame_options', 'hsts']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing",
+            "type": "array"
+          }
+        },
+        "title": "SecurityHeaderDetail",
+        "type": "object"
+      },
+      "SourceLocation": {
+        "description": "File/line pointer for a piece of evidence.",
+        "properties": {
+          "path": {
+            "description": "Relative path to the source file",
+            "title": "Path",
+            "type": "string"
+          },
+          "line": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "1-based line number, if known",
+            "title": "Line"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "SourceLocation",
+        "type": "object"
+      },
+      "TestingDetail": {
+        "description": "Testing, validation, and CI/CD posture for a component or application.",
+        "properties": {
+          "has_unit_tests": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when unit test files are detected",
+            "title": "Has Unit Tests"
+          },
+          "has_integration_tests": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when integration test files or suites are detected",
+            "title": "Has Integration Tests"
+          },
+          "test_frameworks": {
+            "description": "Test frameworks detected, e.g. ['pytest', 'jest', 'vitest', 'hypothesis']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Test Frameworks",
+            "type": "array"
+          },
+          "ci_cd_pipeline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "CI/CD platform detected, e.g. 'github_actions', 'gitlab_ci', 'jenkins'",
+            "title": "Ci Cd Pipeline"
+          },
+          "quality_gates": {
+            "description": "Quality gate tools detected, e.g. ['codecov', 'sonarqube', 'snyk']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Quality Gates",
+            "type": "array"
+          },
+          "test_coverage_tool": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Coverage measurement tool detected, e.g. 'coverage.py', 'istanbul'",
+            "title": "Test Coverage Tool"
+          }
+        },
+        "title": "TestingDetail",
+        "type": "object"
+      },
+      "ToolParameter": {
+        "description": "Schema for a single parameter accepted by a TOOL node.\n\nCaptured from function signatures and docstrings by the SBOM extractor.\nUsed by the redteam test generator to craft parameter-injection payloads\nfor TOOL_ABUSE scenarios.",
+        "properties": {
+          "name": {
+            "description": "Parameter name as it appears in the function signature",
+            "title": "Name",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Python/TypeScript type annotation string, e.g. 'str', 'int', 'dict'",
+            "title": "Type"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Parameter description extracted from the function docstring",
+            "title": "Description"
+          },
+          "required": {
+            "default": true,
+            "description": "True when the parameter has no default value",
+            "title": "Required",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ToolParameter",
+        "type": "object"
+      }
+    },
+    "description": "Validated input for enriching an existing SBOM.",
+    "properties": {
+      "sbom": {
+        "$ref": "#/$defs/AiSbomDocument"
+      },
+      "target_url": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Target Url"
+      },
+      "llm_config": {
+        "$ref": "#/$defs/SbomEnrichmentLlmConfig"
+      },
+      "probe_auth": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SbomProbeAuthConfig"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "cache_version": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Cache Version"
+      },
+      "output_path": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Output Path"
+      }
+    },
+    "required": [
+      "sbom"
+    ],
+    "title": "SbomEnrichmentRequest",
+    "type": "object"
+  },
+  "sbom.SbomEnrichmentResult": {
+    "$defs": {
+      "AccessType": {
+        "description": "Access direction on ``ACCESSES`` edges.",
+        "enum": [
+          "read",
+          "write",
+          "readwrite"
+        ],
+        "title": "AccessType",
+        "type": "string"
+      },
+      "AiSbomDocument": {
+        "$id": "https://nuguard.ai/schemas/aibom/1.5.0/aibom.schema.json",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "AI Bill of Materials document produced by NuGuard.\n\nThis is the canonical output format.  Use ``AiSbomSerializer.to_json()``\nto serialise and ``AiSbomDocument.model_validate()`` to parse and validate.",
+        "properties": {
+          "schema_version": {
+            "default": "1.5.0",
+            "description": "AIBOM schema version (semver); bump when format changes",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "generated_at": {
+            "description": "ISO 8601 UTC timestamp when this document was generated",
+            "format": "date-time",
+            "title": "Generated At",
+            "type": "string"
+          },
+          "generator": {
+            "default": "nuguard",
+            "description": "Tool that produced this document",
+            "title": "Generator",
+            "type": "string"
+          },
+          "target": {
+            "description": "Repository URL or local path that was scanned",
+            "title": "Target",
+            "type": "string"
+          },
+          "nodes": {
+            "description": "Detected AI components",
+            "items": {
+              "$ref": "#/$defs/Node"
+            },
+            "title": "Nodes",
+            "type": "array"
+          },
+          "edges": {
+            "description": "Directed relationships between components",
+            "items": {
+              "$ref": "#/$defs/Edge"
+            },
+            "title": "Edges",
+            "type": "array"
+          },
+          "deps": {
+            "description": "Package dependencies from manifests (pyproject.toml, requirements*.txt, package.json, \u2026)",
+            "items": {
+              "$ref": "#/$defs/PackageDep"
+            },
+            "title": "Deps",
+            "type": "array"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ScanSummary"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scan-level metadata: use-case summary, frameworks, modalities, API endpoints, and IaC/deployment context"
+          },
+          "relationship_graph_md": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Markdown section containing a Mermaid flowchart of key component relationships (AGENT \u2192 TOOL \u2192 DATASTORE, guardrail coverage, etc.) plus an LLM-written plain-English narrative. Only populated when enable_llm=True during SBOM generation.",
+            "title": "Relationship Graph Md"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "title": "AiSbomDocument",
+        "type": "object"
+      },
+      "AuthDetail": {
+        "description": "Detailed authentication and authorization posture for a component.",
+        "properties": {
+          "protocols": {
+            "description": "Auth protocols in use, e.g. ['oauth2', 'bearer', 'api_key', 'basic']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Protocols",
+            "type": "array"
+          },
+          "token_expiry_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Token TTL in seconds when detectable",
+            "title": "Token Expiry Seconds"
+          },
+          "mfa_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when MFA is required for access",
+            "title": "Mfa Required"
+          },
+          "credential_rotation_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Rotation policy description, e.g. '90-day', 'on-demand'",
+            "title": "Credential Rotation Policy"
+          },
+          "enforcement_strict": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when auth is enforced on every request with no opt-out",
+            "title": "Enforcement Strict"
+          },
+          "auth_roles": {
+            "description": "Roles or scopes required for access, e.g. ['admin', 'read:users']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Auth Roles",
+            "type": "array"
+          },
+          "jwt_algorithm_restricted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a JWT verification call site pins an explicit expected algorithm (e.g. `algorithms: ['HS256']`); False when a verify call was found with no such restriction, which admits alg-confusion attacks (a forged token can switch the algorithm, e.g. to `none`, and be accepted); None when no verification call site was found.",
+            "title": "Jwt Algorithm Restricted"
+          }
+        },
+        "title": "AuthDetail",
+        "type": "object"
+      },
+      "ComponentType": {
+        "enum": [
+          "AGENT",
+          "GUARDRAIL",
+          "FRAMEWORK",
+          "MODEL",
+          "TOOL",
+          "DATASTORE",
+          "AUTH",
+          "PRIVILEGE",
+          "API_ENDPOINT",
+          "DEPLOYMENT",
+          "PROMPT",
+          "CONTAINER_IMAGE",
+          "IAM",
+          "DEVELOPER_TOOL_CONFIG",
+          "LIFECYCLE_SCRIPT",
+          "GITHUB_WORKFLOW",
+          "MCP_SERVER"
+        ],
+        "title": "ComponentType",
+        "type": "string"
+      },
+      "CorsPolicyDetail": {
+        "description": "CORS configuration extracted from code or IaC.",
+        "properties": {
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Configured allowed origin(s), e.g. '*' or 'https://example.com'",
+            "title": "Origin"
+          },
+          "allow_credentials": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the CORS policy allows credentialed cross-origin requests",
+            "title": "Allow Credentials"
+          },
+          "wildcard_with_credentials": {
+            "default": false,
+            "description": "True when origin is wildcarded AND credentials are allowed \u2014 the dangerous combination",
+            "title": "Wildcard With Credentials",
+            "type": "boolean"
+          }
+        },
+        "title": "CorsPolicyDetail",
+        "type": "object"
+      },
+      "DataHandlingDetail": {
+        "description": "Data retention, backup, anonymization, and consent configuration.",
+        "properties": {
+          "retention_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Data retention period in days",
+            "title": "Retention Days"
+          },
+          "purge_schedule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Schedule or trigger for data purge, e.g. 'weekly', 'on-account-deletion'",
+            "title": "Purge Schedule"
+          },
+          "backup_frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Backup frequency, e.g. 'daily', 'hourly', '7-day-retention'",
+            "title": "Backup Frequency"
+          },
+          "backup_encrypted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when backups are encrypted",
+            "title": "Backup Encrypted"
+          },
+          "anonymization_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Anonymization or pseudonymization technique, e.g. 'tokenization', 'k-anonymity'",
+            "title": "Anonymization Method"
+          },
+          "consent_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when user consent is required before processing data",
+            "title": "Consent Required"
+          },
+          "cross_border_transfer": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when data is transferred across jurisdictional borders",
+            "title": "Cross Border Transfer"
+          }
+        },
+        "title": "DataHandlingDetail",
+        "type": "object"
+      },
+      "Edge": {
+        "description": "A directed relationship between two Nodes.",
+        "properties": {
+          "source": {
+            "description": "ID of the source Node",
+            "format": "uuid",
+            "title": "Source",
+            "type": "string"
+          },
+          "target": {
+            "description": "ID of the target Node",
+            "format": "uuid",
+            "title": "Target",
+            "type": "string"
+          },
+          "relationship_type": {
+            "$ref": "#/$defs/RelationshipType"
+          },
+          "access_type": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AccessType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Access direction on ACCESSES edges: read | write | readwrite"
+          },
+          "derivation": {
+            "default": "hint",
+            "description": "'hint': backed by an adapter-emitted RelationshipHint (explicit code evidence). 'fallback_heuristic': synthesized by structural fallback rules with no direct evidence.",
+            "enum": [
+              "hint",
+              "fallback_heuristic"
+            ],
+            "title": "Derivation",
+            "type": "string"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Set only for fallback_heuristic edges \u2014 a rough strength score for the guess. None for hint edges (evidence-backed, no separate score needed).",
+            "title": "Confidence"
+          }
+        },
+        "required": [
+          "source",
+          "target",
+          "relationship_type"
+        ],
+        "title": "Edge",
+        "type": "object"
+      },
+      "EncryptionDetail": {
+        "description": "Encryption and redaction posture for a component.",
+        "properties": {
+          "in_transit": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when data is encrypted in transit (TLS/SSL)",
+            "title": "In Transit"
+          },
+          "at_rest": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when data is encrypted at rest",
+            "title": "At Rest"
+          },
+          "algorithm": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Encryption algorithm, e.g. 'AES256', 'aws:kms', 'RSA-4096'",
+            "title": "Algorithm"
+          },
+          "tls_min_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Minimum TLS version enforced, e.g. 'TLS1.2', 'TLS1.3'",
+            "title": "Tls Min Version"
+          },
+          "redacted_fields": {
+            "description": "Field names whose values are redacted before logging or storage",
+            "items": {
+              "type": "string"
+            },
+            "title": "Redacted Fields",
+            "type": "array"
+          },
+          "log_redaction_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when sensitive fields are masked/redacted in logs",
+            "title": "Log Redaction Enabled"
+          },
+          "key_management": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Key management service, e.g. 'aws_kms', 'gcp_cmek', 'azure_key_vault', 'hashicorp_vault'",
+            "title": "Key Management"
+          }
+        },
+        "title": "EncryptionDetail",
+        "type": "object"
+      },
+      "Evidence": {
+        "description": "A single piece of detection evidence supporting a Node.",
+        "properties": {
+          "kind": {
+            "description": "Detection method: 'ast', 'regex', 'config', 'iac', 'inferred'",
+            "title": "Kind",
+            "type": "string"
+          },
+          "confidence": {
+            "description": "Evidence-level confidence [0, 1]",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence",
+            "type": "number"
+          },
+          "detail": {
+            "description": "Detection description: '<adapter>: <evidence_kind>' for PROMPT nodes (full content is in metadata.extras.content); '<adapter>: <snippet>' (up to 500 chars) for all other node types.",
+            "title": "Detail",
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/$defs/SourceLocation"
+          }
+        },
+        "required": [
+          "kind",
+          "confidence",
+          "detail",
+          "location"
+        ],
+        "title": "Evidence",
+        "type": "object"
+      },
+      "InstrumentationDetail": {
+        "description": "Observability and monitoring tooling configured for a component or application.",
+        "properties": {
+          "tools": {
+            "description": "Observability tools detected, e.g. ['opentelemetry', 'datadog', 'prometheus', 'sentry']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tools",
+            "type": "array"
+          },
+          "log_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Configured log level, e.g. 'DEBUG', 'INFO', 'WARNING'",
+            "title": "Log Level"
+          },
+          "tracing_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when distributed tracing is configured",
+            "title": "Tracing Enabled"
+          },
+          "metrics_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when metrics collection is configured",
+            "title": "Metrics Enabled"
+          },
+          "sampling_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Trace or log sampling rate [0.0, 1.0] when detectable",
+            "title": "Sampling Rate"
+          }
+        },
+        "title": "InstrumentationDetail",
+        "type": "object"
+      },
+      "Node": {
+        "description": "A detected AI component (agent, model, tool, prompt, datastore, etc.).",
+        "properties": {
+          "id": {
+            "description": "Stable UUID for edge references",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the component",
+            "title": "Name",
+            "type": "string"
+          },
+          "component_type": {
+            "$ref": "#/$defs/ComponentType"
+          },
+          "confidence": {
+            "description": "Extraction confidence [0, 1]",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence",
+            "type": "number"
+          },
+          "metadata": {
+            "$ref": "#/$defs/NodeMetadata"
+          },
+          "evidence": {
+            "description": "Detection evidence supporting this node",
+            "items": {
+              "$ref": "#/$defs/Evidence"
+            },
+            "title": "Evidence",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "component_type",
+          "confidence"
+        ],
+        "title": "Node",
+        "type": "object"
+      },
+      "NodeMetadata": {
+        "description": "Typed + open-ended metadata attached to a Node.",
+        "properties": {
+          "framework": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Agentic framework (e.g. 'langgraph', 'crewai', 'mcp-server')",
+            "title": "Framework"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM / embedding model name if applicable",
+            "title": "Model Name"
+          },
+          "datastore_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Datastore technology, e.g. 'redis', 'postgres', 'pinecone'",
+            "title": "Datastore Type"
+          },
+          "auth_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Authentication mechanism, e.g. 'oauth2', 'bearer', 'api_key', 'jwt'",
+            "title": "Auth Type"
+          },
+          "auth_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Auth provider class name, e.g. 'BearerAuthProvider', 'OAuth2ClientCredentialsProvider'",
+            "title": "Auth Class"
+          },
+          "privilege_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Privilege or permission scope label, e.g. 'db_write', 'filesystem_read'",
+            "title": "Privilege Scope"
+          },
+          "endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "API endpoint address, e.g. '0.0.0.0:8080 (sse)' for MCP or '/chat' for REST",
+            "title": "Endpoint"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "HTTP method, e.g. 'GET', 'POST'",
+            "title": "Method"
+          },
+          "transport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Transport protocol for API/MCP nodes, e.g. 'sse', 'streamable-http', 'stdio'",
+            "title": "Transport"
+          },
+          "server_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Server display name (MCP FastMCP name kwarg, or inferred service name)",
+            "title": "Server Name"
+          },
+          "deployment_target": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cloud or container deployment target, e.g. 'aws', 'gcp', 'kubernetes'",
+            "title": "Deployment Target"
+          },
+          "data_classification": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "PII/PHI classification labels detected in schemas stored in this datastore, e.g. ['PHI', 'PII'].  Null when no classified fields were found.",
+            "title": "Data Classification"
+          },
+          "classified_tables": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "SQL table or Python model names within this datastore that carry PII/PHI fields.",
+            "title": "Classified Tables"
+          },
+          "classified_fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Per-table/-model mapping of sensitive field names to their classification labels, e.g. {'patients': ['name', 'dob'], 'users': ['email', 'password']}.",
+            "title": "Classified Fields"
+          },
+          "image_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Container image name, e.g. 'python'",
+            "title": "Image Name"
+          },
+          "image_tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Image tag, e.g. '3.12-slim'",
+            "title": "Image Tag"
+          },
+          "image_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Image digest, e.g. 'sha256:abc\u2026'",
+            "title": "Image Digest"
+          },
+          "registry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Registry host, e.g. 'docker.io', 'gcr.io'",
+            "title": "Registry"
+          },
+          "base_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Full base image reference, e.g. 'python:3.12-slim'",
+            "title": "Base Image"
+          },
+          "cloud_region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cloud region, e.g. 'us-east-1', 'eastus', 'us-central1'",
+            "title": "Cloud Region"
+          },
+          "availability_zones": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Availability zones configured, e.g. ['us-east-1a', 'us-east-1b']",
+            "title": "Availability Zones"
+          },
+          "secret_store": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Secret management service in use, e.g. 'aws_secrets_manager', 'azure_key_vault', 'gcp_secret_manager', 'hashicorp_vault', 'k8s_secret'",
+            "title": "Secret Store"
+          },
+          "encryption_at_rest": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when encryption-at-rest is explicitly configured in IaC",
+            "title": "Encryption At Rest"
+          },
+          "encryption_key_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "KMS key ARN, Key Vault URI, or CMEK resource reference",
+            "title": "Encryption Key Ref"
+          },
+          "runs_as_root": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the container is configured to run as root (UID 0); False = non-root",
+            "title": "Runs As Root"
+          },
+          "has_health_check": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a HEALTHCHECK instruction (Dockerfile) or liveness/readiness probe (K8s) is present",
+            "title": "Has Health Check"
+          },
+          "has_resource_limits": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when Kubernetes resource limits are defined for the workload container",
+            "title": "Has Resource Limits"
+          },
+          "ha_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "High-availability topology: 'multi-az', 'replicated', or 'single'",
+            "title": "Ha Mode"
+          },
+          "iam_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "IAM entity kind: 'role', 'policy', 'service_account', 'managed_identity', 'role_binding'",
+            "title": "Iam Type"
+          },
+          "principal": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ARN, email, or object ID of the IAM principal",
+            "title": "Principal"
+          },
+          "permissions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Actions or scopes granted by this IAM entity (up to 20 entries)",
+            "title": "Permissions"
+          },
+          "iam_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scope of the IAM binding: 'project', 'subscription', 'cluster', 'namespace', 'resource'",
+            "title": "Iam Scope"
+          },
+          "trust_principals": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Principals trusted to assume this role (AWS trust policy subjects, K8s binding subjects)",
+            "title": "Trust Principals"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Human-readable description of this component. For TOOL nodes: extracted from function docstring; used by the redteam test generator to craft context-authentic parameter injection payloads. For AGENT nodes: extracted from the agent's purpose/role description.",
+            "title": "Description"
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/$defs/ToolParameter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "For TOOL nodes: list of parameters accepted by this tool, extracted from the function signature and docstring. Used by TOOL_ABUSE test scenarios to craft parameter-injection payloads targeting each parameter.",
+            "title": "Parameters"
+          },
+          "injection_risk_score": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "For AGENT nodes: pre-computed injection risk score in [0, 1] set by the graph enricher. Derived from: number of tools with no_auth_required or high_privilege, presence of unguarded paths, reachable PII datastores, and unguarded HITL triggers. Used by ScenarioGenerator to sort generated test scenarios by expected impact.",
+            "title": "Injection Risk Score"
+          },
+          "mcp_server_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "URL of the MCP server this tool belongs to, e.g. 'http://mcp.example.com'",
+            "title": "Mcp Server Url"
+          },
+          "trust_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MCP server trust classification set by the graph enricher: 'trusted' | 'untrusted' | 'n/a'. All external MCP servers are 'untrusted' unless listed in redteam.mcp_trusted_servers in nuguard.yaml.",
+            "title": "Trust Level"
+          },
+          "no_auth_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool or endpoint is invocable without authentication",
+            "title": "No Auth Required"
+          },
+          "high_privilege": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool has access to administrative or cross-tenant resources",
+            "title": "High Privilege"
+          },
+          "sql_injectable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool constructs SQL queries from agent-provided string parameters",
+            "title": "Sql Injectable"
+          },
+          "ssrf_possible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool accepts URL parameters that are fetched server-side (SSRF surface)",
+            "title": "Ssrf Possible"
+          },
+          "accepts_external_url": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool has a URL/endpoint parameter that is passed to an outbound request",
+            "title": "Accepts External Url"
+          },
+          "reads_external_content": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the tool fetches or reads content from an external source (web, email, GitHub, etc.)",
+            "title": "Reads External Content"
+          },
+          "system_prompt_excerpt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "First 500 characters of the agent's system prompt / instructions / backstory. Used by the red-team scenario generator to craft context-authentic payloads.",
+            "title": "System Prompt Excerpt"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Prompt role, e.g. 'system', 'user'. PROMPT nodes only.",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Full prompt/instructions text. PROMPT nodes only.",
+            "title": "Content"
+          },
+          "char_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Character count of the prompt content. PROMPT nodes only.",
+            "title": "Char Count"
+          },
+          "is_template": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the prompt content contains '{variable}' placeholders. PROMPT nodes only.",
+            "title": "Is Template"
+          },
+          "template_variables": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Template variable names found in the prompt content, e.g. ['user_name']. PROMPT nodes only.",
+            "title": "Template Variables"
+          },
+          "prompt_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Prompt kind set by some adapters, e.g. 'instructions', 'agent_input'. PROMPT nodes only.",
+            "title": "Prompt Type"
+          },
+          "rules_excerpt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Short description of the guardrail's rules, validator class, or blocking logic",
+            "title": "Rules Excerpt"
+          },
+          "blocked_topics": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Topics this guardrail is known to block (extracted by enricher or adapter)",
+            "title": "Blocked Topics"
+          },
+          "blocked_actions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Actions this guardrail is known to block (extracted by enricher or adapter)",
+            "title": "Blocked Actions"
+          },
+          "refusal_style": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How this guardrail normally refuses: 'hard_block', 'redirect', 'warn', etc.",
+            "title": "Refusal Style"
+          },
+          "auth_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this API endpoint requires authentication",
+            "title": "Auth Required"
+          },
+          "auth_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "OAuth2 scope or role required to call this endpoint: 'user' | 'admin' | 'none'",
+            "title": "Auth Scope"
+          },
+          "accepts_user_input": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this endpoint accepts user-controlled input in body or query params",
+            "title": "Accepts User Input"
+          },
+          "returns_sensitive_data": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this endpoint returns PII, PHI, or other sensitive data",
+            "title": "Returns Sensitive Data"
+          },
+          "rate_limited": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when rate limiting is configured for this endpoint",
+            "title": "Rate Limited"
+          },
+          "idor_surface": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this endpoint has user- or tenant-scoped path parameters such as {user_id} or {tenant_id}",
+            "title": "Idor Surface"
+          },
+          "path_params": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Path parameter names extracted from the endpoint URL template, e.g. ['user_id', 'tenant_id']",
+            "title": "Path Params"
+          },
+          "path_param_sources": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maps each entry in path_params to the API_ENDPOINT path that creates the identified resource, e.g. {'id': '/chat/conversations'} for a chat endpoint at '/chat/conversations/:id/messages'",
+            "title": "Path Param Sources"
+          },
+          "request_body_schema": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Pydantic/dataclass field map for the request body: {field_name: type_string}",
+            "title": "Request Body Schema",
+            "type": "object"
+          },
+          "chat_payload_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inferred primary prompt field in the request body (e.g. 'message', 'query')",
+            "title": "Chat Payload Key"
+          },
+          "chat_payload_list": {
+            "default": false,
+            "description": "True when the chat payload key is typed as a list (e.g. list[str])",
+            "title": "Chat Payload List",
+            "type": "boolean"
+          },
+          "response_text_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inferred primary response text field in the response body",
+            "title": "Response Text Key"
+          },
+          "context_payload_fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Non-chat context fields detected in the POST request body schema, mapping field_name \u2192 kind. kind='identity': static per user (user_id, tenant_id, account_id\u2026) \u2014 auto-injected from login response or requires explicit config. kind='session': dynamic per conversation (session_id, thread_id\u2026) \u2014 auto-generated as UUID for the first request per scenario.",
+            "title": "Context Payload Fields"
+          },
+          "pii_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Flat list of general PII field names in this datastore, e.g. ['name', 'email', 'phone', 'address', 'date_of_birth']. Derived from classified_fields by the graph enricher. Financial identifiers (card numbers, bank accounts) belong in pfi_fields.",
+            "title": "Pii Fields"
+          },
+          "phi_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Flat list of PHI field names in this datastore (HIPAA-regulated), e.g. ['diagnosis', 'medication', 'lab_result', 'patient_id']. Derived from classified_fields by the graph enricher.",
+            "title": "Phi Fields"
+          },
+          "pfi_fields": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Flat list of Personal Financial Information field names (PCI-DSS / GLBA), e.g. ['card_number', 'bank_account', 'routing_number', 'cvv', 'ssn', 'tax_id', 'account_balance', 'iban', 'swift_code']. Derived from classified_fields by the graph enricher.",
+            "title": "Pfi Fields"
+          },
+          "access_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Datastore access mode inferred from ACCESSES edge: 'read' | 'write' | 'readwrite'",
+            "title": "Access Type"
+          },
+          "descriptive_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM-generated human-readable label, e.g. 'User Authentication API'",
+            "title": "Descriptive Name"
+          },
+          "security_headers_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SecurityHeaderDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "HTTP security-header posture extracted from code or IaC"
+          },
+          "cors_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/CorsPolicyDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "CORS configuration extracted from code or IaC"
+          },
+          "debug_error_leak": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the app runs in a debug/verbose-error mode that leaks stack traces",
+            "title": "Debug Error Leak"
+          },
+          "rate_limit_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RateLimitDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Structured rate limit configuration extracted from code or IaC"
+          },
+          "auth_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AuthDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Detailed authentication and authorization posture"
+          },
+          "encryption_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/EncryptionDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Encryption and redaction posture; supersedes encryption_at_rest for new consumers"
+          },
+          "data_handling": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/DataHandlingDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Data retention, backup, anonymization, and consent configuration"
+          },
+          "dependency_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package names from the manifest that appear in this component's source files",
+            "title": "Dependency Names"
+          },
+          "instrumentation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InstrumentationDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Observability and monitoring tooling detected for this component"
+          },
+          "testing": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TestingDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Test coverage and CI/CD posture for this component"
+          },
+          "loc": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total lines of source code across the files where this component is defined",
+            "title": "Loc"
+          },
+          "request_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Request body JSON schema for API endpoints, keyed by Pydantic model class name",
+            "title": "Request Schema"
+          },
+          "response_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Response body JSON schema for API endpoints, keyed by Pydantic model class name",
+            "title": "Response Schema"
+          },
+          "has_network_policy": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "K8s workload: True when covered by a NetworkPolicy resource in the same namespace",
+            "title": "Has Network Policy"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model artifact origin URL (HuggingFace repo, local path, or API base endpoint)",
+            "title": "Source Url"
+          },
+          "integrity_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model artifact SHA-256 or git revision hash for supply-chain verification",
+            "title": "Integrity Hash"
+          },
+          "checksum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model artifact checksum (md5, sha1, sha256) as a hex string",
+            "title": "Checksum"
+          },
+          "tool_config_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "AI-agent or editor config sub-type, e.g. 'claude-settings', 'mcp-config', 'cursor-config', 'vscode-config', 'gemini-config', 'smithery-config'",
+            "title": "Tool Config Type"
+          },
+          "permissions_granted": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Permission patterns granted in this config, e.g. ['Bash(*:*)', 'Read', 'Write']",
+            "title": "Permissions Granted"
+          },
+          "permissions_denied": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Permission patterns denied in this config, e.g. ['Bash(rm:*)']",
+            "title": "Permissions Denied"
+          },
+          "auto_execute": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when auto-run or auto-approve mode is enabled in this config",
+            "title": "Auto Execute"
+          },
+          "permission_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Scope at which this config grants permissions: 'repo' | 'user' | 'global'",
+            "title": "Permission Scope"
+          },
+          "file_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Raw file size in bytes of this config file (for SC-017: large file detection)",
+            "title": "File Size Bytes"
+          },
+          "content_entropy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Shannon entropy (bits/byte) of the file content computed at extraction time (for SC-018: high-entropy blob detection). Typical text is ~4\u20135; encrypted/base64 is >6.5.",
+            "title": "Content Entropy"
+          },
+          "script_phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package lifecycle phase this script runs at, e.g. 'postinstall', 'preinstall', 'prepare', 'build-backend', 'publish-hook'",
+            "title": "Script Phase"
+          },
+          "script_body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Lifecycle script body, truncated to 2000 chars",
+            "title": "Script Body"
+          },
+          "invokes_network": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script contains network download commands (curl, wget, fetch, etc.)",
+            "title": "Invokes Network"
+          },
+          "invokes_shell": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script pipes into a shell (| bash, | sh, | node, etc.)",
+            "title": "Invokes Shell"
+          },
+          "downloads_binary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script downloads and executes a binary (Bun, node, etc.)",
+            "title": "Downloads Binary"
+          },
+          "references_credentials": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when the script references credential paths or env vars: /proc/*/environ, .npmrc, AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN, etc.",
+            "title": "References Credentials"
+          },
+          "workflow_has_unpinned_global_install": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when any step in this workflow runs an unpinned global npm install or npx",
+            "title": "Workflow Has Unpinned Global Install"
+          },
+          "workflow_has_cred_access": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when any step in this workflow accesses credential paths or env vars",
+            "title": "Workflow Has Cred Access"
+          },
+          "workflow_triggers": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "GitHub Actions trigger event names parsed from the 'on:' block",
+            "title": "Workflow Triggers"
+          },
+          "workflow_permissions": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Top-level permissions block, e.g. {'id-token': 'write', 'contents': 'read'}",
+            "title": "Workflow Permissions"
+          },
+          "publishes_to": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Publish targets detected in workflow steps, e.g. ['pypi', 'npm', 'smithery']",
+            "title": "Publishes To"
+          },
+          "uses_oidc": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when any job has permissions.id-token: write (OIDC publishing)",
+            "title": "Uses Oidc"
+          },
+          "action_refs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "All 'uses: owner/action@ref' strings found in this workflow. Unpinned refs (branch or tag, not full SHA) indicate a supply-chain risk.",
+            "title": "Action Refs"
+          },
+          "mcp_server_trusted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when this MCP server is explicitly listed as trusted in nuguard.yaml",
+            "title": "Mcp Server Trusted"
+          },
+          "mcp_transport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "MCP transport protocol declared in .mcp.json: 'stdio' | 'http' | 'sse'",
+            "title": "Mcp Transport"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "description": "Adapter-specific key/value pairs (provider, model_family, version, \u2026)",
+            "title": "Extras",
+            "type": "object"
+          }
+        },
+        "title": "NodeMetadata",
+        "type": "object"
+      },
+      "PackageDep": {
+        "description": "A single declared package dependency.",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "version_spec": {
+            "title": "Version Spec",
+            "type": "string"
+          },
+          "purl": {
+            "title": "Purl",
+            "type": "string"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "source_file": {
+            "title": "Source File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "version_spec",
+          "purl",
+          "group",
+          "source_file"
+        ],
+        "title": "PackageDep",
+        "type": "object"
+      },
+      "RateLimitDetail": {
+        "description": "Structured rate limit configuration extracted from code or IaC.",
+        "properties": {
+          "requests_per_minute": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum requests allowed per minute",
+            "title": "Requests Per Minute"
+          },
+          "requests_per_hour": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum requests allowed per hour",
+            "title": "Requests Per Hour"
+          },
+          "requests_per_day": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum requests allowed per day",
+            "title": "Requests Per Day"
+          },
+          "burst_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Burst/concurrency limit above the steady-state rate",
+            "title": "Burst Size"
+          },
+          "window_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Duration of the rate limit window in seconds",
+            "title": "Window Seconds"
+          },
+          "enforcement_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How the rate limit is enforced, e.g. 'decorator', 'middleware', 'api_gateway'",
+            "title": "Enforcement Type"
+          }
+        },
+        "title": "RateLimitDetail",
+        "type": "object"
+      },
+      "RelationshipType": {
+        "enum": [
+          "USES",
+          "CALLS",
+          "ACCESSES",
+          "PROTECTS",
+          "DEPLOYS",
+          "DELEGATES_TO",
+          "CONTAINS"
+        ],
+        "title": "RelationshipType",
+        "type": "string"
+      },
+      "ScanSummary": {
+        "description": "Deterministic scan-level summary populated on every extraction.",
+        "properties": {
+          "use_case": {
+            "default": "",
+            "description": "Human-readable description of the application's AI use cases",
+            "title": "Use Case",
+            "type": "string"
+          },
+          "frameworks": {
+            "description": "Agentic framework names detected (e.g. ['langgraph', 'crewai'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Frameworks",
+            "type": "array"
+          },
+          "modalities": {
+            "description": "Supported I/O modalities in upper-case (e.g. ['TEXT', 'VOICE'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Modalities",
+            "type": "array"
+          },
+          "modality_support": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "description": "Detailed modality flags, e.g. {'text': true, 'voice': false}",
+            "title": "Modality Support",
+            "type": "object"
+          },
+          "api_endpoints": {
+            "description": "API route paths extracted from source (e.g. ['/chat', '/health'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Api Endpoints",
+            "type": "array"
+          },
+          "deployment_platforms": {
+            "description": "Cloud/CI platforms inferred from IaC files (e.g. ['AWS', 'GCP'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Deployment Platforms",
+            "type": "array"
+          },
+          "regions": {
+            "description": "Cloud regions referenced in IaC/config (e.g. ['us-east-1'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Regions",
+            "type": "array"
+          },
+          "environments": {
+            "description": "Deployment environments inferred from config (e.g. ['prod', 'staging'])",
+            "items": {
+              "type": "string"
+            },
+            "title": "Environments",
+            "type": "array"
+          },
+          "deployment_urls": {
+            "description": "Canonical deployment URLs found in IaC/workflow files",
+            "items": {
+              "type": "string"
+            },
+            "title": "Deployment Urls",
+            "type": "array"
+          },
+          "iac_accounts": {
+            "description": "Cloud account IDs / subscription IDs / project IDs found in IaC",
+            "items": {
+              "type": "string"
+            },
+            "title": "Iac Accounts",
+            "type": "array"
+          },
+          "node_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+            "title": "Node Counts",
+            "type": "object"
+          },
+          "secret_stores": {
+            "description": "Deduped secret management services referenced across all IaC files",
+            "items": {
+              "type": "string"
+            },
+            "title": "Secret Stores",
+            "type": "array"
+          },
+          "availability_zones": {
+            "description": "All cloud availability zones referenced in IaC files",
+            "items": {
+              "type": "string"
+            },
+            "title": "Availability Zones",
+            "type": "array"
+          },
+          "encryption_at_rest_coverage": {
+            "default": false,
+            "description": "True when at least one IaC resource has encryption-at-rest configured",
+            "title": "Encryption At Rest Coverage",
+            "type": "boolean"
+          },
+          "security_findings": {
+            "description": "Notable security / resilience findings across IaC and container config, e.g. ['container_runs_as_root', 'missing_health_check', 'no_resource_limits', 'secrets_in_env_vars', 'overly_permissive_iam']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Security Findings",
+            "type": "array"
+          },
+          "iam_principals": {
+            "description": "IAM role ARNs, GCP service account emails, and Azure managed identity names",
+            "items": {
+              "type": "string"
+            },
+            "title": "Iam Principals",
+            "type": "array"
+          },
+          "service_accounts": {
+            "description": "K8s ServiceAccount names and GCP/Azure service account identifiers",
+            "items": {
+              "type": "string"
+            },
+            "title": "Service Accounts",
+            "type": "array"
+          },
+          "iac_security_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM-generated security briefing for practitioners covering deployment posture, IAM configuration, secret management, encryption, HA, and CI/CD risks across all detected IaC and GitHub Actions workflows.",
+            "title": "Iac Security Summary"
+          },
+          "data_classification": {
+            "description": "Union of all data classification labels detected across the repository, e.g. ['PHI', 'PII'].  Empty list when no classified fields are found.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Data Classification",
+            "type": "array"
+          },
+          "classified_tables": {
+            "description": "Names of SQL tables or Python models that contain classified data fields (PII or PHI).  Sorted alphabetically.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Classified Tables",
+            "type": "array"
+          },
+          "startup_commands": {
+            "description": "Startup commands discovered from package.json, Makefile, Procfile, pyproject.toml, or inferred entry points.  Each entry is {command, source, label} where label is 'dev' or 'start'.",
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Startup Commands",
+            "type": "array"
+          },
+          "env_files": {
+            "description": "Relative paths to .env / dotenv files found in the repository.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Env Files",
+            "type": "array"
+          },
+          "env_var_keys": {
+            "description": "Sorted list of environment variable *keys* found across all dotenv files. Values are intentionally omitted from the SBOM.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Env Var Keys",
+            "type": "array"
+          },
+          "local_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Inferred local dev URL (e.g. 'http://localhost:8000') derived from PORT env var or startup command hints.  None when not determinable.",
+            "title": "Local Url"
+          },
+          "staging_urls": {
+            "description": "Staging / QA deployment URLs discovered from env files or config.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Staging Urls",
+            "type": "array"
+          },
+          "production_urls": {
+            "description": "Production deployment URLs discovered from env files or config.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Production Urls",
+            "type": "array"
+          },
+          "log_paths": {
+            "description": "Log file paths discovered during scanning (relative to app root).",
+            "items": {
+              "type": "string"
+            },
+            "title": "Log Paths",
+            "type": "array"
+          },
+          "uses_streaming": {
+            "default": false,
+            "description": "True when the application exposes one or more streaming output endpoints (SSE, StreamingResponse, or framework-native streaming such as Google ADK /run_sse).  The behavior step reads this to enable streaming-aware turn execution instead of buffered HTTP requests.",
+            "title": "Uses Streaming",
+            "type": "boolean"
+          },
+          "streaming_endpoints": {
+            "description": "API endpoint paths confirmed to serve streaming output (e.g. ['/run_sse', '/chat/stream']).  Populated from FastAPI StreamingResponse return types, SSE route patterns, ADK /run_sse, and similar source-code evidence.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Streaming Endpoints",
+            "type": "array"
+          },
+          "total_loc": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total lines of source code scanned across all files in the repository",
+            "title": "Total Loc"
+          },
+          "tokens_used_for_enrichment": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Total LLM tokens consumed (prompt + completion) during SBOM enrichment",
+            "title": "Tokens Used For Enrichment"
+          },
+          "input_tokens_used": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM prompt tokens consumed during SBOM enrichment",
+            "title": "Input Tokens Used"
+          },
+          "output_tokens_used": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM completion tokens consumed during SBOM enrichment",
+            "title": "Output Tokens Used"
+          },
+          "llm_model_used": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "LLM model string used for SBOM enrichment, e.g. 'gemini/gemini-2.0-flash'",
+            "title": "Llm Model Used"
+          },
+          "instrumentation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InstrumentationDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "App-wide observability and monitoring tooling summary"
+          },
+          "testing": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TestingDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "App-wide testing and CI/CD posture summary"
+          },
+          "github_actions_content": {
+            "default": "",
+            "description": "Raw concatenation of all detected GitHub Actions workflow YAML files, separated by '\n---\n'. Used by NGA-010/011/014 regex rules as a fallback when structured workflow_security_findings are not available.",
+            "title": "Github Actions Content",
+            "type": "string"
+          },
+          "workflow_security_findings": {
+            "description": "Structured security findings emitted by GitHubActionsAdapter during SBOM extraction. Each dict has keys: {rule_signal, path, line, snippet, confidence}.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Workflow Security Findings",
+            "type": "array"
+          },
+          "k8s_network_policy_namespaces": {
+            "description": "Kubernetes namespaces that have at least one NetworkPolicy resource detected. Populated by K8sAdapter. Used by NGA-013 to assert cross-file coverage.",
+            "items": {
+              "type": "string"
+            },
+            "title": "K8S Network Policy Namespaces",
+            "type": "array"
+          },
+          "has_package_json": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a package.json file was found at the repo root during SBOM extraction. Used by supply-chain scanner to check lockfile coverage (SC-024) without requiring a live filesystem.",
+            "title": "Has Package Json"
+          },
+          "has_lockfile": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when at least one npm lockfile (package-lock.json, pnpm-lock.yaml, or yarn.lock) was found at the repo root during SBOM extraction. Used by supply-chain scanner (SC-024) without requiring a live filesystem.",
+            "title": "Has Lockfile"
+          },
+          "minified_js_files": {
+            "description": "Relative paths to JavaScript files that contain a single line exceeding 5000 characters \u2014 a reliable indicator of minified/bundled code. Populated by the extractor during the main JS scanning pass. Used by supply-chain scanner (SC-019) without requiring a live filesystem.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Minified Js Files",
+            "type": "array"
+          }
+        },
+        "title": "ScanSummary",
+        "type": "object"
+      },
+      "SecurityHeaderDetail": {
+        "description": "HTTP security-header posture extracted from code or IaC.",
+        "properties": {
+          "csp": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a Content-Security-Policy header is set",
+            "title": "Csp"
+          },
+          "x_frame_options": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when an X-Frame-Options header is set",
+            "title": "X Frame Options"
+          },
+          "hsts": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when a Strict-Transport-Security header is set",
+            "title": "Hsts"
+          },
+          "missing": {
+            "description": "Security headers confirmed absent, e.g. ['csp', 'x_frame_options', 'hsts']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing",
+            "type": "array"
+          }
+        },
+        "title": "SecurityHeaderDetail",
+        "type": "object"
+      },
+      "SourceLocation": {
+        "description": "File/line pointer for a piece of evidence.",
+        "properties": {
+          "path": {
+            "description": "Relative path to the source file",
+            "title": "Path",
+            "type": "string"
+          },
+          "line": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "1-based line number, if known",
+            "title": "Line"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "SourceLocation",
+        "type": "object"
+      },
+      "TestingDetail": {
+        "description": "Testing, validation, and CI/CD posture for a component or application.",
+        "properties": {
+          "has_unit_tests": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when unit test files are detected",
+            "title": "Has Unit Tests"
+          },
+          "has_integration_tests": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "True when integration test files or suites are detected",
+            "title": "Has Integration Tests"
+          },
+          "test_frameworks": {
+            "description": "Test frameworks detected, e.g. ['pytest', 'jest', 'vitest', 'hypothesis']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Test Frameworks",
+            "type": "array"
+          },
+          "ci_cd_pipeline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "CI/CD platform detected, e.g. 'github_actions', 'gitlab_ci', 'jenkins'",
+            "title": "Ci Cd Pipeline"
+          },
+          "quality_gates": {
+            "description": "Quality gate tools detected, e.g. ['codecov', 'sonarqube', 'snyk']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Quality Gates",
+            "type": "array"
+          },
+          "test_coverage_tool": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Coverage measurement tool detected, e.g. 'coverage.py', 'istanbul'",
+            "title": "Test Coverage Tool"
+          }
+        },
+        "title": "TestingDetail",
+        "type": "object"
+      },
+      "ToolParameter": {
+        "description": "Schema for a single parameter accepted by a TOOL node.\n\nCaptured from function signatures and docstrings by the SBOM extractor.\nUsed by the redteam test generator to craft parameter-injection payloads\nfor TOOL_ABUSE scenarios.",
+        "properties": {
+          "name": {
+            "description": "Parameter name as it appears in the function signature",
+            "title": "Name",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Python/TypeScript type annotation string, e.g. 'str', 'int', 'dict'",
+            "title": "Type"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Parameter description extracted from the function docstring",
+            "title": "Description"
+          },
+          "required": {
+            "default": true,
+            "description": "True when the parameter has no default value",
+            "title": "Required",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ToolParameter",
+        "type": "object"
+      }
+    },
+    "description": "Validated enrichment result without credentials or target responses.",
+    "properties": {
+      "sbom": {
+        "$ref": "#/$defs/AiSbomDocument"
+      },
+      "enriched": {
+        "title": "Enriched",
+        "type": "boolean"
+      },
+      "confidence_before": {
+        "maximum": 1.0,
+        "minimum": 0.0,
+        "title": "Confidence Before",
+        "type": "number"
+      },
+      "confidence_after": {
+        "maximum": 1.0,
+        "minimum": 0.0,
+        "title": "Confidence After",
+        "type": "number"
+      },
+      "reasons": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Reasons",
+        "type": "array"
+      },
+      "probe_attempted": {
+        "title": "Probe Attempted",
+        "type": "boolean"
+      },
+      "probe_requests": {
+        "minimum": 0,
+        "title": "Probe Requests",
+        "type": "integer"
+      },
+      "cache_fingerprint": {
+        "title": "Cache Fingerprint",
+        "type": "string"
+      },
+      "artifact_path": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Artifact Path"
+      }
+    },
+    "required": [
+      "sbom",
+      "enriched",
+      "confidence_before",
+      "confidence_after",
+      "probe_attempted",
+      "probe_requests",
+      "cache_fingerprint"
+    ],
+    "title": "SbomEnrichmentResult",
     "type": "object"
   },
   "sbom.SbomExportRequest": {
@@ -13354,6 +19597,27 @@
       "edge_count"
     ],
     "title": "SbomParseResult",
+    "type": "object"
+  },
+  "sbom.SbomProbeAuthConfig": {
+    "description": "Secret HTTP header used only for bounded target probing.",
+    "properties": {
+      "header_name": {
+        "title": "Header Name",
+        "type": "string"
+      },
+      "header_value": {
+        "format": "password",
+        "title": "Header Value",
+        "type": "string",
+        "writeOnly": true
+      }
+    },
+    "required": [
+      "header_name",
+      "header_value"
+    ],
+    "title": "SbomProbeAuthConfig",
     "type": "object"
   },
   "sbom.SbomRenderRequest": {

--- a/tests/contracts/test_public_api_schema_contract.py
+++ b/tests/contracts/test_public_api_schema_contract.py
@@ -46,7 +46,9 @@ from nuguard.policy.public_api import (
     CognitivePolicyParseResult,
 )
 from nuguard.redteam.public_api import (
+    RedteamAuthConfig,
     RedteamExecutionResult,
+    RedteamLoginFlowConfig,
     RedteamRunRequest,
     RedteamRunResult,
 )
@@ -104,7 +106,9 @@ _MODEL_REGISTRY: dict[str, type[BaseModel]] = {
     "policy.CognitivePolicyParseDetail": CognitivePolicyParseDetail,
     "policy.CognitivePolicyParseRequest": CognitivePolicyParseRequest,
     "policy.CognitivePolicyParseResult": CognitivePolicyParseResult,
+    "redteam.RedteamAuthConfig": RedteamAuthConfig,
     "redteam.RedteamExecutionResult": RedteamExecutionResult,
+    "redteam.RedteamLoginFlowConfig": RedteamLoginFlowConfig,
     "redteam.RedteamRunRequest": RedteamRunRequest,
     "redteam.RedteamRunResult": RedteamRunResult,
     "sbom.SbomEnrichmentLlmConfig": SbomEnrichmentLlmConfig,

--- a/tests/contracts/test_public_api_schema_contract.py
+++ b/tests/contracts/test_public_api_schema_contract.py
@@ -13,8 +13,8 @@ from typing import Any
 from pydantic import BaseModel
 
 from nuguard.analysis.public_api import AnalysisRunRequest, AnalysisRunResult
-from nuguard.behavior.public_api import BehaviorAnalysisRequest, BehaviorRunRequest
 from nuguard.behavior.models import BehaviorAnalysisResult, BehaviorRunResult
+from nuguard.behavior.public_api import BehaviorAnalysisRequest, BehaviorRunRequest
 from nuguard.common.discovery import TargetDiscoveryResult
 from nuguard.common.streaming_models import (
     BehaviorProgressState,
@@ -40,18 +40,27 @@ from nuguard.output.public_api import (
     ValidationReportExportResult,
     ValidationReportMetaModel,
 )
+from nuguard.policy.public_api import (
+    CognitivePolicyParseDetail,
+    CognitivePolicyParseRequest,
+    CognitivePolicyParseResult,
+)
 from nuguard.redteam.public_api import (
     RedteamExecutionResult,
     RedteamRunRequest,
     RedteamRunResult,
 )
 from nuguard.sbom.public_api import (
+    SbomEnrichmentLlmConfig,
+    SbomEnrichmentRequest,
+    SbomEnrichmentResult,
     SbomExportRequest,
     SbomExportResult,
     SbomGenerateRequest,
     SbomGenerateResult,
     SbomParseRequest,
     SbomParseResult,
+    SbomProbeAuthConfig,
     SbomRenderRequest,
     SbomRenderResult,
 )
@@ -92,9 +101,15 @@ _MODEL_REGISTRY: dict[str, type[BaseModel]] = {
     "output.ValidationReportExportRequest": ValidationReportExportRequest,
     "output.ValidationReportExportResult": ValidationReportExportResult,
     "output.ValidationReportMetaModel": ValidationReportMetaModel,
+    "policy.CognitivePolicyParseDetail": CognitivePolicyParseDetail,
+    "policy.CognitivePolicyParseRequest": CognitivePolicyParseRequest,
+    "policy.CognitivePolicyParseResult": CognitivePolicyParseResult,
     "redteam.RedteamExecutionResult": RedteamExecutionResult,
     "redteam.RedteamRunRequest": RedteamRunRequest,
     "redteam.RedteamRunResult": RedteamRunResult,
+    "sbom.SbomEnrichmentLlmConfig": SbomEnrichmentLlmConfig,
+    "sbom.SbomEnrichmentRequest": SbomEnrichmentRequest,
+    "sbom.SbomEnrichmentResult": SbomEnrichmentResult,
     "sbom.SbomExportRequest": SbomExportRequest,
     "sbom.SbomExportResult": SbomExportResult,
     "sbom.SbomGenerateRequest": SbomGenerateRequest,
@@ -103,6 +118,7 @@ _MODEL_REGISTRY: dict[str, type[BaseModel]] = {
     "sbom.SbomParseResult": SbomParseResult,
     "sbom.SbomRenderRequest": SbomRenderRequest,
     "sbom.SbomRenderResult": SbomRenderResult,
+    "sbom.SbomProbeAuthConfig": SbomProbeAuthConfig,
     "sbom.toolbox.ToolboxListPluginsRequest": ToolboxListPluginsRequest,
     "sbom.toolbox.ToolboxListPluginsResult": ToolboxListPluginsResult,
     "sbom.toolbox.ToolboxRunAllRequest": ToolboxRunAllRequest,

--- a/tests/policy/test_public_api.py
+++ b/tests/policy/test_public_api.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from nuguard.models.policy import CognitivePolicy
+from nuguard.policy import (
+    CognitivePolicyParseRequest,
+    CognitivePolicyParseResult,
+    parse_cognitive_policy,
+)
+from nuguard.policy.public_api import normalize_cognitive_policy
+
+
+def test_parse_cognitive_policy_returns_validated_public_result() -> None:
+    result = parse_cognitive_policy(
+        CognitivePolicyParseRequest(markdown="## Allowed Topics\n- Customer support\n")
+    )
+
+    assert result.success is True
+    assert result.policy is not None
+    assert result.policy.allowed_topics == ["Customer support"]
+    assert CognitivePolicyParseResult.model_validate_json(result.model_dump_json()) == result
+
+
+def test_parse_cognitive_policy_returns_sanitized_failure() -> None:
+    """Validation failures return stable diagnostics without source disclosure."""
+    secret = "private-policy-content"
+    validation_error = ValidationError.from_exception_data("CognitivePolicy", [])
+
+    with patch("nuguard.policy.public_api.parse_policy", side_effect=validation_error):
+        result = parse_cognitive_policy(CognitivePolicyParseRequest(markdown=secret))
+
+    assert result.success is False
+    assert result.errors[0].code == "policy_validation_failed"
+    assert secret not in result.model_dump_json()
+
+
+def test_parse_cognitive_policy_sanitizes_unexpected_parser_failure() -> None:
+    """Unexpected parser errors do not disclose policy content or exception text."""
+    secret = "private-policy-content"
+
+    with patch(
+        "nuguard.policy.public_api.parse_policy",
+        side_effect=RuntimeError(f"parser failed for {secret}"),
+    ):
+        result = parse_cognitive_policy(CognitivePolicyParseRequest(markdown=secret))
+
+    assert result.success is False
+    assert result.errors[0].code == "policy_parse_failed"
+    assert secret not in result.model_dump_json()
+
+
+def test_normalize_cognitive_policy_accepts_model_and_parse_result() -> None:
+    """Successful public parse results normalize to their policy model."""
+    policy = CognitivePolicy(allowed_topics=["Support"])
+    parse_result = CognitivePolicyParseResult(success=True, policy=policy)
+
+    assert normalize_cognitive_policy(policy) is policy
+    assert normalize_cognitive_policy(parse_result) is policy
+
+
+def test_normalize_cognitive_policy_rejects_failed_parse_result() -> None:
+    """Failed parse results cannot silently disable policy enforcement."""
+    parse_result = CognitivePolicyParseResult(success=False)
+
+    with pytest.raises(ValueError, match="did not produce a valid policy"):
+        normalize_cognitive_policy(parse_result)

--- a/tests/redteam/test_public_api.py
+++ b/tests/redteam/test_public_api.py
@@ -19,13 +19,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
-from nuguard.common.auth import AuthConfig
-from nuguard.config import RedteamFindingTriggers
+from nuguard.common.auth import AuthConfig, LoginFlowConfig
+from nuguard.config import AppAuthConfig, RedteamFindingTriggers
 from nuguard.models.finding import Finding, Severity
 from nuguard.models.health_report import TargetHealthReport
+from nuguard.models.policy import CognitivePolicy
 from nuguard.models.token_usage import TokenUsage
+from nuguard.policy import CognitivePolicyParseResult
 from nuguard.redteam.coverage.tracker import CoverageTracker
-from nuguard.redteam.public_api import RedteamRunRequest, RedteamRunResult, run_redteam, run_redteam_stream
+from nuguard.redteam.public_api import (
+    RedteamRunRequest,
+    RedteamRunResult,
+    run_redteam,
+    run_redteam_stream,
+)
 from nuguard.redteam.target.canary import CanaryConfig
 
 
@@ -94,6 +101,28 @@ def test_redteam_run_request_json_roundtrip():
     assert restored.canary_config is not None
 
 
+@pytest.mark.parametrize(
+    "auth",
+    [
+        AppAuthConfig(type="bearer", header="Authorization: Bearer token"),
+        AppAuthConfig(type="api_key", header="X-API-Key: token"),
+        AppAuthConfig(type="basic", username="user", password="password"),
+        AppAuthConfig(
+            type="login_flow",
+            login_flow=LoginFlowConfig(payload={"username": "user", "password": "password"}),
+        ),
+        AppAuthConfig(type="cookie_file", cookie_file="cookies.txt"),
+        AppAuthConfig(type="none"),
+    ],
+)
+def test_redteam_request_accepts_app_auth_config(auth: AppAuthConfig) -> None:
+    """App-level auth models retain every value when normalized for redteam."""
+    request = RedteamRunRequest(target_url="http://localhost:9999", auth_config=auth)
+
+    assert isinstance(request.auth_config, AuthConfig)
+    assert request.auth_config.model_dump() == auth.model_dump()
+
+
 def test_redteam_run_request_defaults_match_orchestrator_constructor():
     req = RedteamRunRequest(target_url="http://x")
     assert req.profile == "ci"
@@ -142,15 +171,17 @@ def test_redteam_run_result_rejects_invalid_scan_outcome():
 
 @pytest.mark.asyncio
 async def test_run_redteam_constructs_orchestrator_and_builds_result():
+    """The orchestrator receives the policy model unwrapped from a parse result."""
     findings = [_finding("prompt_driven_threat"), _finding("data_exfiltration")]
     mock_instance = _make_mock_orchestrator(findings)
     sbom = MagicMock()
-    policy = MagicMock()
+    policy = CognitivePolicy(allowed_topics=["Support"])
+    parsed_policy = CognitivePolicyParseResult(success=True, policy=policy)
 
     with patch("nuguard.redteam.public_api.RedteamOrchestrator") as mock_cls:
         mock_cls.return_value = mock_instance
         request = RedteamRunRequest(target_url="http://target", profile="standard")
-        result = await run_redteam(request, sbom=sbom, policy=policy)
+        result = await run_redteam(request, sbom=sbom, policy=parsed_policy)
 
     mock_cls.assert_called_once()
     _, kwargs = mock_cls.call_args
@@ -178,6 +209,30 @@ async def test_run_redteam_constructs_orchestrator_and_builds_result():
     assert result.catalog_coverage is None
     assert result.coverage_tracker is not None
     assert result.coverage_tracker["nodes"][0]["name"] == "Agent1"
+
+
+@pytest.mark.asyncio
+async def test_run_redteam_normalizes_parse_result_for_remediation() -> None:
+    """Remediation receives a CognitivePolicy, not the public parse envelope."""
+    policy = CognitivePolicy(restricted_topics=["Credentials"])
+    parsed_policy = CognitivePolicyParseResult(success=True, policy=policy)
+    mock_instance = _make_mock_orchestrator([_finding()])
+
+    with (
+        patch("nuguard.redteam.public_api.RedteamOrchestrator") as mock_cls,
+        patch(
+            "nuguard.redteam.public_api._build_remediation_plan",
+            new=AsyncMock(return_value=[]),
+        ) as remediation_mock,
+    ):
+        mock_cls.return_value = mock_instance
+        await run_redteam(
+            RedteamRunRequest(target_url="http://target"),
+            sbom=MagicMock(),
+            policy=parsed_policy,
+        )
+
+    assert remediation_mock.await_args.kwargs["policy"] is policy
 
 
 @pytest.mark.asyncio

--- a/tests/redteam/test_public_api.py
+++ b/tests/redteam/test_public_api.py
@@ -17,7 +17,7 @@ import dataclasses
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from nuguard.common.auth import AuthConfig, LoginFlowConfig
 from nuguard.config import AppAuthConfig, RedteamFindingTriggers
@@ -28,6 +28,8 @@ from nuguard.models.token_usage import TokenUsage
 from nuguard.policy import CognitivePolicyParseResult
 from nuguard.redteam.coverage.tracker import CoverageTracker
 from nuguard.redteam.public_api import (
+    RedteamAuthConfig,
+    RedteamLoginFlowConfig,
     RedteamRunRequest,
     RedteamRunResult,
     run_redteam,
@@ -116,11 +118,140 @@ def test_redteam_run_request_json_roundtrip():
     ],
 )
 def test_redteam_request_accepts_app_auth_config(auth: AppAuthConfig) -> None:
-    """App-level auth models retain every value when normalized for redteam."""
+    """App-level auth models retain every runtime value behind the public boundary."""
     request = RedteamRunRequest(target_url="http://localhost:9999", auth_config=auth)
 
-    assert isinstance(request.auth_config, AuthConfig)
-    assert request.auth_config.model_dump() == auth.model_dump()
+    assert isinstance(request.auth_config, RedteamAuthConfig)
+    assert request.auth_config.to_internal().model_dump() == auth.model_dump()
+
+
+def test_redteam_request_accepts_legacy_auth_config_with_nested_login_payload() -> None:
+    """The existing internal auth model remains accepted without losing payload values."""
+    auth = AuthConfig(
+        type="login_flow",
+        login_flow=LoginFlowConfig(
+            endpoint="/session",
+            method="POST",
+            base_url="https://identity.example.test",
+            payload={
+                "identity": {
+                    "username": "legacy-user",
+                    "factors": ["legacy-password", {"otp": "123456"}],
+                },
+                "remember": True,
+                "attempt": 2,
+                "optional": None,
+            },
+            token_response_key="data.access_token",
+            token_header="X-Session-Token:",
+            refresh_on_401=False,
+        ),
+    )
+
+    request = RedteamRunRequest(target_url="http://localhost:9999", auth_config=auth)
+
+    assert isinstance(request.auth_config, RedteamAuthConfig)
+    assert request.auth_config.to_internal().model_dump() == auth.model_dump()
+
+
+@pytest.mark.parametrize(
+    ("auth_data", "message"),
+    [
+        ({"type": "bearer"}, "requires auth.header"),
+        ({"type": "api_key"}, "requires auth.header"),
+        ({"type": "basic", "username": "user"}, "requires auth.username and auth.password"),
+        ({"type": "login_flow"}, "requires auth.login_flow block"),
+        ({"type": "cookie_file"}, "requires auth.cookie_file"),
+    ],
+)
+def test_redteam_auth_config_rejects_missing_required_fields(
+    auth_data: dict[str, object],
+    message: str,
+) -> None:
+    """The secret-safe auth model preserves the runtime model's validation contract."""
+    with pytest.raises(ValidationError, match=message):
+        RedteamAuthConfig.model_validate(auth_data)
+
+
+@pytest.mark.parametrize(
+    ("auth", "secrets"),
+    [
+        (RedteamAuthConfig(type="bearer", header="Authorization: Bearer bearer-secret"), ["bearer-secret"]),
+        (RedteamAuthConfig(type="api_key", header="X-API-Key: api-secret"), ["api-secret"]),
+        (
+            RedteamAuthConfig(type="basic", username="basic-user", password="basic-password"),
+            ["basic-user", "basic-password"],
+        ),
+        (
+            RedteamAuthConfig(
+                type="login_flow",
+                login_flow=RedteamLoginFlowConfig(
+                    payload={
+                        "username": "login-user",
+                        "password": "login-password",
+                        "nested": {"token": "nested-secret"},
+                    }
+                ),
+            ),
+            ["login-user", "login-password", "nested-secret"],
+        ),
+    ],
+)
+def test_redteam_auth_secrets_are_redacted_from_serialization(
+    auth: RedteamAuthConfig,
+    secrets: list[str],
+) -> None:
+    request = RedteamRunRequest(target_url="http://localhost:9999", auth_config=auth)
+
+    serialized = request.model_dump_json()
+
+    for secret in secrets:
+        assert secret not in serialized
+
+
+def test_redteam_request_header_and_confirmation_credentials_are_redacted() -> None:
+    """Header overrides and confirmation credentials never serialize as plaintext."""
+    request = RedteamRunRequest(
+        target_url="http://localhost:9999",
+        extra_headers={"Authorization": "Bearer header-secret"},
+        credentials={"account": "credential-secret"},
+    )
+
+    serialized = request.model_dump_json()
+
+    assert "header-secret" not in serialized
+    assert "credential-secret" not in serialized
+
+
+def test_nested_login_payload_is_secret_safe_and_preserves_non_string_values() -> None:
+    """Nested objects and arrays redact strings without changing JSON scalar values."""
+    payload = {
+        "identity": {
+            "username": "nested-user",
+            "factors": ["nested-password", {"otp": "654321"}],
+        },
+        "remember": True,
+        "attempt": 2,
+        "optional": None,
+    }
+    login_flow = RedteamLoginFlowConfig(payload=payload)
+
+    serialized = login_flow.model_dump(mode="json")
+    restored_payload = login_flow.to_internal().payload
+
+    assert isinstance(login_flow.payload["identity"]["username"], SecretStr)
+    assert isinstance(login_flow.payload["identity"]["factors"][0], SecretStr)
+    assert isinstance(login_flow.payload["identity"]["factors"][1]["otp"], SecretStr)
+    assert serialized["payload"] == {
+        "identity": {
+            "username": "**********",
+            "factors": ["**********", {"otp": "**********"}],
+        },
+        "remember": True,
+        "attempt": 2,
+        "optional": None,
+    }
+    assert restored_payload == payload
 
 
 def test_redteam_run_request_defaults_match_orchestrator_constructor():
@@ -260,10 +391,88 @@ async def test_run_redteam_passes_config_scalar_and_embedded_model_fields():
 
     _, kwargs = mock_cls.call_args
     assert kwargs["canary_config"] is canary
-    assert kwargs["auth_config"] is auth
+    assert isinstance(kwargs["auth_config"], AuthConfig)
+    assert kwargs["auth_config"].model_dump() == auth.model_dump()
     assert kwargs["finding_triggers"] is triggers
     assert kwargs["guided_mutation_mode"] == "soft"
     assert kwargs["tree_breadth"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_redteam_reveals_secrets_only_for_orchestrator() -> None:
+    """The public wrapper reveals protected values only at the runtime boundary."""
+    mock_instance = _make_mock_orchestrator([])
+    request = RedteamRunRequest(
+        target_url="http://target",
+        auth_config=RedteamAuthConfig(
+            type="login_flow",
+            login_flow=RedteamLoginFlowConfig(
+                payload={"username": "runtime-user", "password": "runtime-password"}
+            ),
+        ),
+        extra_headers={"X-API-Key": "runtime-header"},
+        credentials={"pin": "runtime-pin"},
+    )
+
+    with patch("nuguard.redteam.public_api.RedteamOrchestrator") as mock_cls:
+        mock_cls.return_value = mock_instance
+        await run_redteam(request, sbom=MagicMock())
+
+    _, kwargs = mock_cls.call_args
+    assert kwargs["auth_config"].login_flow.payload == {
+        "username": "runtime-user",
+        "password": "runtime-password",
+    }
+    assert kwargs["extra_headers"] == {"X-API-Key": "runtime-header"}
+    assert kwargs["credentials"] == {"pin": "runtime-pin"}
+
+
+@pytest.mark.asyncio
+async def test_cli_orchestrator_adapter_protects_auth_values_before_public_call() -> None:
+    """The CLI passes only secret-safe request values into the public API wrapper."""
+    from nuguard.cli.commands.redteam import _run_orchestrator
+
+    result = RedteamRunResult(
+        findings=[],
+        scenario_records=[],
+        scan_outcome="no_findings",
+        token_usage=TokenUsage(),
+        resolved_chat_path="/chat",
+        resolved_chat_path_source="configured",
+    )
+    auth = AuthConfig(
+        type="login_flow",
+        login_flow=LoginFlowConfig(
+            payload={"identity": {"password": "cli-login-secret"}}
+        ),
+    )
+
+    with patch(
+        "nuguard.redteam.public_api.run_redteam",
+        new=AsyncMock(return_value=result),
+    ) as run_mock:
+        await _run_orchestrator(
+            sbom_doc=object(),
+            target_url="http://target",
+            cognitive_policy=None,
+            canary_config=None,
+            profile="ci",
+            min_impact_score=0.0,
+            scenario_filter=None,
+            auth_config=auth,
+            extra_headers={"X-API-Key": "cli-header-secret"},
+            credentials={"pin": "cli-credential-secret"},
+        )
+
+    request = run_mock.await_args.args[0]
+    assert isinstance(request.auth_config, RedteamAuthConfig)
+    assert isinstance(request.auth_config.login_flow.payload["identity"]["password"], SecretStr)
+    assert isinstance(request.extra_headers["X-API-Key"], SecretStr)
+    assert isinstance(request.credentials["pin"], SecretStr)
+    serialized = request.model_dump_json()
+    assert "cli-login-secret" not in serialized
+    assert "cli-header-secret" not in serialized
+    assert "cli-credential-secret" not in serialized
 
 
 @pytest.mark.asyncio

--- a/tests/sbom/test_public_enrichment_api.py
+++ b/tests/sbom/test_public_enrichment_api.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from nuguard.common.auto_sbom_enricher import EnrichmentResult
+from nuguard.sbom.models import AiSbomDocument
+from nuguard.sbom.public_api import (
+    SbomEnrichmentLlmConfig,
+    SbomEnrichmentRequest,
+    SbomProbeAuthConfig,
+    enrich_sbom,
+)
+
+
+@pytest.mark.asyncio
+async def test_enrich_sbom_is_copy_on_write_and_does_not_persist_by_default() -> None:
+    """A mutating enricher cannot alter input and no implicit artifact is written."""
+    source = AiSbomDocument(target="app")
+
+    async def mutate_copy(*, sbom: AiSbomDocument, **kwargs: object) -> EnrichmentResult:
+        sbom.target = "enriched-app"
+        return EnrichmentResult(
+            sbom=sbom,
+            enriched=True,
+            confidence_before=0.5,
+            confidence_after=0.8,
+            reasons=["enriched"],
+            probe_attempted=False,
+            probe_requests=0,
+            artifact_path=None,
+        )
+
+    with (
+        patch(
+            "nuguard.common.auto_sbom_enricher.maybe_auto_enrich_sbom",
+            new=AsyncMock(side_effect=mutate_copy),
+        ) as enrich_mock,
+        patch("nuguard.sbom.public_api.Path.mkdir") as mkdir_mock,
+        patch("nuguard.sbom.public_api.Path.write_text") as write_mock,
+    ):
+        result = await enrich_sbom(SbomEnrichmentRequest(sbom=source))
+
+    delegated = enrich_mock.await_args.kwargs
+    assert delegated["sbom"] is not source
+    assert delegated["sbom_path"] is None
+    assert source.target == "app"
+    assert result.sbom.target == "enriched-app"
+    assert result.artifact_path is None
+    mkdir_mock.assert_not_called()
+    write_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enrichment_secrets_are_transport_only_and_do_not_affect_fingerprint() -> None:
+    """Credentials are SecretStr inputs, transport-only, and excluded from cache keys."""
+    source = AiSbomDocument(target="app")
+    first_secret = "llm-secret-one"
+    second_secret = "llm-secret-two"
+    auth_secret = "probe-secret"
+    private_result = EnrichmentResult(
+        sbom=source,
+        enriched=False,
+        confidence_before=0.7,
+        confidence_after=0.7,
+        reasons=[],
+        probe_attempted=False,
+        probe_requests=0,
+        artifact_path=None,
+    )
+
+    async_mock = AsyncMock(return_value=private_result)
+    with patch("nuguard.common.auto_sbom_enricher.maybe_auto_enrich_sbom", new=async_mock):
+        first = await enrich_sbom(
+            SbomEnrichmentRequest(
+                sbom=source,
+                target_url=f"https://user:{first_secret}@example.com/chat?access_token={auth_secret}",
+                llm_config=SbomEnrichmentLlmConfig(enabled=True, api_key=first_secret),
+                probe_auth=SbomProbeAuthConfig(
+                    header_name="Authorization", header_value=auth_secret
+                ),
+            )
+        )
+        second = await enrich_sbom(
+            SbomEnrichmentRequest(
+                sbom=source,
+                target_url=(
+                    f"https://user:{second_secret}@example.com/chat?access_token="
+                    "different-probe-secret"
+                ),
+                llm_config=SbomEnrichmentLlmConfig(enabled=True, api_key=second_secret),
+                probe_auth=SbomProbeAuthConfig(
+                    header_name="Authorization", header_value="different-probe-secret"
+                ),
+            )
+        )
+
+    assert isinstance(
+        async_mock.await_args_list[0].kwargs["llm_api_key"],
+        str,
+    )
+    assert async_mock.await_args_list[0].kwargs["llm_api_key"] == first_secret
+    assert async_mock.await_args_list[0].kwargs["probe_auth_header"].endswith(auth_secret)
+    assert first.cache_fingerprint == second.cache_fingerprint
+    request = SbomEnrichmentRequest(
+        sbom=source,
+        llm_config=SbomEnrichmentLlmConfig(enabled=True, api_key=first_secret),
+        probe_auth=SbomProbeAuthConfig(
+            header_name="Authorization",
+            header_value=auth_secret,
+        ),
+    )
+    assert isinstance(request.llm_config.api_key, SecretStr)
+    assert isinstance(request.probe_auth.header_value, SecretStr)
+    assert first_secret not in request.model_dump_json()
+    assert auth_secret not in request.model_dump_json()
+    serialized = first.model_dump_json()
+    assert first_secret not in serialized
+    assert auth_secret not in serialized
+
+
+@pytest.mark.asyncio
+async def test_enrichment_fingerprint_is_deterministic_and_cache_version_invalidates() -> None:
+    """Equivalent requests reuse a key while cache_version explicitly invalidates it."""
+    source = AiSbomDocument(target="app")
+    private_result = EnrichmentResult(
+        sbom=source,
+        enriched=False,
+        confidence_before=0.7,
+        confidence_after=0.7,
+        reasons=[],
+        probe_attempted=False,
+        probe_requests=0,
+        artifact_path=None,
+    )
+
+    with patch(
+        "nuguard.common.auto_sbom_enricher.maybe_auto_enrich_sbom",
+        new=AsyncMock(return_value=private_result),
+    ):
+        first = await enrich_sbom(SbomEnrichmentRequest(sbom=source))
+        repeated = await enrich_sbom(SbomEnrichmentRequest(sbom=source))
+        invalidated = await enrich_sbom(
+            SbomEnrichmentRequest(sbom=source, cache_version="v2")
+        )
+
+    assert first.cache_fingerprint == repeated.cache_fingerprint
+    assert invalidated.cache_fingerprint != first.cache_fingerprint
+
+
+@pytest.mark.asyncio
+async def test_enrichment_sanitizes_legacy_sbom_target_without_mutating_input() -> None:
+    token = "legacy-repository-token"
+    source = AiSbomDocument(target=f"https://x-access-token:{token}@github.com/org/repo.git")
+
+    async def _return_input(**kwargs):
+        sbom = kwargs["sbom"]
+        return EnrichmentResult(
+            sbom=sbom,
+            enriched=False,
+            confidence_before=0.7,
+            confidence_after=0.7,
+            reasons=[],
+            probe_attempted=False,
+            probe_requests=0,
+            artifact_path=None,
+        )
+
+    with patch(
+        "nuguard.common.auto_sbom_enricher.maybe_auto_enrich_sbom",
+        new=AsyncMock(side_effect=_return_input),
+    ):
+        result = await enrich_sbom(SbomEnrichmentRequest(sbom=source))
+
+    assert token in source.target
+    assert result.sbom.target == "https://github.com/org/repo.git"
+    assert token not in result.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_enrich_sbom_persists_only_to_explicit_output_path(tmp_path) -> None:
+    source = AiSbomDocument(target="app")
+    output_path = tmp_path / "platform-cache" / "enriched.json"
+    private_result = EnrichmentResult(
+        sbom=source,
+        enriched=True,
+        confidence_before=0.2,
+        confidence_after=0.8,
+        reasons=["missing AGENT node"],
+        probe_attempted=False,
+        probe_requests=0,
+        artifact_path=None,
+    )
+
+    with patch(
+        "nuguard.common.auto_sbom_enricher.maybe_auto_enrich_sbom",
+        new=AsyncMock(return_value=private_result),
+    ):
+        result = await enrich_sbom(
+            SbomEnrichmentRequest(sbom=source, output_path=str(output_path))
+        )
+
+    assert result.artifact_path == str(output_path)
+    assert AiSbomDocument.model_validate_json(output_path.read_text()) == source
+
+
+def test_probe_auth_rejects_header_injection() -> None:
+    with pytest.raises(ValidationError):
+        SbomProbeAuthConfig(header_name="Authorization\r\nX-Leak", header_value="secret")

--- a/tests/sbom/test_repository_url_redaction.py
+++ b/tests/sbom/test_repository_url_redaction.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nuguard.common.url_sanitization import sanitize_repository_url
+from nuguard.sbom.config import AiSbomConfig
+from nuguard.sbom.extractor import AiSbomExtractor
+from nuguard.sbom.generator import SbomGenerator
+from nuguard.sbom.models import AiSbomDocument
+from nuguard.sbom.public_api import SbomGenerateRequest, generate_sbom
+
+_TOKEN = "ghp_super_secret_value"
+_AUTHENTICATED_URL = f"https://x-access-token:{_TOKEN}@github.com/org/repo.git"
+_DISPLAY_URL = "https://github.com/org/repo.git"
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (_AUTHENTICATED_URL, _DISPLAY_URL),
+        (
+            f"https://github.com/org/repo.git?ref=main&access_token={_TOKEN}",
+            "https://github.com/org/repo.git?ref=main&access_token=REDACTED",
+        ),
+        (_DISPLAY_URL, _DISPLAY_URL),
+    ],
+)
+def test_sanitize_repository_url(url: str, expected: str) -> None:
+    assert sanitize_repository_url(url) == expected
+
+
+def test_generator_uses_sanitized_source_ref() -> None:
+    generator = SbomGenerator()
+    received: dict[str, str | None] = {}
+
+    def fake_extract(
+        url: str,
+        ref: str,
+        config: AiSbomConfig,
+        cache_dir: str | Path | None = None,
+        source_ref: str | None = None,
+    ) -> AiSbomDocument:
+        received.update(url=url, source_ref=source_ref)
+        return AiSbomDocument(target=source_ref or url)
+
+    generator._extractor.extract_from_repo = fake_extract  # type: ignore[method-assign]
+    result = generator.from_repo(_AUTHENTICATED_URL)
+
+    assert received == {"url": _AUTHENTICATED_URL, "source_ref": _DISPLAY_URL}
+    assert result.target == _DISPLAY_URL
+    assert _TOKEN not in result.model_dump_json()
+
+
+def test_repository_cache_name_uses_url_path_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    extractor = AiSbomExtractor()
+    clone_destinations: list[Path] = []
+
+    monkeypatch.setattr(
+        extractor,
+        "_clone_repo",
+        lambda *, url, ref, dest: clone_destinations.append(dest),
+    )
+    monkeypatch.setattr(
+        extractor,
+        "extract_from_path",
+        lambda path, config, **kwargs: AiSbomDocument(target=kwargs["source_ref"]),
+    )
+
+    result = extractor.extract_from_repo(
+        f"{_AUTHENTICATED_URL}?ref=main&access_token={_TOKEN}",
+        "main",
+        AiSbomConfig(),
+        cache_dir=tmp_path,
+    )
+
+    assert clone_destinations == [tmp_path / "repo" / "repo"]
+    assert result.target.endswith("?ref=main&access_token=REDACTED")
+    assert _TOKEN not in result.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_public_result_uses_sanitized_source_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_from_repo(
+        self: SbomGenerator,
+        url: str,
+        ref: str = "main",
+        output: Path | None = None,
+    ) -> AiSbomDocument:
+        return AiSbomDocument(target=sanitize_repository_url(url))
+
+    monkeypatch.setattr(SbomGenerator, "from_repo", fake_from_repo)
+    result = await generate_sbom(SbomGenerateRequest(repo_url=_AUTHENTICATED_URL))
+
+    assert result.source_ref == _DISPLAY_URL
+    assert result.sbom.target == _DISPLAY_URL
+    assert _TOKEN not in result.model_dump_json()
+
+
+def test_clone_failure_redacts_url_logs_and_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    stderr = f"fatal: unable to access '{_AUTHENTICATED_URL}': denied".encode()
+
+    def fail_clone(*args: object, **kwargs: object) -> None:
+        raise subprocess.CalledProcessError(128, "git", stderr=stderr)
+
+    monkeypatch.setattr(subprocess, "run", fail_clone)
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        AiSbomExtractor._clone_repo(_AUTHENTICATED_URL, "main", tmp_path / "repo")
+
+    assert _TOKEN not in str(exc_info.value)
+    assert _DISPLAY_URL in str(exc_info.value)
+    assert _TOKEN not in caplog.text


### PR DESCRIPTION
## Summary

- add complete behavior-analysis streaming with ordered progress, heartbeat, cancellation, and sanitized terminal failures
- add public cognitive-policy parsing and existing-SBOM enrichment contracts
- prevent repository credentials and red-team authentication secrets from leaking through public Pydantic serialization
- add the Pydantic interface maintenance skill, schema contracts, documentation, and focused regression coverage

## Validation

- `uv run pytest tests/redteam/test_public_api.py tests/contracts/test_public_api_schema_contract.py -q` (36 passed)
- `uv run pytest tests/cli/test_redteam_format_output.py tests/redteam/test_public_api.py tests/contracts/test_public_api_schema_contract.py -q` (44 passed)
- `uv run pytest tests/redteam/ -q` (1077 passed, 6 skipped; 2 unrelated existing v2-removal failures)
- `uv run mypy nuguard/` (617 source files clean)
- changed-file Ruff and `git diff --check` pass
- full suite: 2274 passed, 39 skipped, 5 unrelated existing failures

The six locally regenerated application SBOM files are intentionally excluded from this PR.

Closes #491
Closes #492
Closes #493