### PR TITLE
fix(analysis): checkov title/evidence/dedup fixes and ATLAS asyncio fix (combines #477, #478, #479)

### DIFF
--- a/nuguard/analysis/plugins/checkov_scanner.py
+++ b/nuguard/analysis/plugins/checkov_scanner.py
@@ -90,6 +90,7 @@ class CheckovScannerPlugin(AnalysisPlugin):
         all_findings: list[dict[str, Any]] = []
         for path in iac_paths:
             all_findings.extend(_run_checkov(binary, path, config))
+        all_findings = _dedupe_findings(all_findings)
 
         status = "warning" if all_findings else "ok"
         message = (
@@ -105,6 +106,39 @@ class CheckovScannerPlugin(AnalysisPlugin):
             findings=all_findings,
             details={"total": len(all_findings), "scanned_paths": list(iac_paths)},
         )
+
+
+def _dedupe_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse findings for the same rule + affected component.
+
+    Checkov has no CLI flag for this (checked: no dedup/uniqueness option
+    exists). The same (rule_id, resource-address) pair can legitimately be
+    reported more than once — e.g. two different files each defining a
+    Terraform resource with the same address — which the report then
+    displays as repeated, identical-looking finding blocks since it groups
+    by the bare resource address with no file qualifier. Rather than drop
+    the duplicate (losing the fact that a second file also has the issue),
+    merge their ``evidence`` (file:line) values so a reader still sees every
+    affected location. remediation is a deterministic function of rule_id
+    alone (checkov's guideline URL doesn't vary per-resource), so rule_id
+    equality already implies remediation equality.
+    """
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    order: list[tuple[str, str]] = []
+    for f in findings:
+        key = (f["rule_id"], f["affected"][0] if f["affected"] else "")
+        if key not in merged:
+            merged[key] = dict(f)
+            order.append(key)
+            continue
+        existing = merged[key]
+        new_evidence = f.get("evidence")
+        if new_evidence:
+            locations = existing["evidence"].split("; ") if existing.get("evidence") else []
+            if new_evidence not in locations:
+                locations.append(new_evidence)
+                existing["evidence"] = "; ".join(locations)
+    return [merged[k] for k in order]
 
 
 def _collect_iac_paths(sbom: dict[str, Any], config: dict[str, Any]) -> set[str]:

--- a/nuguard/analysis/plugins/checkov_scanner.py
+++ b/nuguard/analysis/plugins/checkov_scanner.py
@@ -229,13 +229,17 @@ def _parse_checkov_output(data: Any, scan_path: str) -> list[dict[str, Any]]:
             line_range = check_result.get("file_line_range") or []
             location = f"{file_path}:{line_range[0]}" if line_range else file_path
             display_resource = location if _HEX_HASH_RE.match(resource) else (resource or location)
+            # Omit evidence when it would just repeat the affected-component
+            # value (the CKV_SECRET_* hash-avoidance case already shows it).
+            evidence = None if display_resource == location else location
 
             findings.append({
                 "rule_id":     check_id,
-                "title":       name,
+                "title":       f"[IaC misconfiguration] {name} — {display_resource}",
                 "description": f"IaC misconfiguration: {name} in `{display_resource}`",
                 "severity":    severity,
                 "affected":    [display_resource],
+                "evidence":    evidence,
                 "remediation": guideline,
                 "url":         guideline,
                 "source":      "checkov",

--- a/nuguard/analysis/plugins/checkov_scanner.py
+++ b/nuguard/analysis/plugins/checkov_scanner.py
@@ -20,6 +20,7 @@ Usage
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -39,6 +40,11 @@ _SEV_MAP: dict[str, str] = {
     "LOW":      "LOW",
     "UNKNOWN":  "LOW",
 }
+
+# Checkov's secrets runner sets `resource` to a hex hash of the detected
+# secret rather than a real resource address; matched so we can fall back
+# to the file location instead of surfacing the hash as a display name.
+_HEX_HASH_RE = re.compile(r"^[0-9a-f]{20,}(:[0-9a-f]{20,})?$", re.IGNORECASE)
 
 
 def _checkov_path() -> str | None:
@@ -211,22 +217,25 @@ def _parse_checkov_output(data: Any, scan_path: str) -> list[dict[str, Any]]:
             continue
         for check_result in (entry.get("results", {}).get("failed_checks") or []):
             check_id  = check_result.get("check_id", "")
-            check_obj = check_result.get("check", {})
-            name      = check_obj.get("name", check_id)
+            name      = check_result.get("check_name", check_id)
             resource  = check_result.get("resource", "")
             file_path = check_result.get("file_path", scan_path)
-            guideline = check_obj.get("guideline", "")
+            guideline = check_result.get("guideline", "")
             severity  = _SEV_MAP.get(
-                str(check_result.get("severity") or check_obj.get("severity") or "MEDIUM").upper(),
+                str(check_result.get("severity") or "MEDIUM").upper(),
                 "MEDIUM",
             )
+
+            line_range = check_result.get("file_line_range") or []
+            location = f"{file_path}:{line_range[0]}" if line_range else file_path
+            display_resource = location if _HEX_HASH_RE.match(resource) else (resource or location)
 
             findings.append({
                 "rule_id":     check_id,
                 "title":       name,
-                "description": f"IaC misconfiguration: {name} in `{resource}`",
+                "description": f"IaC misconfiguration: {name} in `{display_resource}`",
                 "severity":    severity,
-                "affected":    [resource] if resource else [file_path],
+                "affected":    [display_resource],
                 "remediation": guideline,
                 "url":         guideline,
                 "source":      "checkov",

--- a/nuguard/analysis/static_analyzer.py
+++ b/nuguard/analysis/static_analyzer.py
@@ -314,7 +314,9 @@ class StaticAnalyzer:
         # skip_nga=True so the annotator does not re-run NGA rules; Step 1
         # already annotated NGA findings with ATLAS techniques directly.
         if self.enable_atlas:
-            atlas = self._run_atlas_native(sbom_dict, sbom_graph=sbom_graph)
+            atlas = await asyncio.to_thread(
+                self._run_atlas_native, sbom_dict, sbom_graph=sbom_graph
+            )
             all_findings.extend(atlas)
             self.tool_status["atlas"] = {"status": "ok", "findings": str(len(atlas))}
         else:

--- a/nuguard/cli/commands/analyze.py
+++ b/nuguard/cli/commands/analyze.py
@@ -1080,6 +1080,8 @@ def _render_markdown(
                     lines += [f"**Remediation:** {f.remediation}  ", ""]
                 if f.affected_component:
                     lines += [f"**Affected Components:** `{_component_label(f)}`  ", ""]
+                if f.evidence:
+                    lines += [f"**Evidence:** `{f.evidence}`  ", ""]
                 lines += [f"**Source:** {sources_str}  ", ""]
                 framework = _framework_mapping_text(
                     f.owasp_llm_ref, f.owasp_asi_ref, f.mitre_atlas_technique

--- a/tests/analysis/test_checkov_scanner.py
+++ b/tests/analysis/test_checkov_scanner.py
@@ -1,0 +1,97 @@
+"""Tests for the Checkov IaC scanner plugin's JSON parsing.
+
+Covers ``_parse_checkov_output`` against fixtures shaped like real Checkov
+output (top-level ``check_name``/``guideline``/``severity`` — no nested
+``"check"`` object, which never exists in actual Checkov JSON).
+"""
+
+from __future__ import annotations
+
+from nuguard.analysis.plugins.checkov_scanner import _parse_checkov_output
+
+
+def _base_check_result(**overrides: object) -> dict:
+    result = {
+        "check_id": "CKV_AWS_150",
+        "check_name": "Ensure that S3 buckets are encrypted with KMS by default",
+        "check_result": {"result": "FAILED"},
+        "resource": "aws_s3_bucket.example",
+        "file_path": "/main.tf",
+        "file_line_range": [10, 15],
+        "guideline": "https://docs.example.com/CKV_AWS_150",
+        "severity": "HIGH",
+    }
+    result.update(overrides)
+    return result
+
+
+def _checkov_output(*check_results: dict) -> dict:
+    return {"results": {"failed_checks": list(check_results)}}
+
+
+def test_resolves_real_check_name_not_rule_id():
+    data = _checkov_output(_base_check_result())
+    findings = _parse_checkov_output(data, "/main.tf")
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["rule_id"] == "CKV_AWS_150"
+    assert finding["title"] == "Ensure that S3 buckets are encrypted with KMS by default"
+    assert finding["title"] != finding["rule_id"]
+
+
+def test_populates_remediation_and_severity_from_top_level_fields():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["remediation"] == "https://docs.example.com/CKV_AWS_150"
+    assert finding["url"] == "https://docs.example.com/CKV_AWS_150"
+    assert finding["severity"] == "HIGH"
+
+
+def test_normal_resource_used_as_affected_component():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["affected"] == ["aws_s3_bucket.example"]
+    assert "aws_s3_bucket.example" in finding["description"]
+
+
+def test_secret_hash_resource_falls_back_to_file_location():
+    secret_result = _base_check_result(
+        check_id="CKV_SECRET_13",
+        check_name="CKV_SECRET_13",
+        resource="967649db3de73fc65f333fcbdf3fe58e334bcc7a",
+        file_path="/app/config.py",
+        file_line_range=[42, 42],
+        guideline="",
+    )
+    data = _checkov_output(secret_result)
+    finding = _parse_checkov_output(data, "/app/config.py")[0]
+
+    assert finding["affected"] == ["/app/config.py:42"]
+    assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["affected"][0]
+    assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["description"]
+
+
+def test_missing_line_range_falls_back_to_bare_file_path():
+    secret_result = _base_check_result(
+        check_id="CKV_SECRET_6",
+        check_name="CKV_SECRET_6",
+        resource="a" * 40,
+        file_path="/app/settings.py",
+        file_line_range=[],
+    )
+    data = _checkov_output(secret_result)
+    finding = _parse_checkov_output(data, "/app/settings.py")[0]
+
+    assert finding["affected"] == ["/app/settings.py"]
+
+
+def test_missing_check_name_falls_back_to_check_id():
+    check_result = _base_check_result()
+    del check_result["check_name"]
+    data = _checkov_output(check_result)
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["title"] == "CKV_AWS_150"

--- a/tests/analysis/test_checkov_scanner.py
+++ b/tests/analysis/test_checkov_scanner.py
@@ -36,8 +36,18 @@ def test_resolves_real_check_name_not_rule_id():
     assert len(findings) == 1
     finding = findings[0]
     assert finding["rule_id"] == "CKV_AWS_150"
-    assert finding["title"] == "Ensure that S3 buckets are encrypted with KMS by default"
+    assert "Ensure that S3 buckets are encrypted with KMS by default" in finding["title"]
     assert finding["title"] != finding["rule_id"]
+
+
+def test_title_includes_category_and_affected_resource():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["title"] == (
+        "[IaC misconfiguration] Ensure that S3 buckets are encrypted with "
+        "KMS by default — aws_s3_bucket.example"
+    )
 
 
 def test_populates_remediation_and_severity_from_top_level_fields():
@@ -57,6 +67,13 @@ def test_normal_resource_used_as_affected_component():
     assert "aws_s3_bucket.example" in finding["description"]
 
 
+def test_evidence_populated_with_file_and_line_for_normal_resource_check():
+    data = _checkov_output(_base_check_result())
+    finding = _parse_checkov_output(data, "/main.tf")[0]
+
+    assert finding["evidence"] == "/main.tf:10"
+
+
 def test_secret_hash_resource_falls_back_to_file_location():
     secret_result = _base_check_result(
         check_id="CKV_SECRET_13",
@@ -72,6 +89,8 @@ def test_secret_hash_resource_falls_back_to_file_location():
     assert finding["affected"] == ["/app/config.py:42"]
     assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["affected"][0]
     assert "967649db3de73fc65f333fcbdf3fe58e334bcc7a" not in finding["description"]
+    # Evidence would just repeat the affected-component value here — omitted.
+    assert finding["evidence"] is None
 
 
 def test_missing_line_range_falls_back_to_bare_file_path():
@@ -94,4 +113,4 @@ def test_missing_check_name_falls_back_to_check_id():
     data = _checkov_output(check_result)
     finding = _parse_checkov_output(data, "/main.tf")[0]
 
-    assert finding["title"] == "CKV_AWS_150"
+    assert finding["title"] == "[IaC misconfiguration] CKV_AWS_150 — aws_s3_bucket.example"

--- a/tests/analysis/test_checkov_scanner.py
+++ b/tests/analysis/test_checkov_scanner.py
@@ -7,7 +7,7 @@ output (top-level ``check_name``/``guideline``/``severity`` — no nested
 
 from __future__ import annotations
 
-from nuguard.analysis.plugins.checkov_scanner import _parse_checkov_output
+from nuguard.analysis.plugins.checkov_scanner import _dedupe_findings, _parse_checkov_output
 
 
 def _base_check_result(**overrides: object) -> dict:
@@ -114,3 +114,59 @@ def test_missing_check_name_falls_back_to_check_id():
     finding = _parse_checkov_output(data, "/main.tf")[0]
 
     assert finding["title"] == "[IaC misconfiguration] CKV_AWS_150 — aws_s3_bucket.example"
+
+
+def _finding(**overrides: object) -> dict:
+    base = {
+        "rule_id": "CKV_AWS_150",
+        "title": "[IaC misconfiguration] Ensure deletion protection — aws_lb.juice_shop",
+        "description": "IaC misconfiguration: Ensure deletion protection in `aws_lb.juice_shop`",
+        "severity": "MEDIUM",
+        "affected": ["aws_lb.juice_shop"],
+        "evidence": "terraform/networking.tf:12",
+        "remediation": "https://docs.example.com/CKV_AWS_150",
+        "url": "https://docs.example.com/CKV_AWS_150",
+        "source": "checkov",
+        "scan_target": "/repo",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_dedupe_collapses_same_rule_and_component_merging_evidence():
+    findings = [
+        _finding(evidence="terraform/networking.tf:12"),
+        _finding(evidence="infrastructure/terraform/networking.tf:12"),
+    ]
+
+    deduped = _dedupe_findings(findings)
+
+    assert len(deduped) == 1
+    assert deduped[0]["evidence"] == (
+        "terraform/networking.tf:12; infrastructure/terraform/networking.tf:12"
+    )
+
+
+def test_dedupe_leaves_distinct_components_and_rules_untouched():
+    findings = [
+        _finding(rule_id="CKV_AWS_150", affected=["aws_lb.juice_shop"]),
+        _finding(rule_id="CKV_AWS_91", affected=["aws_lb.juice_shop"]),
+        _finding(rule_id="CKV_AWS_150", affected=["aws_lb.other"]),
+    ]
+
+    deduped = _dedupe_findings(findings)
+
+    assert len(deduped) == 3
+
+
+def test_dedupe_handles_missing_or_identical_evidence_without_artifacts():
+    findings = [
+        _finding(evidence="terraform/networking.tf:12"),
+        _finding(evidence="terraform/networking.tf:12"),  # exact duplicate
+        _finding(evidence=None),
+    ]
+
+    deduped = _dedupe_findings(findings)
+
+    assert len(deduped) == 1
+    assert deduped[0]["evidence"] == "terraform/networking.tf:12"

--- a/tests/apps/owasp-juice-shop/nuguard-azure.yaml
+++ b/tests/apps/owasp-juice-shop/nuguard-azure.yaml
@@ -173,16 +173,16 @@ redteam:
 
   # LLM for attack-payload generation (must tolerate adversarial content)
   llm:
-    model: azure/DeepSeek-V4-Pro    # any LiteLLM model string (openai/gpt-4o, etc.)
+    model: azure/${AZURE_DEEPSEEK_MODEL_NAME}    # any LiteLLM model string (openai/gpt-4o, etc.)
     api_key: ${AZURE_DEEPSEEK_KEY}
     api_base: ${AZURE_DEEPSEEK_ENDPOINT}     # optional override for Azure OpenAI endpoint URL
 
   # LLM for response evaluation and finding summarisation
   eval_llm:
-  model: azure/${AZURE_DEEPSEEK_MODEL_NAME}    # any LiteLLM model string (openai/gpt-4o, etc.)
-  api_key: ${AZURE_DEEPSEEK_KEY}     # never put keys here; use env var interpolation
-  api_base: ${AZURE_DEEPSEEK_ENDPOINT}
-  
+    model: azure/${AZURE_DEEPSEEK_MODEL_NAME}    # any LiteLLM model string (openai/gpt-4o, etc.)
+    api_key: ${AZURE_DEEPSEEK_KEY}     # never put keys here; use env var interpolation
+    api_base: ${AZURE_DEEPSEEK_ENDPOINT}
+
   # MCP server hostnames treated as trusted.
   # Servers absent from this list are classified 'untrusted' and eligible
   # as toxic-flow attack sources.


### PR DESCRIPTION
## Summary
Combines three stacked Checkov-analysis fixes into a single PR rebased on latest `develop`, replacing #477, #478, #479 (which were stacked on each other and had gone stale/out of sync with `develop`):

- **#477** — `_parse_checkov_output` read a nested `"check"` object that doesn't exist in real Checkov JSON, collapsing every finding title to the bare rule ID and dropping remediation guideline URLs/severity; `CKV_SECRET_*` findings leaked a raw secret hash into "Affected Components" instead of a canonical file location. Also fixes ATLAS LLM enrichment silently failing on every `nuguard scan` run (`_run_atlas_native` was called synchronously from within an already-running event loop, causing a swallowed nested-`asyncio.run()` RuntimeError), plus a hardcoded wrong Azure DeepSeek deployment name and broken YAML indentation (`eval_llm` silently parsed as `None`) in the juice-shop Azure test config.
- **#478** — Richer Checkov titles (`[IaC misconfiguration] {check_name} — {resource}`) and a new `Evidence: file_path:line` line in the markdown report, using the previously-unused `Finding.evidence` field.
- **#479** — Dedupes Checkov findings on `(rule_id, affected component)` when the same resource address is defined in multiple files, merging `evidence` from every duplicate instead of dropping information.

## Test plan
- [x] `uv run ruff check nuguard/`
- [x] `uv run pytest tests/analysis/test_checkov_scanner.py -q` — 11 passed
- [x] Merged cleanly onto current `develop` tip with no conflicts

Closes #475
Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gt5YoGPkiMeeWvmpUq43Q