### PR TITLE
perf(redteam): loosen phase gate to destructive-last; isolate guided concurrency

### DIFF
--- a/nuguard/redteam/executor/orchestrator.py
+++ b/nuguard/redteam/executor/orchestrator.py
@@ -1691,6 +1691,13 @@ class RedteamOrchestrator:
         acquired the semaphore.
         """
         sem = asyncio.Semaphore(self._concurrency)
+        # Guided multi-turn conversations (up to `guided_max_turns` turns, each
+        # doing an LLM director call + a target HTTP call + an LLM assess
+        # call) hold a slot for their entire multi-turn lifetime. Gating them
+        # under a dedicated, independently-sized semaphore keeps a handful of
+        # slow guided scenarios from starving fast static-chain scenarios out
+        # of `sem`'s slots for the whole run.
+        guided_sem = asyncio.Semaphore(self._guided_concurrency)
         abort_event = asyncio.Event()
         # Separate abort event for direct-HTTP endpoint-probe outages — only
         # consulted by direct-HTTP-only scenarios (see
@@ -1780,7 +1787,9 @@ class RedteamOrchestrator:
             if _is_direct_http and endpoint_abort_event.is_set():
                 return [], (scenario.title, scenario.goal_type.value, False), _skipped_record("target_unreachable")
 
-            async with sem:
+            _is_guided = scenario.guided_conversation is not None and guided_executor is not None
+            _slot = guided_sem if _is_guided else sem
+            async with _slot:
                 # Re-check after acquiring the semaphore — another coroutine may
                 # have tripped the circuit while we were waiting.
                 if abort_event.is_set():
@@ -2144,77 +2153,100 @@ class RedteamOrchestrator:
             )
             return result
 
-        _log.info(
-            "Running %d scenarios across phased batches (concurrency=%d)",
-            len(active), self._concurrency,
-        )
-
-        # Hard phase gate: dispatch scenarios in ascending attack_phase
-        # batches, each batch fully completing before the next phase's batch
-        # starts. Previously the whole sorted list was fired through one
-        # asyncio.gather, so phase order was only a scheduling hint — once
-        # >= concurrency scenarios were in flight, a late-phase (e.g.
-        # destructive, phase 9) scenario could acquire a freed semaphore slot
-        # before an earlier-phase (recon/boundary-mapping) scenario elsewhere
-        # had finished. Batching by phase makes the boundary a real barrier
-        # while intra-phase concurrency (via the shared `sem`) is unchanged.
         indexed_active = list(enumerate(active))
         results: list[tuple[list[Finding], tuple[str, str, bool], ScenarioRecord]] = []
         _progressive = self._mode == "progressive"
         _halt_order = {"critical": 0, "high": 1}
         _halt_threshold = _halt_order.get(self._progressive_halt_on_severity, None)
-        batch_start = 0
-        while batch_start < len(indexed_active):
-            phase = indexed_active[batch_start][1].attack_phase
-            batch_end = batch_start
-            while (
-                batch_end < len(indexed_active)
-                and indexed_active[batch_end][1].attack_phase == phase
-            ):
-                batch_end += 1
-            batch = indexed_active[batch_start:batch_end]
-            _log.info("Phase %d: dispatching %d scenario(s)", phase, len(batch))
-            if _progressive:
+
+        if _progressive:
+            _log.info(
+                "Running %d scenarios across phased batches (concurrency=%d, progressive mode)",
+                len(active), self._concurrency,
+            )
+            # Progressive mode keeps a real per-attack_phase barrier: each
+            # phase batch runs strictly sequentially and the run can halt
+            # between phases based on `redteam.progressive.halt_on_severity`
+            # (docs/claude-redteam-3.md §4). This is a deliberate feature —
+            # not a scheduling artifact — so it is untouched by the
+            # concurrent-mode restructuring below.
+            batch_start = 0
+            while batch_start < len(indexed_active):
+                phase = indexed_active[batch_start][1].attack_phase
+                batch_end = batch_start
+                while (
+                    batch_end < len(indexed_active)
+                    and indexed_active[batch_end][1].attack_phase == phase
+                ):
+                    batch_end += 1
+                batch = indexed_active[batch_start:batch_end]
+                _log.info("Phase %d: dispatching %d scenario(s)", phase, len(batch))
                 # Strictly sequential — no two scenarios run at once, so the
                 # target application is never asked two adversarial things
                 # "at once" within a phase either (docs/claude-redteam-3.md §4).
                 batch_results = [await _run_and_emit(s, idx) for idx, s in batch]
-            else:
-                batch_results = await asyncio.gather(*(_run_and_emit(s, idx) for idx, s in batch))
-            results.extend(batch_results)
-            batch_start = batch_end
+                results.extend(batch_results)
+                batch_start = batch_end
 
-            if _progressive and _halt_threshold is not None:
-                from nuguard.redteam.risk_engine.risk_scorer import highest_severity
+                if _halt_threshold is not None:
+                    from nuguard.redteam.risk_engine.risk_scorer import highest_severity
 
-                batch_findings = [f for new_findings, _, _ in batch_results for f in new_findings]
-                worst = highest_severity(batch_findings)
-                worst_rank = _halt_order.get(worst.value if worst else "", 99)
-                if worst_rank <= _halt_threshold:
-                    _log.info(
-                        "Progressive mode: halting after phase %d — %s finding confirmed "
-                        "(redteam.progressive.halt_on_severity=%s)",
-                        phase, worst.value if worst else "", self._progressive_halt_on_severity,
-                    )
-                    for _, s in indexed_active[batch_start:]:
-                        results.append(
-                            (
-                                [],
-                                (s.title, s.goal_type.value, False),
-                                ScenarioRecord(
-                                    title=s.title,
-                                    goal_type=s.goal_type.value,
-                                    scenario_type=s.scenario_type.value,
-                                    description=s.description,
-                                    impact_score=s.impact_score,
-                                    affected="",
-                                    chain_status="skipped:halted_on_severity",
-                                    had_finding=False,
-                                    steps=[],
-                                ),
-                            )
+                    batch_findings = [f for new_findings, _, _ in batch_results for f in new_findings]
+                    worst = highest_severity(batch_findings)
+                    worst_rank = _halt_order.get(worst.value if worst else "", 99)
+                    if worst_rank <= _halt_threshold:
+                        _log.info(
+                            "Progressive mode: halting after phase %d — %s finding confirmed "
+                            "(redteam.progressive.halt_on_severity=%s)",
+                            phase, worst.value if worst else "", self._progressive_halt_on_severity,
                         )
-                    break
+                        for _, s in indexed_active[batch_start:]:
+                            results.append(
+                                (
+                                    [],
+                                    (s.title, s.goal_type.value, False),
+                                    ScenarioRecord(
+                                        title=s.title,
+                                        goal_type=s.goal_type.value,
+                                        scenario_type=s.scenario_type.value,
+                                        description=s.description,
+                                        impact_score=s.impact_score,
+                                        affected="",
+                                        chain_status="skipped:halted_on_severity",
+                                        had_finding=False,
+                                        steps=[],
+                                    ),
+                                )
+                            )
+                        break
+        else:
+            # Concurrent mode: dispatch in two groups — all non-destructive
+            # scenarios, then all destructive scenarios — instead of a hard
+            # per-attack_phase barrier. The only correctness invariant that
+            # actually matters is that destructive scenarios (cancel, delete,
+            # close, ...) must not run before non-destructive scenarios that
+            # need intact account/data state to probe meaningfully; the
+            # finer 1-9 attack_phase numbering is a reporting/narrative
+            # order (see nuguard/redteam/scenarios/generator.py docstring),
+            # not a data dependency between phases. Gating on every phase
+            # boundary left `self._concurrency` slots mostly idle whenever a
+            # phase had fewer scenarios than the configured concurrency, and
+            # turned any single straggler's retry/backoff tail into a stall
+            # for the whole run instead of just that one scenario.
+            non_destructive = [(idx, s) for idx, s in indexed_active if not _is_destructive_scenario(s)]
+            destructive = [(idx, s) for idx, s in indexed_active if _is_destructive_scenario(s)]
+            _log.info(
+                "Running %d scenarios (%d non-destructive, %d destructive; concurrency=%d, "
+                "guided_concurrency=%d)",
+                len(active), len(non_destructive), len(destructive),
+                self._concurrency, self._guided_concurrency,
+            )
+            for group_name, group in (("non-destructive", non_destructive), ("destructive", destructive)):
+                if not group:
+                    continue
+                _log.info("Dispatching %d %s scenario(s)", len(group), group_name)
+                batch_results = await asyncio.gather(*(_run_and_emit(s, idx) for idx, s in group))
+                results.extend(batch_results)
 
         findings: list[Finding] = []
         executed: list[tuple[str, str, bool]] = []

--- a/tests/redteam/test_phase_gating.py
+++ b/tests/redteam/test_phase_gating.py
@@ -1,11 +1,14 @@
-"""Tests for hard phase-gating in RedteamOrchestrator._run_scenarios.
+"""Tests for scenario dispatch grouping in RedteamOrchestrator._run_scenarios.
 
-Covers the escalation-order fix: scenarios must be dispatched in ascending
-``attack_phase`` batches, with each batch fully completing before the next
-phase's batch is even created — not just sorted-then-fired-through-one-
-asyncio.gather, which only made phase order a scheduling hint once
->= concurrency scenarios were in flight (see
-nuguard/redteam/executor/orchestrator.py::_run_scenarios).
+In concurrent mode (the platform default), scenarios are no longer gated by
+the fine-grained 1-9 ``attack_phase`` barrier — they're dispatched in two
+groups: all non-destructive scenarios, then all destructive scenarios
+(``_is_destructive_scenario``). That's the only ordering invariant with a
+real correctness reason (destructive scenarios must not run before
+non-destructive ones that need intact account/data state). The strict
+per-``attack_phase`` barrier is retained only for ``mode="progressive"``,
+which needs it for its halt-on-severity gate (docs/claude-redteam-3.md §4)
+— see ``tests/redteam/test_progressive_sequential_execution.py``.
 """
 from __future__ import annotations
 
