### PR TITLE
fix(redteam): self-heal schema errors on HTTP 400, not just 422

### DIFF
--- a/nuguard/common/target_client_builder.py
+++ b/nuguard/common/target_client_builder.py
@@ -366,10 +366,10 @@ def build_target_app_client(
         explicitly_set: Set of config field names that were *explicitly* provided
             by the user (e.g. Pydantic ``model_fields_set``).  Discovery only
             overrides values that are *not* in this set.
-        heal_llm: Optional LLM client used to self-heal a 422 schema-validation
-            error by inferring the missing request field(s) from the error
-            body (see ``TargetAppClient._attempt_422_heal``). None disables
-            self-healing.
+        heal_llm: Optional LLM client used to self-heal a schema-validation
+            error (HTTP 400 or 422) by inferring the missing request field(s)
+            from the error body (see ``TargetAppClient._attempt_schema_heal``).
+            None disables self-healing.
 
     Returns:
         A fully configured :class:`TargetAppClient` instance.  Check

--- a/nuguard/redteam/target/client.py
+++ b/nuguard/redteam/target/client.py
@@ -34,11 +34,11 @@ _adk_fallback_warned: set[str] = set()
 DEFAULT_TIMEOUT = 30.0
 
 # Cap on how many times a single TargetAppClient will ask the LLM to repair
-# a 422 body shape. Bounded low: this is meant to fix a one-off config gap
-# (a required field the auto-discovered chat payload doesn't know about),
-# not to iteratively hill-climb an arbitrary schema at LLM-call expense on
-# every scenario.
-MAX_422_HEAL_ATTEMPTS = 2
+# a schema/validation error (HTTP 400 or 422). Bounded low: this is meant to
+# fix a one-off config gap (a required field the auto-discovered chat payload
+# doesn't know about), not to iteratively hill-climb an arbitrary schema at
+# LLM-call expense on every scenario.
+MAX_SCHEMA_HEAL_ATTEMPTS = 2
 
 _HEAL_SYSTEM_PROMPT = (
     "You are helping repair an HTTP API request that failed schema validation. "
@@ -55,31 +55,19 @@ _HEAL_SYSTEM_PROMPT = (
 
 
 def _looks_like_schema_error(body_text: str) -> bool:
-    """Return True when *body_text* looks like a field-validation error body.
+    """Return True when *body_text* is worth asking the LLM to classify/repair.
 
-    Recognises the common shapes: FastAPI/Pydantic
-    ``{"detail": [{"loc": [...], "msg": ..., "type": "missing"}]}``, and the
-    simpler ``{"detail": [{"field": ..., "message": ...}]}`` variant. This
-    gate exists so a 422 that's actually an auth/business-logic rejection
-    (no field-shape information) doesn't burn an LLM call for nothing.
+    Deliberately format-agnostic: target apps signal "missing/invalid field"
+    with wildly different shapes (FastAPI/Pydantic's structured
+    ``{"detail": [...]}``, a flat ``{"error": "..."}`` string, or arbitrarily
+    nested hand-rolled bodies), and hardcoding a shape whitelist here misses new
+    ones indefinitely. Instead this is just a cheap pre-filter to avoid burning
+    an LLM call on a genuinely empty error body — actual classification (is
+    this a field-validation error vs. an auth/business-logic/rate-limit
+    rejection?) is delegated to the LLM via ``_HEAL_SYSTEM_PROMPT``, which is
+    instructed to respond with ``{}`` when the body isn't a schema error.
     """
-    if not body_text:
-        return False
-    try:
-        data = json.loads(body_text)
-    except Exception:
-        return False
-    detail = data.get("detail") if isinstance(data, dict) else None
-    if isinstance(detail, str):
-        return False
-    if isinstance(detail, list) and detail:
-        return all(
-            isinstance(item, dict) and ({"loc", "msg"} <= item.keys() or "field" in item)
-            for item in detail
-        )
-    if isinstance(data, dict) and isinstance(data.get("errors"), (list, dict)):
-        return True
-    return False
+    return bool(body_text and body_text.strip())
 
 # Well-known OpenAI/Anthropic/LangChain-style chat-history field names.  When
 # chat_payload_key matches one of these (and chat_payload_list is True), the
@@ -354,10 +342,10 @@ class TargetAppClient:
         # Populated by build_target_app_client() with human-readable notes about
         # automatic config resolution (URL fallback, auth upgrade, etc.).
         self.resolution_notes: list[str] = []
-        # Optional LLM used to self-heal a 422 schema-validation error by
-        # inferring the missing request field(s) from the error body — see
-        # _attempt_422_heal(). None disables self-healing (falls straight
-        # through to the existing "[HTTP 422]" behaviour).
+        # Optional LLM used to self-heal a schema-validation error (HTTP 400
+        # or 422) by inferring the missing request field(s) from the error
+        # body — see _attempt_schema_heal(). None disables self-healing
+        # (falls straight through to the existing "[HTTP <status>]" behaviour).
         self._heal_llm: "LLMClient | None" = heal_llm
         self._heal_attempts_used = 0
 
@@ -515,8 +503,17 @@ class TargetAppClient:
             _log.debug("Direct-HTTP endpoint probe recovered — resetting error counter")
         self._consecutive_endpoint_errors = 0
 
-    async def _attempt_422_heal(self, sent_body: dict, error_body_text: str) -> bool:
-        """Ask the LLM to infer missing/invalid field(s) from a 422 error body.
+    async def _attempt_schema_heal(
+        self, sent_body: dict, error_body_text: str, status: int
+    ) -> bool:
+        """Ask the LLM to infer missing/invalid field(s) from a schema-error body.
+
+        *status* is the actual HTTP status observed (400 or 422 — apps signal
+        "your request body is invalid/incomplete" with either) and is only used
+        for prompt/log/note text; the body-shape classification itself is left
+        entirely to the LLM so arbitrarily-shaped or nested error bodies are
+        handled without hardcoding another shape here — see
+        ``_looks_like_schema_error``.
 
         On success, merges the inferred fields into ``self._chat_payload_extras``
         (so every subsequent request on this client carries them, not just a
@@ -524,7 +521,7 @@ class TargetAppClient:
         is disabled, the budget is exhausted, the error body doesn't look like
         a field-validation error, or the LLM call didn't yield anything new.
         """
-        if self._heal_llm is None or self._heal_attempts_used >= MAX_422_HEAL_ATTEMPTS:
+        if self._heal_llm is None or self._heal_attempts_used >= MAX_SCHEMA_HEAL_ATTEMPTS:
             return False
         if not _looks_like_schema_error(error_body_text):
             return False
@@ -532,7 +529,7 @@ class TargetAppClient:
         self._heal_attempts_used += 1
         prompt = (
             f"Request body sent:\n{json.dumps(sent_body)}\n\n"
-            f"Server validation error (HTTP 422):\n{error_body_text[:1000]}"
+            f"Server validation error (HTTP {status}):\n{error_body_text[:1000]}"
         )
         try:
             from nuguard.common.json_utils import extract_json_object  # noqa: PLC0415
@@ -540,12 +537,12 @@ class TargetAppClient:
             raw = await self._heal_llm.complete(
                 prompt,
                 system=_HEAL_SYSTEM_PROMPT,
-                label=f"422-heal | path={self._chat_path}",
+                label=f"schema-heal | path={self._chat_path}",
                 temperature=0.0,
             )
             extra_fields = extract_json_object(raw)
         except Exception as exc:
-            _log.debug("_attempt_422_heal: LLM call failed: %s", exc)
+            _log.debug("_attempt_schema_heal: LLM call failed: %s", exc)
             return False
 
         if not isinstance(extra_fields, dict) or not extra_fields:
@@ -559,12 +556,13 @@ class TargetAppClient:
 
         self._chat_payload_extras.update(new_fields)
         _log.info(
-            "422 self-heal: inferred missing field(s) %s for %s (attempt %d/%d) — "
-            "retrying and reusing for subsequent requests",
-            list(new_fields), self._chat_path, self._heal_attempts_used, MAX_422_HEAL_ATTEMPTS,
+            "Schema self-heal: inferred missing field(s) %s for %s (HTTP %d, "
+            "attempt %d/%d) — retrying and reusing for subsequent requests",
+            list(new_fields), self._chat_path, status,
+            self._heal_attempts_used, MAX_SCHEMA_HEAL_ATTEMPTS,
         )
         self.resolution_notes.append(
-            f"HTTP 422 on {self._chat_path} was auto-repaired by inferring field(s) "
+            f"HTTP {status} on {self._chat_path} was auto-repaired by inferring field(s) "
             f"{list(new_fields)} from the validation error body via LLM. Consider "
             f"adding these under target.chat_payload_extras in nuguard.yaml to skip "
             f"this at startup."
@@ -847,9 +845,9 @@ class TargetAppClient:
         """Inner send implementation (called with or without the request semaphore)."""
         data: dict | list | str = {}
         body: dict | None = None
-        # Bounded to max_429_retries + MAX_422_HEAL_ATTEMPTS so a 422 self-heal
+        # Bounded to max_429_retries + MAX_SCHEMA_HEAL_ATTEMPTS so a schema-heal
         # retry doesn't eat into the 429 backoff budget (and vice versa).
-        for attempt in range(self._max_429_retries + MAX_422_HEAL_ATTEMPTS + 1):
+        for attempt in range(self._max_429_retries + MAX_SCHEMA_HEAL_ATTEMPTS + 1):
             try:
                 session_id: str = ""
                 if self._framework_adapter is not None:
@@ -964,10 +962,10 @@ class TargetAppClient:
                     await asyncio.sleep(delay)
                     continue
                 if (
-                    status == 422
+                    status in (400, 422)
                     and self._framework_adapter is None
                     and body is not None
-                    and await self._attempt_422_heal(body, exc.response.text or "")
+                    and await self._attempt_schema_heal(body, exc.response.text or "", status)
                 ):
                     continue
                 # 4xx responses mean the target IS reachable — it actively rejected our

--- a/tests/redteam/test_new_scenarios.py
+++ b/tests/redteam/test_new_scenarios.py
@@ -716,6 +716,162 @@ async def test_send_422_heal_skipped_without_llm() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_self_heals_400_with_flat_error_body() -> None:
+    """A hand-rolled HTTP 400 with a flat {"error": "..."} body is also self-healed."""
+    import httpx
+    from nuguard.redteam.target.client import TargetAppClient
+    from nuguard.redteam.target.session import AttackSession
+
+    heal_llm = MagicMock()
+    heal_llm.complete = AsyncMock(return_value='{"consumerID": "abc123"}')
+
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_key="message",
+        heal_llm=heal_llm,
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    req = httpx.Request("POST", "http://localhost:9999/chat")
+    err_body = json.dumps({"error": "consumerID and message are required"})
+    resp_400 = MagicMock()
+    resp_400.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "400", request=req, response=httpx.Response(400, request=req, text=err_body)
+        )
+    )
+
+    resp_ok = MagicMock()
+    resp_ok.raise_for_status = MagicMock()
+    resp_ok.json = MagicMock(return_value={"response": "ok"})
+
+    with patch.object(
+        client._client, "post", new_callable=AsyncMock, side_effect=[resp_400, resp_ok]
+    ) as post_mock:
+        text, _ = await client.send("hello", session)
+
+    assert text == "ok"
+    assert post_mock.await_count == 2
+    heal_llm.complete.assert_awaited_once()
+    assert "HTTP 400" in heal_llm.complete.await_args.args[0]
+    assert client._chat_payload_extras == {"consumerID": "abc123"}
+    assert client.resolution_notes and "HTTP 400" in client.resolution_notes[-1]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_self_heals_nested_arbitrary_error_body() -> None:
+    """A deliberately nested, non-whitelisted error shape still reaches the LLM."""
+    import httpx
+    from nuguard.redteam.target.client import TargetAppClient
+    from nuguard.redteam.target.session import AttackSession
+
+    heal_llm = MagicMock()
+    heal_llm.complete = AsyncMock(return_value='{"consumerID": "abc123"}')
+
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_key="message",
+        heal_llm=heal_llm,
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    req = httpx.Request("POST", "http://localhost:9999/chat")
+    err_body = json.dumps({"error": {"details": {"missing": ["consumerID"]}}})
+    resp_400 = MagicMock()
+    resp_400.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "400", request=req, response=httpx.Response(400, request=req, text=err_body)
+        )
+    )
+
+    resp_ok = MagicMock()
+    resp_ok.raise_for_status = MagicMock()
+    resp_ok.json = MagicMock(return_value={"response": "ok"})
+
+    with patch.object(
+        client._client, "post", new_callable=AsyncMock, side_effect=[resp_400, resp_ok]
+    ) as post_mock:
+        text, _ = await client.send("hello", session)
+
+    assert text == "ok"
+    heal_llm.complete.assert_awaited_once()
+    assert "missing" in heal_llm.complete.await_args.args[0]
+    assert client._chat_payload_extras == {"consumerID": "abc123"}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_heal_rejected_by_llm_for_non_schema_400() -> None:
+    """The LLM (not a regex) rejects a non-schema 400 by returning {} — no retry."""
+    import httpx
+    from nuguard.redteam.target.client import TargetAppClient
+    from nuguard.redteam.target.session import AttackSession
+
+    heal_llm = MagicMock()
+    heal_llm.complete = AsyncMock(return_value="{}")
+
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_key="message",
+        heal_llm=heal_llm,
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    req = httpx.Request("POST", "http://localhost:9999/chat")
+    err_body = json.dumps({"error": "unauthorized"})
+    resp_400 = MagicMock()
+    resp_400.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "400", request=req, response=httpx.Response(400, request=req, text=err_body)
+        )
+    )
+
+    with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp_400) as post_mock:
+        text, _ = await client.send("hello", session)
+
+    assert text == "[HTTP 400]"
+    heal_llm.complete.assert_awaited_once()
+    assert post_mock.await_count == 1
+    assert client._chat_payload_extras == {}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_skips_llm_call_for_empty_error_body() -> None:
+    """An empty error body short-circuits before ever calling the LLM."""
+    import httpx
+    from nuguard.redteam.target.client import TargetAppClient
+    from nuguard.redteam.target.session import AttackSession
+
+    heal_llm = MagicMock()
+    heal_llm.complete = AsyncMock(return_value="{}")
+
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_key="message",
+        heal_llm=heal_llm,
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    req = httpx.Request("POST", "http://localhost:9999/chat")
+    resp_400 = MagicMock()
+    resp_400.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "400", request=req, response=httpx.Response(400, request=req, text="")
+        )
+    )
+
+    with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp_400) as post_mock:
+        text, _ = await client.send("hello", session)
+
+    assert text == "[HTTP 400]"
+    heal_llm.complete.assert_not_awaited()
+    assert post_mock.await_count == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_invoke_endpoint_retries_429_then_succeeds() -> None:
     """invoke_endpoint() retries HTTP 429 responses before returning."""
     from nuguard.redteam.target.client import TargetAppClient