@@ -16,23 +19,25 @@ import pytest
 from nuguard.config import RedteamFindingTriggers
 from nuguard.models.exploit_chain import ExploitChain, GoalType, ScenarioType
 from nuguard.redteam.executor.orchestrator import RedteamOrchestrator
+from nuguard.redteam.models.guided_conversation import GuidedConversation
 from nuguard.redteam.scenarios.scenario_types import AttackScenario
 from nuguard.redteam.target.session import AttackSession
 from nuguard.sbom.models import AiSbomDocument
 
 
-def _orchestrator() -> RedteamOrchestrator:
+def _orchestrator(*, concurrency: int = 5, guided_concurrency: int = 1) -> RedteamOrchestrator:
     sbom = AiSbomDocument(target="unit-test", nodes=[], edges=[])
     return RedteamOrchestrator(
         sbom=sbom,
         target_url="http://localhost:3000",
         finding_triggers=RedteamFindingTriggers(),
         codegen_escalation_enabled=False,
-        concurrency=5,
+        concurrency=concurrency,
+        guided_concurrency=guided_concurrency,
     )
 
 
-def _scenario(chain_id: str, attack_phase: int) -> AttackScenario:
+def _scenario(chain_id: str, attack_phase: int, title: str | None = None) -> AttackScenario:
     chain = ExploitChain(
         chain_id=chain_id,
         goal_type=GoalType.PROMPT_DRIVEN_THREAT,
@@ -43,7 +48,7 @@ def _scenario(chain_id: str, attack_phase: int) -> AttackScenario:
         scenario_id=chain_id,
         goal_type=GoalType.PROMPT_DRIVEN_THREAT,
         scenario_type=ScenarioType.SKELETON_KEY,
-        title=f"Scenario {chain_id}",
+        title=title or f"Scenario {chain_id}",
         description="unit test scenario",
         target_node_ids=["node-1"],
         chain=chain,
@@ -80,23 +85,50 @@ class _FakeExecutor:
 
 
 @pytest.mark.asyncio
-async def test_phase_9_never_starts_before_phase_1_completes() -> None:
+async def test_destructive_never_starts_before_non_destructive_completes() -> None:
+    """The one real ordering invariant in concurrent mode: destructive scenarios
+    (title/description matching a destructive keyword) must not start until every
+    non-destructive scenario has finished — regardless of attack_phase."""
     orchestrator = _orchestrator()
     scenarios = [
-        _scenario("phase1-a", attack_phase=1),
-        _scenario("phase1-b", attack_phase=1),
-        _scenario("phase9-fast", attack_phase=9),
+        _scenario("recon-a", attack_phase=1, title="Recon Probe A"),
+        _scenario("recon-b", attack_phase=1, title="Recon Probe B"),
+        # Deliberately an *earlier* attack_phase than the recon scenarios to
+        # prove destructive-last is enforced independent of phase number.
+        _scenario("destructive-fast", attack_phase=1, title="Cancel Subscription Attack"),
     ]
     events: list[str] = []
-    executor = _FakeExecutor(events, slow_chain_ids={"phase1-a", "phase1-b"})
+    executor = _FakeExecutor(events, slow_chain_ids={"recon-a", "recon-b"})
 
     await orchestrator._run_scenarios(scenarios, executor)  # type: ignore[arg-type]
 
+    destructive_start_idx = events.index("destructive-fast:start")
+    recon_a_end_idx = events.index("recon-a:end")
+    recon_b_end_idx = events.index("recon-b:end")
+    assert destructive_start_idx > recon_a_end_idx
+    assert destructive_start_idx > recon_b_end_idx
+
+
+@pytest.mark.asyncio
+async def test_cross_phase_non_destructive_scenarios_run_concurrently() -> None:
+    """Non-destructive scenarios in DIFFERENT attack_phases must overlap now —
+    the fine-grained 1-9 phase barrier is loosened to a single non-destructive
+    batch in concurrent mode (only destructive-last is a real invariant)."""
+    orchestrator = _orchestrator()
+    scenarios = [
+        _scenario("phase1-a", attack_phase=1),
+        _scenario("phase9-fast", attack_phase=9),
+    ]
+    events: list[str] = []
+    executor = _FakeExecutor(events, slow_chain_ids={"phase1-a"})
+
+    await orchestrator._run_scenarios(scenarios, executor)  # type: ignore[arg-type]
+
+    # The fast phase-9 scenario should start (and can even finish) while the
+    # slow phase-1 scenario is still running — no phase barrier between them.
     phase9_start_idx = events.index("phase9-fast:start")
     phase1a_end_idx = events.index("phase1-a:end")
-    phase1b_end_idx = events.index("phase1-b:end")
-    assert phase9_start_idx > phase1a_end_idx
-    assert phase9_start_idx > phase1b_end_idx
+    assert phase9_start_idx < phase1a_end_idx
 
 
 @pytest.mark.asyncio
@@ -135,6 +167,74 @@ async def test_all_scenarios_produce_results_across_phases() -> None:
     assert len(executed) == 3
     assert len(records) == 3
     assert {e[0] for e in executed} == {"Scenario phase1-a", "Scenario phase5-a", "Scenario phase9-a"}
+
+
+def _guided_scenario(chain_id: str, attack_phase: int = 1) -> AttackScenario:
+    return AttackScenario(
+        scenario_id=chain_id,
+        goal_type=GoalType.PROMPT_DRIVEN_THREAT,
+        scenario_type=ScenarioType.SKELETON_KEY,
+        title=f"Guided {chain_id}",
+        description="unit test guided scenario",
+        target_node_ids=["node-1"],
+        chain=None,
+        guided_conversation=GuidedConversation(
+            conversation_id=chain_id,
+            goal_type=GoalType.PROMPT_DRIVEN_THREAT,
+            goal_description="test goal",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_guided_scenarios_use_their_own_concurrency_slot(monkeypatch) -> None:
+    """A slow guided scenario must not block a fast static-chain scenario out of
+    `sem` — guided scenarios are gated by the separate `guided_sem`
+    (sized by `guided_concurrency`), not the shared HTTP semaphore."""
+    events: list[str] = []
+
+    async def _fake_run_guided_scenario(self, scenario, guided_executor, affected, variation_idx=0):
+        events.append(f"{scenario.scenario_id}:start")
+        await asyncio.sleep(0.05)
+        events.append(f"{scenario.scenario_id}:end")
+        return [], (scenario.title, scenario.goal_type.value, False), _record(scenario)
+
+    def _record(scenario: AttackScenario):
+        from nuguard.redteam.executor.orchestrator import ScenarioRecord
+        return ScenarioRecord(
+            title=scenario.title,
+            goal_type=scenario.goal_type.value,
+            scenario_type=scenario.scenario_type.value,
+            description=scenario.description,
+            impact_score=scenario.impact_score,
+            affected="",
+            chain_status="completed",
+            had_finding=False,
+        )
+
+    monkeypatch.setattr(
+        RedteamOrchestrator, "_run_guided_scenario", _fake_run_guided_scenario,
+    )
+
+    # concurrency=1 means the shared `sem` can only hold ONE scenario at a
+    # time — if the guided scenario shared that semaphore, the fast static
+    # scenario would be blocked behind it for the full 0.05s sleep.
+    orchestrator = _orchestrator(concurrency=1, guided_concurrency=1)
+    scenarios = [_guided_scenario("guided-a"), _scenario("static-fast", attack_phase=1)]
+    static_executor = _FakeExecutor(events, slow_chain_ids=set())
+
+    await orchestrator._run_scenarios(
+        scenarios, static_executor, guided_executor=object(),  # type: ignore[arg-type]
+    )
+
+    # The fast static scenario must complete while the slow guided scenario
+    # is still mid-flight (holding its own `guided_sem` slot) — proof they
+    # aren't contending for the same semaphore. If they shared one semaphore
+    # with concurrency=1, "static-fast" couldn't even start until "guided-a"
+    # released its slot, so its "end" event would come after guided-a's.
+    guided_end_idx = events.index("guided-a:end")
+    static_end_idx = events.index("static-fast:end")
+    assert static_end_idx < guided_end_idx
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes #505 (parts 1 and 2 — the phase-gating stall and dead `guided_concurrency`
param). Part 3 (scenario-generation prompt cache wiring) lives on the platform
side (NuGuard-app), not here — nuguard's caches themselves are unchanged.

- `RedteamOrchestrator._run_scenarios` (concurrent mode): the hard
  per-`attack_phase` gate is loosened to a 2-group barrier — all
  non-destructive scenarios, then all destructive scenarios — instead of
  stalling at every one of the 9 phase boundaries. `mode="progressive"`'s
  strict per-phase halt-on-severity loop is untouched.
- Guided multi-turn conversations now acquire a dedicated `guided_sem`
  (sized by the previously-dead `guided_concurrency` param) instead of the
  shared `sem`, so they can no longer starve fast static-chain scenarios
  out of concurrency slots for their entire multi-turn lifetime.

## Test plan
- [x] `uv run pytest tests/redteam/ -v` — 1081 passed, 6 skipped
- [x] `uv run pytest tests/ -q` (full suite) — 2288 passed, 40 skipped
- [x] `uv run ruff check nuguard/` — clean
- [x] `uv run mypy nuguard/` — clean (617 source files)
- [x] `tests/redteam/test_phase_gating.py` updated/extended to cover the new
      destructive-last invariant, cross-phase concurrency, and guided/static
      semaphore isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SR8EHeahyFFr334Gia6bq5