### PR DESCRIPTION
## Summary
- `TargetAppClient`'s schema-error self-heal only fired on HTTP 422 with a FastAPI/Pydantic-shaped `{"detail": [...]}` body — target apps that signal "missing required field" via HTTP 400 with a flat or arbitrarily-nested hand-rolled body (`{"error": "consumerID and message are required"}`) never got healed, causing explicit-endpoint runs to hard-abort instead of self-repairing.
- Broadened the retry-loop trigger in `send()` from `status == 422` to `status in (400, 422)`.
- Simplified `_looks_like_schema_error` from a hardcoded shape whitelist down to a cheap non-empty-body pre-filter — actual classification (schema error vs. auth/business-logic rejection) and field inference is delegated to the LLM via the existing heal prompt, which already instructs it to return `{}` for non-schema errors. This handles arbitrarily nested/shaped bodies without hardcoding another regex/shape.
- Renamed `_attempt_422_heal` → `_attempt_schema_heal` and threaded the real HTTP status through the LLM prompt, log lines, and `resolution_notes` instead of hardcoding "422".
- `TargetAppClient` is the single shared client used by both the behavior and redteam pipelines (via `build_target_app_client`), so this fix applies to both without duplication.

Closes #501

## Test plan
- [x] `uv run pytest tests/redteam/test_new_scenarios.py nuguard/redteam/tests/test_target_client.py -q` — 125 passed, including 4 new tests (400 flat-body heal, nested-body heal, LLM-rejected non-schema 400, empty-body short-circuit)
- [x] `uv run ruff check nuguard/redteam/target/client.py nuguard/common/target_client_builder.py`
- [x] `uv run mypy nuguard/redteam/target/client.py`
- [x] Full suite `uv run pytest tests/ nuguard/ -q` — 4786 passed, 2 pre-existing failures in `test_llm_client_stream_retry.py` unrelated to this change (pass in isolation both with and without this diff — full-suite ordering flakiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gt5YoGPkiMeeWvmpUq43Q