### PR TITLE
feat(pentest): add bounded cloud application scanning

### DIFF
--- a/documentation/docs/cloud-pentesting.md
+++ b/documentation/docs/cloud-pentesting.md
@@ -1,0 +1,168 @@
+# Cloud application pentesting
+
+NuGuard provides an explicitly authorized command for conventional HTTP and
+HTTPS application pentesting:
+
+~~~bash
+nuguard pentest \
+  --target https://staging.example.com \
+  --acknowledge-authorization
+~~~
+
+Active testing is separate from `nuguard analyze`. Static analysis must not
+silently send active-test traffic to a running application.
+
+## Authorization
+
+Run the command only against applications you own or have documented
+permission to test. The command refuses to run unless
+`--acknowledge-authorization` is supplied.
+
+The acknowledgement does not grant permission. It records an explicit operator
+decision and helps prevent accidental execution through copied commands or CI
+configuration.
+
+## Nuclei engine
+
+The first engine is ProjectDiscovery Nuclei. NuGuard requires Nuclei 3.10.0 or
+newer and verifies that the installed build exposes every safety option used by
+the integration.
+
+NuGuard does not install or update Nuclei. Install and review the scanner
+separately, then place it on `PATH` or provide `--nuclei-binary`.
+
+The engine uses:
+
+- an HTTP-only template-type allowlist;
+- signed templates only;
+- no OAST or Interactsh;
+- no unsigned templates;
+- no code, JavaScript, headless, file, DNS, TCP, workflow, SSL, WebSocket, or
+  WHOIS template protocols;
+- no fuzzing, denial-of-service, brute-force, default-login, or intrusive tags;
+- no redirect following;
+- no stdin targets;
+- no automatic update checks or template downloads during a scan;
+- no inherited cloud-upload activation;
+- no raw request, response, curl-command, or template-body retention;
+- a closed set of scanner arguments;
+- bounded rate, concurrency, retries, request timeout, whole-scan timeout,
+  response size, JSONL line size, and total output size.
+
+The whole-scan deadline is enforced by NuGuard's parent-process watchdog. It
+does not rely on an engine-specific whole-scan CLI option.
+
+## Target scope
+
+Only explicit `http://` and `https://` URLs are accepted.
+
+The target validator rejects:
+
+- credentials embedded in URLs;
+- credential-like query parameters;
+- URL fragments and control characters;
+- loopback addresses;
+- link-local addresses;
+- multicast and reserved ranges;
+- cloud metadata-service addresses;
+- Kubernetes control-plane hostnames;
+- mixed DNS answers containing any blocked address;
+- private addresses unless `--allow-private` is supplied;
+- more than 50 input targets.
+
+`--allow-private` permits private RFC1918 and unique-local targets, but it does
+not permit loopback, link-local, metadata-service, multicast, or reserved
+targets.
+
+Public scans also enable Nuclei's local-network restriction. That option is
+omitted only when the operator explicitly selects `--allow-private`.
+
+## Profiles
+
+The default `safe` profile scans low, medium, high, and critical findings.
+
+The `standard` profile also includes informational templates. Both profiles
+retain the same protocol and intrusive-template restrictions.
+
+~~~bash
+nuguard pentest \
+  --target https://staging.example.com \
+  --profile standard \
+  --acknowledge-authorization
+~~~
+
+## Multiple targets
+
+Repeat `--target`:
+
+~~~bash
+nuguard pentest \
+  --target https://app.example.com \
+  --target https://api.example.com \
+  --acknowledge-authorization
+~~~
+
+Or supply a UTF-8 target file:
+
+~~~text
+# authorized-targets.txt
+https://app.example.com
+https://api.example.com
+~~~
+
+~~~bash
+nuguard pentest \
+  --target-file authorized-targets.txt \
+  --acknowledge-authorization
+~~~
+
+## Reports
+
+Supported formats are:
+
+- `text`
+- `json`
+- `markdown`
+- `sarif`
+
+~~~bash
+nuguard pentest \
+  --target https://staging.example.com \
+  --acknowledge-authorization \
+  --format sarif \
+  --output pentest.sarif
+~~~
+
+Reports are written atomically with owner-only permissions. Existing symbolic
+links are rejected. Nuclei request, response, curl-command, and template-body
+fields are ignored. Credential-like values in matched URLs and extracted
+values are redacted.
+
+## CI thresholds
+
+The default threshold is `high`. A completed command exits:
+
+- `0` when no finding reaches the threshold;
+- `1` when a finding reaches the threshold;
+- `2` for authorization, scope, configuration, engine, timeout, or malformed
+  output failures.
+
+~~~bash
+nuguard pentest \
+  --target https://staging.example.com \
+  --acknowledge-authorization \
+  --format sarif \
+  --output pentest.sarif \
+  --fail-on medium
+~~~
+
+Use `--fail-on none` when findings should not fail the job.
+
+## Authentication
+
+This first engine intentionally does not accept raw authorization headers or
+tokens on the command line. Command-line secrets can appear in shell history,
+process listings, CI logs, or crash reports.
+
+Authenticated active scanning should be added through NuGuard's secret-provider
+abstraction rather than arbitrary Nuclei arguments or header passthrough.

--- a/nuguard/cli/commands/pentest.py
+++ b/nuguard/cli/commands/pentest.py
@@ -1,0 +1,247 @@
+"""CLI command for explicitly authorized cloud-application pentesting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nuguard.pentest import (
+    PentestConfig,
+    PentestError,
+    ReportFormat,
+    ScanProfile,
+    Severity,
+    run_pentest,
+)
+from nuguard.pentest.reporting import (
+    render_report,
+    threshold_exit_code,
+    write_report,
+)
+
+_MAX_TARGET_FILE_BYTES = 1024 * 1024
+
+
+def _target_file_values(
+    target_file: Path | None,
+) -> list[str]:
+    if target_file is None:
+        return []
+
+    target_file = target_file.expanduser().resolve()
+
+    if not target_file.is_file():
+        raise typer.BadParameter(f"Target file does not exist: {target_file}")
+
+    if target_file.stat().st_size > _MAX_TARGET_FILE_BYTES:
+        raise typer.BadParameter("Target file exceeds the 1 MiB limit.")
+
+    try:
+        lines = target_file.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise typer.BadParameter(f"Could not read target file: {exc}") from exc
+
+    return [line.strip() for line in lines if (line.strip() and not line.lstrip().startswith("#"))]
+
+
+def pentest(
+    target: list[str] | None = typer.Option(
+        None,
+        "--target",
+        "-t",
+        help=("Authorized HTTP/HTTPS target. Repeat for multiple targets."),
+    ),
+    target_file: Path | None = typer.Option(
+        None,
+        "--target-file",
+        help=("UTF-8 file containing one authorized HTTP/HTTPS target per line."),
+    ),
+    acknowledge_authorization: bool = typer.Option(
+        False,
+        "--acknowledge-authorization",
+        help=("Confirm that you own every target or have documented permission to test it."),
+    ),
+    allow_private: bool = typer.Option(
+        False,
+        "--allow-private",
+        help=(
+            "Permit RFC1918 or unique-local targets. "
+            "Loopback, link-local, metadata, multicast, "
+            "and reserved addresses remain blocked."
+        ),
+    ),
+    profile: str = typer.Option(
+        ScanProfile.SAFE.value,
+        "--profile",
+        help="Pentest profile: safe or standard.",
+    ),
+    report_format: str = typer.Option(
+        ReportFormat.TEXT.value,
+        "--format",
+        help=("Report format: text, json, markdown, or sarif."),
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help=("Write the report atomically to this owner-only file."),
+    ),
+    fail_on: str = typer.Option(
+        Severity.HIGH.value,
+        "--fail-on",
+        help=(
+            "Exit 1 when findings meet this severity: none, info, low, medium, high, or critical."
+        ),
+    ),
+    nuclei_binary: str = typer.Option(
+        "nuclei",
+        "--nuclei-binary",
+        help=("Nuclei executable name or path. Arbitrary scanner arguments are not accepted."),
+    ),
+    templates_dir: Path | None = typer.Option(
+        None,
+        "--templates-dir",
+        help=("Optional trusted Nuclei templates directory. Unsigned templates remain disabled."),
+    ),
+    rate_limit: int = typer.Option(
+        25,
+        "--rate-limit",
+        min=1,
+        max=100,
+        help="Maximum requests per second.",
+    ),
+    concurrency: int = typer.Option(
+        10,
+        "--concurrency",
+        min=1,
+        max=25,
+        help="Maximum template concurrency.",
+    ),
+    retries: int = typer.Option(
+        1,
+        "--retries",
+        min=0,
+        max=2,
+        help="Maximum request retries.",
+    ),
+    request_timeout: int = typer.Option(
+        10,
+        "--request-timeout",
+        min=1,
+        max=60,
+        help="Per-request timeout in seconds.",
+    ),
+    scan_timeout: int = typer.Option(
+        900,
+        "--scan-timeout",
+        min=10,
+        max=3600,
+        help="Whole-scan timeout in seconds.",
+    ),
+) -> None:
+    """Run bounded conventional pentesting against authorized web targets."""
+    targets = [
+        *(target or []),
+        *_target_file_values(target_file),
+    ]
+
+    if not targets:
+        raise typer.BadParameter("Provide --target or --target-file.")
+
+    try:
+        scan_profile = ScanProfile.parse(profile)
+    except ValueError as exc:
+        raise typer.BadParameter("--profile must be safe or standard.") from exc
+
+    try:
+        selected_format = ReportFormat.parse(report_format)
+    except ValueError as exc:
+        raise typer.BadParameter("--format must be text, json, markdown, or sarif.") from exc
+
+    if fail_on.strip().casefold() == "none":
+        severity_threshold = None
+    else:
+        try:
+            severity_threshold = Severity.parse(fail_on)
+        except ValueError as exc:
+            raise typer.BadParameter(
+                "--fail-on must be none, info, low, medium, high, or critical."
+            ) from exc
+
+    try:
+        config = PentestConfig(
+            targets=tuple(targets),
+            authorized=(acknowledge_authorization),
+            allow_private=allow_private,
+            profile=scan_profile,
+            nuclei_binary=nuclei_binary,
+            templates_dir=templates_dir,
+            rate_limit=rate_limit,
+            concurrency=concurrency,
+            bulk_size=min(
+                concurrency,
+                10,
+            ),
+            retries=retries,
+            request_timeout_seconds=(request_timeout),
+            scan_timeout_seconds=(scan_timeout),
+        )
+
+        report = run_pentest(config)
+
+        rendered = render_report(
+            report,
+            selected_format,
+        )
+
+        if output is None:
+            typer.echo(
+                rendered,
+                nl=False,
+            )
+        else:
+            written = write_report(
+                output,
+                rendered,
+            )
+            typer.echo(
+                f"Pentest report written to {written}",
+                err=True,
+            )
+
+        typer.echo(
+            (
+                f"Pentest completed: "
+                f"{len(report.findings)} finding(s), "
+                f"{len(report.targets)} target(s)."
+            ),
+            err=True,
+        )
+
+        exit_code = threshold_exit_code(
+            report,
+            severity_threshold,
+        )
+
+        if exit_code:
+            raise typer.Exit(code=exit_code)
+
+    except PentestError as exc:
+        typer.secho(
+            f"Pentest failed: {exc}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=2) from exc
+
+    except (
+        OSError,
+        ValueError,
+    ) as exc:
+        typer.secho(
+            f"Pentest configuration failed: {exc}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=2) from exc

--- a/nuguard/cli/main.py
+++ b/nuguard/cli/main.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 # This is a no-op if python-dotenv is not installed or no .env file is found.
 try:
     from dotenv import load_dotenv
+
     load_dotenv(override=False)  # env vars already in the shell take precedence
 except ImportError:
     pass
@@ -20,6 +21,7 @@ from nuguard.cli.commands.analyze import analyze_app
 from nuguard.cli.commands.behavior import behavior_app
 from nuguard.cli.commands.findings import findings_app
 from nuguard.cli.commands.init import init_command
+from nuguard.cli.commands.pentest import pentest as pentest_command
 from nuguard.cli.commands.policy import policy_app
 from nuguard.cli.commands.redteam import redteam_app
 from nuguard.cli.commands.replay import replay_app
@@ -36,6 +38,8 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+app.command(name="pentest")(pentest_command)
 
 app.command(name="init")(init_command)
 app.add_typer(sbom_app, name="sbom")

--- a/nuguard/pentest/__init__.py
+++ b/nuguard/pentest/__init__.py
@@ -1,0 +1,37 @@
+"""Explicitly authorized cloud-application pentesting."""
+
+from .engine import (
+    AuthorizationError,
+    EngineExecutionError,
+    EngineUnavailableError,
+    PentestEngine,
+    PentestError,
+    ScopeError,
+)
+from .models import (
+    PentestConfig,
+    PentestFinding,
+    PentestReport,
+    PentestTarget,
+    ReportFormat,
+    ScanProfile,
+    Severity,
+)
+from .runner import run_pentest
+
+__all__ = [
+    "AuthorizationError",
+    "EngineExecutionError",
+    "EngineUnavailableError",
+    "PentestConfig",
+    "PentestEngine",
+    "PentestError",
+    "PentestFinding",
+    "PentestReport",
+    "PentestTarget",
+    "ReportFormat",
+    "ScanProfile",
+    "ScopeError",
+    "Severity",
+    "run_pentest",
+]

--- a/nuguard/pentest/engine.py
+++ b/nuguard/pentest/engine.py
@@ -1,0 +1,42 @@
+"""Pentest engine contract and public error hierarchy."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from .models import PentestConfig, PentestReport, PentestTarget
+
+
+class PentestError(RuntimeError):
+    """Base class for controlled pentest failures."""
+
+
+class AuthorizationError(PentestError):
+    """Raised when active testing was not explicitly authorized."""
+
+
+class ScopeError(PentestError):
+    """Raised when a target violates the active-testing scope policy."""
+
+
+class EngineUnavailableError(PentestError):
+    """Raised when the selected engine is missing or unsafe to execute."""
+
+
+class EngineExecutionError(PentestError):
+    """Raised when an engine cannot complete a scan safely."""
+
+
+class PentestEngine(ABC):
+    """Interface implemented by active-testing engines."""
+
+    name: str
+
+    @abstractmethod
+    def run(
+        self,
+        config: PentestConfig,
+        targets: Sequence[PentestTarget],
+    ) -> PentestReport:
+        """Execute a bounded scan and return normalized findings."""

--- a/nuguard/pentest/models.py
+++ b/nuguard/pentest/models.py
@@ -1,0 +1,257 @@
+"""Models and bounded configuration for active application pentesting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class Severity(StrEnum):
+    """Normalized pentest severity."""
+
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+    @classmethod
+    def parse(cls, value: str) -> Severity:
+        normalized = value.strip().casefold()
+
+        aliases = {
+            "informational": cls.INFO.value,
+            "moderate": cls.MEDIUM.value,
+            "severe": cls.HIGH.value,
+        }
+
+        return cls(aliases.get(normalized, normalized))
+
+    @classmethod
+    def coerce(cls, value: object) -> Severity:
+        try:
+            return cls.parse(str(value or "info"))
+        except ValueError:
+            return cls.INFO
+
+    @property
+    def rank(self) -> int:
+        return {
+            Severity.INFO: 0,
+            Severity.LOW: 1,
+            Severity.MEDIUM: 2,
+            Severity.HIGH: 3,
+            Severity.CRITICAL: 4,
+        }[self]
+
+
+class ScanProfile(StrEnum):
+    """Supported bounded Nuclei profiles."""
+
+    SAFE = "safe"
+    STANDARD = "standard"
+
+    @classmethod
+    def parse(cls, value: str) -> ScanProfile:
+        return cls(value.strip().casefold())
+
+
+class ReportFormat(StrEnum):
+    """Supported pentest report formats."""
+
+    TEXT = "text"
+    JSON = "json"
+    MARKDOWN = "markdown"
+    SARIF = "sarif"
+
+    @classmethod
+    def parse(cls, value: str) -> ReportFormat:
+        normalized = value.strip().casefold()
+
+        aliases = {
+            "md": cls.MARKDOWN.value,
+            "sarif-json": cls.SARIF.value,
+        }
+
+        return cls(aliases.get(normalized, normalized))
+
+
+@dataclass(frozen=True, slots=True)
+class PentestConfig:
+    """Safety-bounded pentest configuration."""
+
+    targets: tuple[str, ...]
+    authorized: bool
+    allow_private: bool = False
+    profile: ScanProfile = ScanProfile.SAFE
+    nuclei_binary: str = "nuclei"
+    templates_dir: Path | None = None
+    rate_limit: int = 25
+    concurrency: int = 10
+    bulk_size: int = 10
+    retries: int = 1
+    request_timeout_seconds: int = 10
+    scan_timeout_seconds: int = 900
+    max_host_errors: int = 10
+    response_size_read: int = 1_048_576
+    response_size_save: int = 1_048_576
+    max_output_bytes: int = 50 * 1024 * 1024
+    max_line_bytes: int = 2 * 1024 * 1024
+    max_targets: int = 50
+
+    def __post_init__(self) -> None:
+        if not self.targets:
+            raise ValueError("At least one target is required.")
+
+        if len(self.targets) > self.max_targets:
+            raise ValueError(f"At most {self.max_targets} targets are allowed per scan.")
+
+        bounded_values = {
+            "rate_limit": (self.rate_limit, 1, 100),
+            "concurrency": (self.concurrency, 1, 25),
+            "bulk_size": (self.bulk_size, 1, 25),
+            "retries": (self.retries, 0, 2),
+            "request_timeout_seconds": (
+                self.request_timeout_seconds,
+                1,
+                60,
+            ),
+            "scan_timeout_seconds": (
+                self.scan_timeout_seconds,
+                10,
+                3600,
+            ),
+            "max_host_errors": (
+                self.max_host_errors,
+                1,
+                25,
+            ),
+        }
+
+        for name, (value, minimum, maximum) in bounded_values.items():
+            if not minimum <= value <= maximum:
+                raise ValueError(
+                    f"{name} must be between {minimum} and {maximum}; received {value}."
+                )
+
+        if not self.nuclei_binary.strip():
+            raise ValueError("The Nuclei binary name cannot be empty.")
+
+        if self.templates_dir is not None:
+            templates_dir = self.templates_dir.expanduser().resolve()
+
+            if not templates_dir.is_dir():
+                raise ValueError(f"Nuclei templates directory does not exist: {templates_dir}")
+
+            object.__setattr__(
+                self,
+                "templates_dir",
+                templates_dir,
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PentestTarget:
+    """A validated and resolved HTTP target."""
+
+    original: str
+    url: str
+    hostname: str
+    port: int
+    resolved_ips: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "url": self.url,
+            "hostname": self.hostname,
+            "port": self.port,
+            "resolved_ips": list(self.resolved_ips),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PentestFinding:
+    """Normalized active-testing finding."""
+
+    finding_id: str
+    rule_id: str
+    title: str
+    description: str
+    severity: Severity
+    target: str
+    matched_at: str
+    engine: str
+    engine_version: str
+    remediation: str = ""
+    references: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    template_url: str = ""
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.finding_id,
+            "rule_id": self.rule_id,
+            "title": self.title,
+            "description": self.description,
+            "severity": self.severity.value,
+            "target": self.target,
+            "matched_at": self.matched_at,
+            "engine": self.engine,
+            "engine_version": self.engine_version,
+            "remediation": self.remediation,
+            "references": list(self.references),
+            "tags": list(self.tags),
+            "template_url": self.template_url,
+            "evidence": dict(self.evidence),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PentestReport:
+    """Complete normalized pentest report."""
+
+    engine: str
+    engine_version: str
+    profile: str
+    started_at: str
+    finished_at: str
+    duration_seconds: float
+    targets: tuple[str, ...]
+    findings: tuple[PentestFinding, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    def severity_counts(self) -> dict[Severity, int]:
+        counts = {severity: 0 for severity in Severity}
+
+        for finding in self.findings:
+            counts[finding.severity] += 1
+
+        return counts
+
+    def has_at_or_above(self, threshold: Severity) -> bool:
+        return any(finding.severity.rank >= threshold.rank for finding in self.findings)
+
+    def to_dict(self) -> dict[str, Any]:
+        counts = self.severity_counts()
+
+        return {
+            "schema_version": "1.0",
+            "engine": self.engine,
+            "engine_version": self.engine_version,
+            "profile": self.profile,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "duration_seconds": round(self.duration_seconds, 3),
+            "targets": list(self.targets),
+            "summary": {
+                "total": len(self.findings),
+                "by_severity": {severity.value: counts[severity] for severity in Severity},
+            },
+            "findings": [finding.to_dict() for finding in self.findings],
+            "warnings": list(self.warnings),
+        }

--- a/nuguard/pentest/nuclei.py
+++ b/nuguard/pentest/nuclei.py
@@ -1,0 +1,839 @@
+"""Safety-bounded ProjectDiscovery Nuclei engine."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .engine import (
+    EngineExecutionError,
+    EngineUnavailableError,
+    PentestEngine,
+)
+from .models import (
+    PentestConfig,
+    PentestFinding,
+    PentestReport,
+    PentestTarget,
+    ScanProfile,
+    Severity,
+)
+from .scope import sanitize_url_for_report
+
+MIN_NUCLEI_VERSION = (3, 10, 0)
+
+_VERSION_RE = re.compile(r"(?i)\bv?(\d+)\.(\d+)\.(\d+)(?:[-+][A-Za-z0-9.-]+)?\b")
+
+_SECRET_ENV_RE = re.compile(
+    r"(?ix)"
+    r"(?:^|_)"
+    r"(?:token|secret|password|passwd|credential|credentials|"
+    r"authorization|cookie|session|api_key|private_key)"
+    r"(?:_|$)"
+    r"|^(?:aws|azure|google|gcp|openai|anthropic|github|gitlab|nuguard)_"
+    r"|^nuclei_"
+)
+
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+
+_KEY_RE = re.compile(r"\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}\b")
+
+_INLINE_SECRET_RE = re.compile(
+    r"(?i)\b(api[_ -]?key|token|secret|password|authorization)"
+    r"(\s*[:=]\s*)([^\s,;\"']+|\"[^\"]*\"|'[^']*')"
+)
+
+_REQUIRED_HELP_FLAGS = (
+    "-list",
+    "-jsonl",
+    "-output",
+    "-config",
+    "-templates",
+    "-silent",
+    "-no-color",
+    "-severity",
+    "-type",
+    "-disable-unsigned-templates",
+    "-no-interactsh",
+    "-no-stdin",
+    "-disable-update-check",
+    "-disable-redirects",
+    "-restrict-local-network-access",
+    "-omit-raw",
+    "-omit-template",
+    "-exclude-tags",
+    "-rate-limit",
+    "-concurrency",
+    "-bulk-size",
+    "-retries",
+    "-timeout",
+    "-max-host-error",
+    "-response-size-read",
+    "-response-size-save",
+)
+
+
+_EXCLUDED_TAGS = (
+    "bruteforce",
+    "default-login",
+    "dos",
+    "fuzz",
+    "intrusive",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class NucleiInspection:
+    """Validated Nuclei executable metadata."""
+
+    binary: Path
+    version: tuple[int, int, int]
+    version_text: str
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+
+    return {str(key): item for key, item in value.items()}
+
+
+def _redact_text(
+    value: str,
+    *,
+    limit: int = 4096,
+) -> str:
+    value = _BEARER_RE.sub(
+        "Bearer [REDACTED]",
+        value,
+    )
+    value = _KEY_RE.sub(
+        "[REDACTED]",
+        value,
+    )
+    value = _INLINE_SECRET_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        value,
+    )
+
+    if len(value) > limit:
+        return value[:limit] + "..."
+
+    return value
+
+
+def sanitized_environment(
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Remove credential-bearing variables from the scanner process."""
+    source = dict(environment) if environment is not None else dict(os.environ)
+
+    sanitized = {
+        key: value
+        for key, value in source.items()
+        if (
+            not _SECRET_ENV_RE.search(key)
+            and key != "SSH_AUTH_SOCK"
+            and key != "ENABLE_CLOUD_UPLOAD"
+        )
+    }
+
+    sanitized["NO_COLOR"] = "1"
+
+    for variable in (
+        "DISABLE_NUCLEI_TEMPLATES_PUBLIC_DOWNLOAD",
+        "DISABLE_NUCLEI_TEMPLATES_GITHUB_DOWNLOAD",
+        "DISABLE_NUCLEI_TEMPLATES_GITLAB_DOWNLOAD",
+        "DISABLE_NUCLEI_TEMPLATES_AWS_DOWNLOAD",
+        "DISABLE_NUCLEI_TEMPLATES_AZURE_DOWNLOAD",
+    ):
+        sanitized[variable] = "true"
+
+    return sanitized
+
+
+def parse_nuclei_version(
+    output: str,
+) -> tuple[int, int, int]:
+    """Parse the first semantic Nuclei version from command output."""
+    match = _VERSION_RE.search(output)
+
+    if match is None:
+        raise EngineUnavailableError("Could not determine the Nuclei version.")
+
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def _safe_string_list(
+    value: object,
+    *,
+    limit: int = 50,
+) -> tuple[str, ...]:
+    if isinstance(value, str):
+        candidates: Sequence[object] = value.split(",") if "," in value else (value,)
+    elif isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        candidates = value
+    else:
+        candidates = ()
+
+    result: list[str] = []
+    seen: set[str] = set()
+
+    for candidate in candidates:
+        text = _redact_text(
+            str(candidate).strip(),
+            limit=1000,
+        )
+
+        if not text or text in seen:
+            continue
+
+        seen.add(text)
+        result.append(text)
+
+        if len(result) >= limit:
+            break
+
+    return tuple(result)
+
+
+def _classification(
+    value: object,
+) -> dict[str, Any]:
+    source = _mapping(value)
+    allowed = {
+        "cve-id",
+        "cwe-id",
+        "cvss-metrics",
+        "cvss-score",
+        "epss-score",
+        "epss-percentile",
+    }
+
+    return {
+        key: source[key]
+        for key in allowed
+        if key in source
+        and isinstance(
+            source[key],
+            (str, int, float, bool, list),
+        )
+    }
+
+
+def _finding_from_record(
+    record: Mapping[str, Any],
+    *,
+    engine_version: str,
+) -> PentestFinding:
+    info = _mapping(record.get("info"))
+
+    template_id = str(
+        record.get("template-id") or record.get("template") or "unknown-template"
+    ).strip()
+
+    severity = Severity.coerce(info.get("severity"))
+
+    title = _redact_text(
+        str(info.get("name") or template_id).strip(),
+        limit=500,
+    )
+
+    description = _redact_text(
+        str(info.get("description") or title).strip(),
+    )
+
+    remediation = _redact_text(
+        str(info.get("remediation") or "").strip(),
+    )
+
+    matched_at = sanitize_url_for_report(
+        str(record.get("matched-at") or record.get("url") or record.get("host") or "")
+    )
+
+    target = sanitize_url_for_report(
+        str(record.get("host") or record.get("url") or matched_at or "unknown-target")
+    )
+
+    matcher_name = _redact_text(
+        str(record.get("matcher-name") or ""),
+        limit=300,
+    )
+
+    extracted_results = _safe_string_list(
+        record.get("extracted-results"),
+        limit=20,
+    )
+
+    references = _safe_string_list(
+        info.get("reference"),
+        limit=50,
+    )
+
+    tags = tuple(
+        sorted(
+            _safe_string_list(
+                info.get("tags"),
+                limit=100,
+            ),
+            key=str.casefold,
+        )
+    )
+
+    template_url_raw = str(record.get("template-url") or "").strip()
+
+    template_url = (
+        sanitize_url_for_report(template_url_raw)
+        if template_url_raw.startswith(("http://", "https://"))
+        else ""
+    )
+
+    fingerprint_source = "\n".join(
+        (
+            template_id,
+            target,
+            matched_at,
+            matcher_name,
+        )
+    )
+
+    finding_id = (
+        "pentest:nuclei:" + hashlib.sha256(fingerprint_source.encode("utf-8")).hexdigest()[:20]
+    )
+
+    evidence: dict[str, Any] = {
+        "matched_at": matched_at,
+    }
+
+    if matcher_name:
+        evidence["matcher_name"] = matcher_name
+
+    if extracted_results:
+        evidence["extracted_results"] = list(extracted_results)
+
+    metadata: dict[str, Any] = {
+        "template_id": template_id,
+        "protocol": _redact_text(
+            str(record.get("type") or ""),
+            limit=100,
+        ),
+        "classification": _classification(info.get("classification")),
+    }
+
+    for key in (
+        "ip",
+        "port",
+        "scheme",
+    ):
+        value = record.get(key)
+
+        if isinstance(
+            value,
+            (str, int, float),
+        ):
+            metadata[key] = _redact_text(
+                str(value),
+                limit=200,
+            )
+
+    return PentestFinding(
+        finding_id=finding_id,
+        rule_id=f"nuclei:{template_id}",
+        title=title,
+        description=description,
+        severity=severity,
+        target=target,
+        matched_at=matched_at,
+        engine="nuclei",
+        engine_version=engine_version,
+        remediation=remediation,
+        references=references,
+        tags=tags,
+        template_url=template_url,
+        evidence=evidence,
+        metadata=metadata,
+    )
+
+
+def parse_nuclei_jsonl(
+    path: Path,
+    *,
+    engine_version: str,
+    max_output_bytes: int,
+    max_line_bytes: int,
+) -> tuple[PentestFinding, ...]:
+    """Parse bounded JSONL while deliberately excluding raw HTTP data."""
+    if not path.exists():
+        return ()
+
+    size = path.stat().st_size
+
+    if size > max_output_bytes:
+        raise EngineExecutionError(
+            f"Nuclei output exceeded the configured {max_output_bytes}-byte limit."
+        )
+
+    findings: dict[
+        str,
+        PentestFinding,
+    ] = {}
+
+    with path.open("rb") as handle:
+        for line_number, raw_line in enumerate(
+            handle,
+            start=1,
+        ):
+            if len(raw_line) > max_line_bytes:
+                raise EngineExecutionError(
+                    f"Nuclei emitted an oversized JSONL record on line {line_number}."
+                )
+
+            if not raw_line.strip():
+                continue
+
+            try:
+                decoded = raw_line.decode("utf-8")
+                parsed = json.loads(decoded)
+            except (
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+            ) as exc:
+                raise EngineExecutionError(
+                    f"Nuclei emitted malformed JSONL on line {line_number}."
+                ) from exc
+
+            record = _mapping(parsed)
+
+            if not record:
+                raise EngineExecutionError(
+                    f"Nuclei emitted a non-object JSONL record on line {line_number}."
+                )
+
+            finding = _finding_from_record(
+                record,
+                engine_version=engine_version,
+            )
+
+            findings.setdefault(
+                finding.finding_id,
+                finding,
+            )
+
+    return tuple(
+        sorted(
+            findings.values(),
+            key=lambda finding: (
+                -finding.severity.rank,
+                finding.rule_id.casefold(),
+                finding.target.casefold(),
+                finding.finding_id,
+            ),
+        )
+    )
+
+
+def _resolve_binary(
+    binary_name: str,
+) -> Path:
+    candidate = shutil.which(binary_name)
+
+    if candidate is None:
+        explicit = Path(binary_name).expanduser()
+
+        if explicit.exists():
+            candidate = str(explicit)
+
+    if candidate is None:
+        raise EngineUnavailableError(
+            "Nuclei was not found. Install a supported "
+            "ProjectDiscovery Nuclei release and ensure it is on PATH."
+        )
+
+    try:
+        path = Path(candidate).resolve(strict=True)
+    except OSError as exc:
+        raise EngineUnavailableError(f"Could not resolve Nuclei executable: {candidate}") from exc
+
+    file_stat = path.stat()
+
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise EngineUnavailableError(f"Nuclei path is not a regular file: {path}")
+
+    if not os.access(path, os.X_OK):
+        raise EngineUnavailableError(f"Nuclei path is not executable: {path}")
+
+    if file_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise EngineUnavailableError(
+            f"Refusing to execute a group- or world-writable Nuclei binary: {path}"
+        )
+
+    return path
+
+
+def _probe(
+    command: Sequence[str],
+) -> str:
+    try:
+        result = subprocess.run(
+            list(command),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+            env=sanitized_environment(),
+        )
+    except (
+        OSError,
+        subprocess.TimeoutExpired,
+    ) as exc:
+        raise EngineUnavailableError("Could not inspect the Nuclei executable.") from exc
+
+    output = _redact_text(
+        result.stdout or "",
+        limit=100_000,
+    )
+
+    if result.returncode != 0:
+        raise EngineUnavailableError(
+            "Nuclei inspection failed: " + (output.strip() or f"exit code {result.returncode}")
+        )
+
+    return output
+
+
+def inspect_nuclei(
+    binary_name: str,
+) -> NucleiInspection:
+    """Validate executable provenance, version, and required safety flags."""
+    binary = _resolve_binary(binary_name)
+
+    version_output = _probe(
+        (
+            str(binary),
+            "-version",
+        )
+    )
+    version = parse_nuclei_version(version_output)
+
+    if version < MIN_NUCLEI_VERSION:
+        required = ".".join(str(part) for part in MIN_NUCLEI_VERSION)
+        actual = ".".join(str(part) for part in version)
+
+        raise EngineUnavailableError(
+            f"Unsupported Nuclei version {actual}; version {required} or newer is required."
+        )
+
+    help_output = _probe(
+        (
+            str(binary),
+            "-h",
+        )
+    )
+
+    missing_flags = [
+        flag
+        for flag in _REQUIRED_HELP_FLAGS
+        if re.search(
+            rf"(?<![\w-]){re.escape(flag)}(?=[,\s]|$)",
+            help_output,
+        )
+        is None
+    ]
+
+    if missing_flags:
+        raise EngineUnavailableError(
+            "The installed Nuclei build is missing required "
+            "safety controls: " + ", ".join(missing_flags)
+        )
+
+    return NucleiInspection(
+        binary=binary,
+        version=version,
+        version_text=".".join(str(part) for part in version),
+    )
+
+
+def build_nuclei_command(
+    inspection: NucleiInspection,
+    config: PentestConfig,
+    *,
+    target_file: Path,
+    output_file: Path,
+    config_file: Path,
+) -> list[str]:
+    """Build a closed, bounded command without arbitrary argument passthrough."""
+    severities = (
+        "low,medium,high,critical"
+        if config.profile is ScanProfile.SAFE
+        else "info,low,medium,high,critical"
+    )
+
+    command = [
+        str(inspection.binary),
+        "-list",
+        str(target_file),
+        "-jsonl",
+        "-output",
+        str(output_file),
+        "-config",
+        str(config_file),
+        "-silent",
+        "-no-color",
+        "-severity",
+        severities,
+        "-rate-limit",
+        str(config.rate_limit),
+        "-concurrency",
+        str(config.concurrency),
+        "-bulk-size",
+        str(config.bulk_size),
+        "-retries",
+        str(config.retries),
+        "-timeout",
+        str(config.request_timeout_seconds),
+        "-max-host-error",
+        str(config.max_host_errors),
+        "-response-size-read",
+        str(config.response_size_read),
+        "-response-size-save",
+        str(config.response_size_save),
+        "-disable-unsigned-templates",
+        "-no-interactsh",
+        "-no-stdin",
+        "-disable-update-check",
+        "-disable-redirects",
+        "-omit-raw",
+        "-omit-template",
+        "-type",
+        "http",
+        "-exclude-tags",
+        ",".join(_EXCLUDED_TAGS),
+    ]
+
+    if not config.allow_private:
+        command.append("-restrict-local-network-access")
+
+    if config.templates_dir is not None:
+        command.extend(
+            (
+                "-templates",
+                str(config.templates_dir),
+            )
+        )
+
+    return command
+
+
+def _write_private_text(
+    path: Path,
+    content: str,
+) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+
+    try:
+        with os.fdopen(
+            descriptor,
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write(content)
+    except Exception:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+
+
+def _terminate_process(
+    process: subprocess.Popen[bytes],
+) -> None:
+    if process.poll() is not None:
+        return
+
+    if os.name == "posix":
+        try:
+            os.killpg(
+                process.pid,
+                signal.SIGTERM,
+            )
+            process.wait(timeout=3)
+            return
+        except (
+            OSError,
+            subprocess.TimeoutExpired,
+        ):
+            try:
+                os.killpg(
+                    process.pid,
+                    signal.SIGKILL,
+                )
+            except OSError:
+                pass
+    else:
+        process.terminate()
+
+        try:
+            process.wait(timeout=3)
+            return
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    try:
+        process.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _read_limited_text(
+    path: Path,
+    *,
+    limit: int = 65_536,
+) -> str:
+    if not path.exists():
+        return ""
+
+    with path.open("rb") as handle:
+        data = handle.read(limit + 1)
+
+    truncated = len(data) > limit
+    data = data[:limit]
+
+    text = data.decode(
+        "utf-8",
+        errors="replace",
+    )
+
+    if truncated:
+        text += "\n...[truncated]"
+
+    return _redact_text(
+        text,
+        limit=limit + 100,
+    )
+
+
+class NucleiEngine(PentestEngine):
+    """Run signed HTTP Nuclei templates under a closed safety policy."""
+
+    name = "nuclei"
+
+    def run(
+        self,
+        config: PentestConfig,
+        targets: Sequence[PentestTarget],
+    ) -> PentestReport:
+        inspection = inspect_nuclei(config.nuclei_binary)
+        started = datetime.now(UTC)
+        warnings: list[str] = []
+
+        with tempfile.TemporaryDirectory(prefix="nuguard-pentest-") as temporary_directory:
+            work_dir = Path(temporary_directory)
+            work_dir.chmod(0o700)
+
+            target_file = work_dir / "targets.txt"
+            output_file = work_dir / "nuclei.jsonl"
+            config_file = work_dir / "nuclei-config.yaml"
+            stderr_file = work_dir / "nuclei.stderr"
+
+            _write_private_text(
+                target_file,
+                "".join(f"{target.url}\n" for target in targets),
+            )
+            _write_private_text(
+                config_file,
+                "{}\n",
+            )
+            _write_private_text(
+                stderr_file,
+                "",
+            )
+
+            command = build_nuclei_command(
+                inspection,
+                config,
+                target_file=target_file,
+                output_file=output_file,
+                config_file=config_file,
+            )
+
+            try:
+                with stderr_file.open("ab") as stderr_handle:
+                    process = subprocess.Popen(
+                        command,
+                        stdin=subprocess.DEVNULL,
+                        stdout=subprocess.DEVNULL,
+                        stderr=stderr_handle,
+                        cwd=work_dir,
+                        env=sanitized_environment(),
+                        start_new_session=(os.name == "posix"),
+                        shell=False,
+                    )
+
+                    try:
+                        return_code = process.wait(timeout=(config.scan_timeout_seconds + 15))
+                    except subprocess.TimeoutExpired as exc:
+                        _terminate_process(process)
+                        raise EngineExecutionError(
+                            "Nuclei exceeded the configured "
+                            f"{config.scan_timeout_seconds}-second "
+                            "scan timeout."
+                        ) from exc
+
+            except OSError as exc:
+                raise EngineExecutionError("Nuclei could not be started.") from exc
+
+            stderr_text = _read_limited_text(stderr_file).strip()
+
+            if return_code != 0:
+                detail = stderr_text or (f"Nuclei exited with status {return_code}.")
+
+                raise EngineExecutionError("Nuclei scan failed: " + detail)
+
+            if stderr_text:
+                warnings.append("Nuclei diagnostic output: " + stderr_text)
+
+            if output_file.exists():
+                output_file.chmod(0o600)
+
+            findings = parse_nuclei_jsonl(
+                output_file,
+                engine_version=(inspection.version_text),
+                max_output_bytes=(config.max_output_bytes),
+                max_line_bytes=(config.max_line_bytes),
+            )
+
+        finished = datetime.now(UTC)
+
+        return PentestReport(
+            engine=self.name,
+            engine_version=(inspection.version_text),
+            profile=config.profile.value,
+            started_at=(started.isoformat()),
+            finished_at=(finished.isoformat()),
+            duration_seconds=(finished - started).total_seconds(),
+            targets=tuple(target.url for target in targets),
+            findings=findings,
+            warnings=tuple(warnings),
+        )

--- a/nuguard/pentest/reporting.py
+++ b/nuguard/pentest/reporting.py
@@ -1,0 +1,363 @@
+"""Deterministic text, JSON, Markdown, and SARIF pentest reports."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    PentestFinding,
+    PentestReport,
+    ReportFormat,
+    Severity,
+)
+
+
+def _markdown_escape(
+    value: str,
+) -> str:
+    return value.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def render_text(
+    report: PentestReport,
+) -> str:
+    counts = report.severity_counts()
+
+    lines = [
+        "NuGuard cloud application pentest",
+        f"Engine: {report.engine} {report.engine_version}",
+        f"Profile: {report.profile}",
+        f"Targets: {len(report.targets)}",
+        f"Findings: {len(report.findings)}",
+        (
+            "Severity: "
+            + ", ".join(
+                f"{severity.value}={counts[severity]}" for severity in reversed(tuple(Severity))
+            )
+        ),
+        "",
+    ]
+
+    for finding in report.findings:
+        lines.extend(
+            (
+                (f"[{finding.severity.value.upper()}] {finding.title}"),
+                f"  Rule: {finding.rule_id}",
+                f"  Target: {finding.target}",
+                f"  Matched: {finding.matched_at}",
+                f"  Description: {finding.description}",
+            )
+        )
+
+        if finding.remediation:
+            lines.append("  Remediation: " + finding.remediation)
+
+        lines.append("")
+
+    if report.warnings:
+        lines.append("Warnings:")
+
+        for warning in report.warnings:
+            lines.append(f"  - {warning}")
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_markdown(
+    report: PentestReport,
+) -> str:
+    counts = report.severity_counts()
+
+    lines = [
+        "# NuGuard cloud application pentest",
+        "",
+        f"- **Engine:** `{report.engine} {report.engine_version}`",
+        f"- **Profile:** `{report.profile}`",
+        f"- **Targets:** {len(report.targets)}",
+        f"- **Findings:** {len(report.findings)}",
+        "",
+        "## Severity summary",
+        "",
+        "| Severity | Count |",
+        "| --- | ---: |",
+    ]
+
+    for severity in reversed(tuple(Severity)):
+        lines.append(f"| {severity.value} | {counts[severity]} |")
+
+    lines.extend(
+        (
+            "",
+            "## Findings",
+            "",
+        )
+    )
+
+    if not report.findings:
+        lines.append("No findings were reported.")
+
+    for finding in report.findings:
+        lines.extend(
+            (
+                (f"### {finding.severity.value.upper()}: {_markdown_escape(finding.title)}"),
+                "",
+                f"- **Rule:** `{_markdown_escape(finding.rule_id)}`",
+                f"- **Target:** `{_markdown_escape(finding.target)}`",
+                f"- **Matched at:** `{_markdown_escape(finding.matched_at)}`",
+                "",
+                _markdown_escape(finding.description),
+                "",
+            )
+        )
+
+        if finding.remediation:
+            lines.extend(
+                (
+                    "**Remediation:**",
+                    "",
+                    _markdown_escape(finding.remediation),
+                    "",
+                )
+            )
+
+        if finding.references:
+            lines.append("**References:**")
+            lines.append("")
+
+            for reference in finding.references:
+                lines.append(f"- {_markdown_escape(reference)}")
+
+            lines.append("")
+
+    if report.warnings:
+        lines.extend(
+            (
+                "## Warnings",
+                "",
+            )
+        )
+
+        for warning in report.warnings:
+            lines.append(f"- {_markdown_escape(warning)}")
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _sarif_level(
+    severity: Severity,
+) -> str:
+    if severity in {
+        Severity.CRITICAL,
+        Severity.HIGH,
+    }:
+        return "error"
+
+    if severity is Severity.MEDIUM:
+        return "warning"
+
+    return "note"
+
+
+def _sarif_rule(
+    finding: PentestFinding,
+) -> dict[str, Any]:
+    rule: dict[str, Any] = {
+        "id": finding.rule_id,
+        "name": finding.title,
+        "shortDescription": {
+            "text": finding.title,
+        },
+        "fullDescription": {
+            "text": finding.description,
+        },
+        "defaultConfiguration": {"level": _sarif_level(finding.severity)},
+        "properties": {
+            "severity": (finding.severity.value),
+            "tags": list(finding.tags),
+            "engine": finding.engine,
+        },
+    }
+
+    if finding.remediation:
+        rule["help"] = {
+            "text": finding.remediation,
+        }
+
+    return rule
+
+
+def render_sarif(
+    report: PentestReport,
+) -> str:
+    rules: dict[
+        str,
+        dict[str, Any],
+    ] = {}
+
+    results: list[dict[str, Any]] = []
+
+    for finding in report.findings:
+        rules.setdefault(
+            finding.rule_id,
+            _sarif_rule(finding),
+        )
+
+        results.append(
+            {
+                "ruleId": finding.rule_id,
+                "level": _sarif_level(finding.severity),
+                "message": {
+                    "text": finding.description,
+                },
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": (finding.matched_at or finding.target)}
+                        }
+                    }
+                ],
+                "partialFingerprints": {"nuguardPentestId": (finding.finding_id)},
+                "properties": {
+                    "severity": (finding.severity.value),
+                    "target": finding.target,
+                    "matchedAt": (finding.matched_at),
+                    "engine": finding.engine,
+                    "engineVersion": (finding.engine_version),
+                    "tags": list(finding.tags),
+                },
+            }
+        )
+
+    document = {
+        "$schema": ("https://json.schemastore.org/sarif-2.1.0.json"),
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": ("NuGuard cloud pentest"),
+                        "informationUri": ("https://github.com/NuGuardAI/nuguard"),
+                        "rules": list(rules.values()),
+                    }
+                },
+                "results": results,
+                "properties": {
+                    "engine": report.engine,
+                    "engineVersion": (report.engine_version),
+                    "profile": report.profile,
+                    "targets": list(report.targets),
+                    "warnings": list(report.warnings),
+                },
+            }
+        ],
+    }
+
+    return (
+        json.dumps(
+            document,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def render_report(
+    report: PentestReport,
+    report_format: ReportFormat,
+) -> str:
+    if report_format is ReportFormat.JSON:
+        return (
+            json.dumps(
+                report.to_dict(),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    if report_format is ReportFormat.MARKDOWN:
+        return render_markdown(report)
+
+    if report_format is ReportFormat.SARIF:
+        return render_sarif(report)
+
+    return render_text(report)
+
+
+def write_report(
+    path: Path,
+    content: str,
+) -> Path:
+    """Write a report atomically with owner-only permissions."""
+    expanded = path.expanduser()
+
+    if not expanded.is_absolute():
+        expanded = Path.cwd() / expanded
+
+    path = expanded.parent.resolve() / expanded.name
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    if path.is_symlink():
+        raise OSError(f"Refusing to replace report symlink: {path}")
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+
+    try:
+        os.fchmod(
+            descriptor,
+            0o600,
+        )
+
+        with os.fdopen(
+            descriptor,
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        os.replace(
+            temporary_path,
+            path,
+        )
+        path.chmod(0o600)
+
+    except Exception:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return path
+
+
+def threshold_exit_code(
+    report: PentestReport,
+    threshold: Severity | None,
+) -> int:
+    if threshold is None:
+        return 0
+
+    return 1 if report.has_at_or_above(threshold) else 0

--- a/nuguard/pentest/runner.py
+++ b/nuguard/pentest/runner.py
@@ -1,0 +1,46 @@
+"""Public orchestration for explicitly authorized pentests."""
+
+from __future__ import annotations
+
+from .engine import (
+    AuthorizationError,
+    PentestEngine,
+)
+from .models import (
+    PentestConfig,
+    PentestReport,
+)
+from .nuclei import NucleiEngine
+from .scope import (
+    Resolver,
+    validate_targets,
+)
+
+
+def run_pentest(
+    config: PentestConfig,
+    *,
+    resolver: Resolver | None = None,
+    engine: PentestEngine | None = None,
+) -> PentestReport:
+    """Validate authorization and scope before starting an engine."""
+    if not config.authorized:
+        raise AuthorizationError(
+            "Active pentesting requires explicit authorization. "
+            "Pass --acknowledge-authorization only when you own the "
+            "target or have documented permission to test it."
+        )
+
+    targets = validate_targets(
+        config.targets,
+        allow_private=config.allow_private,
+        resolver=resolver,
+        max_targets=config.max_targets,
+    )
+
+    selected_engine = engine if engine is not None else NucleiEngine()
+
+    return selected_engine.run(
+        config,
+        targets,
+    )

--- a/nuguard/pentest/scope.py
+++ b/nuguard/pentest/scope.py
@@ -1,0 +1,380 @@
+"""Target normalization and active-scan network scope controls."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import socket
+from collections.abc import Callable, Sequence
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from .engine import ScopeError
+from .models import PentestTarget
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+Resolver = Callable[[str, int], Sequence[str]]
+
+_BLOCKED_HOSTS = {
+    "localhost",
+    "localhost.localdomain",
+    "metadata.google.internal",
+    "metadata.goog",
+    "kubernetes.default",
+    "kubernetes.default.svc",
+    "kubernetes.default.svc.cluster.local",
+}
+
+_BLOCKED_NETWORKS = (
+    ipaddress.ip_network("169.254.169.254/32"),
+    ipaddress.ip_network("169.254.170.2/32"),
+    ipaddress.ip_network("100.100.100.200/32"),
+    ipaddress.ip_network("fd00:ec2::254/128"),
+)
+
+_SENSITIVE_QUERY_KEY_RE = re.compile(
+    r"(?:api[_-]?key|token|secret|password|passwd|signature|"
+    r"authorization|credential|session|cookie)",
+    re.IGNORECASE,
+)
+
+_HIGH_ENTROPY_PATH_RE = re.compile(r"^(?:sk-[A-Za-z0-9_-]+|[A-Za-z0-9_-]{40,})$")
+
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+
+_KEY_RE = re.compile(r"\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}\b")
+
+_INLINE_SECRET_RE = re.compile(
+    r"(?i)\b(api[_ -]?key|token|secret|password|authorization)"
+    r"(\s*[:=]\s*)([^\s,;\"']+|\"[^\"]*\"|'[^']*')"
+)
+
+
+def _redact_text(value: str, *, limit: int = 2048) -> str:
+    value = _BEARER_RE.sub(
+        "Bearer [REDACTED]",
+        value,
+    )
+    value = _KEY_RE.sub(
+        "[REDACTED]",
+        value,
+    )
+    value = _INLINE_SECRET_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        value,
+    )
+
+    if len(value) > limit:
+        return value[:limit] + "..."
+
+    return value
+
+
+def sanitize_url_for_report(value: str) -> str:
+    """Remove secrets and user information from a URL-like value."""
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return _redact_text(value)
+
+    if not parsed.scheme or parsed.hostname is None:
+        return _redact_text(value)
+
+    host = parsed.hostname
+
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    netloc = f"{host}:{port}" if port is not None else host
+
+    safe_query: list[tuple[str, str]] = []
+
+    for key, item in parse_qsl(
+        parsed.query,
+        keep_blank_values=True,
+    ):
+        safe_item = (
+            "[REDACTED]"
+            if _SENSITIVE_QUERY_KEY_RE.search(key)
+            else _redact_text(
+                item,
+                limit=512,
+            )
+        )
+
+        safe_query.append(
+            (
+                key,
+                safe_item,
+            )
+        )
+
+    safe_segments: list[str] = []
+
+    for segment in parsed.path.split("/"):
+        if _HIGH_ENTROPY_PATH_RE.fullmatch(segment):
+            safe_segments.append("[REDACTED]")
+        else:
+            safe_segments.append(
+                _redact_text(
+                    segment,
+                    limit=512,
+                )
+            )
+
+    safe_path = "/".join(safe_segments)
+
+    return urlunsplit(
+        (
+            parsed.scheme,
+            netloc,
+            safe_path,
+            urlencode(safe_query),
+            "",
+        )
+    )
+
+
+def _default_resolver(
+    hostname: str,
+    port: int,
+) -> Sequence[str]:
+    addresses = {
+        str(result[4][0])
+        for result in socket.getaddrinfo(
+            hostname,
+            port,
+            type=socket.SOCK_STREAM,
+        )
+    }
+
+    return tuple(sorted(addresses))
+
+
+def _blocked_address_reason(
+    address: IPAddress,
+    *,
+    allow_private: bool,
+) -> str | None:
+    for network in _BLOCKED_NETWORKS:
+        if address.version == network.version and address in network:
+            return "cloud metadata-service address"
+
+    if address.is_unspecified:
+        return "unspecified address"
+
+    if address.is_loopback:
+        return "loopback address"
+
+    if address.is_link_local:
+        return "link-local address"
+
+    if address.is_multicast:
+        return "multicast address"
+
+    if address.is_reserved:
+        return "reserved address"
+
+    if address.is_private:
+        if allow_private:
+            return None
+
+        return "private address without --allow-private"
+
+    if not address.is_global:
+        return "non-global address"
+
+    return None
+
+
+def _normalize_target(
+    raw_target: str,
+) -> tuple[str, str, int]:
+    raw_target = raw_target.strip()
+
+    if not raw_target:
+        raise ScopeError("Target cannot be empty.")
+
+    if len(raw_target) > 2048:
+        raise ScopeError("Target exceeds the 2048-character limit.")
+
+    if any(ord(character) < 32 for character in raw_target):
+        raise ScopeError("Target contains control characters.")
+
+    if "\\" in raw_target:
+        raise ScopeError("Backslashes are not allowed in targets.")
+
+    try:
+        parsed = urlsplit(raw_target)
+        port = parsed.port
+    except ValueError as exc:
+        raise ScopeError(f"Invalid target URL: {raw_target!r}") from exc
+
+    scheme = parsed.scheme.casefold()
+
+    if scheme not in {"http", "https"}:
+        raise ScopeError("Only explicit http:// and https:// targets are supported.")
+
+    if parsed.hostname is None:
+        raise ScopeError(f"Target does not contain a hostname: {raw_target!r}")
+
+    if parsed.username is not None or parsed.password is not None:
+        raise ScopeError("Credentials are not allowed in target URLs.")
+
+    if parsed.fragment:
+        raise ScopeError("URL fragments are not allowed in active-scan targets.")
+
+    try:
+        hostname = parsed.hostname.encode("idna").decode("ascii").casefold().rstrip(".")
+    except UnicodeError as exc:
+        raise ScopeError(f"Target hostname is not valid IDNA: {parsed.hostname!r}") from exc
+
+    if hostname in _BLOCKED_HOSTS or hostname.endswith(".localhost"):
+        raise ScopeError(f"Blocked control-plane or local hostname: {hostname}")
+
+    default_port = 443 if scheme == "https" else 80
+    effective_port = port if port is not None else default_port
+
+    if not 1 <= effective_port <= 65535:
+        raise ScopeError(f"Target port is outside the valid range: {effective_port}")
+
+    query = []
+
+    for key, value in parse_qsl(
+        parsed.query,
+        keep_blank_values=True,
+    ):
+        if _SENSITIVE_QUERY_KEY_RE.search(key):
+            raise ScopeError(
+                f"Credential-like query parameters are not allowed in active-scan targets: {key!r}"
+            )
+
+        query.append((key, value))
+
+    display_host = f"[{hostname}]" if ":" in hostname else hostname
+
+    netloc = display_host
+
+    if effective_port != default_port:
+        netloc = f"{display_host}:{effective_port}"
+
+    normalized = urlunsplit(
+        (
+            scheme,
+            netloc,
+            parsed.path or "/",
+            urlencode(query),
+            "",
+        )
+    )
+
+    return (
+        normalized,
+        hostname,
+        effective_port,
+    )
+
+
+def validate_target(
+    raw_target: str,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> PentestTarget:
+    """Normalize and resolve a target, rejecting unsafe address classes."""
+    normalized, hostname, port = _normalize_target(raw_target)
+
+    try:
+        literal_address = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal_address = None
+
+    resolved: tuple[str, ...]
+
+    if literal_address is not None:
+        resolved = (str(literal_address),)
+    else:
+        resolve = resolver if resolver is not None else _default_resolver
+
+        try:
+            resolved = tuple(
+                resolve(
+                    hostname,
+                    port,
+                )
+            )
+        except OSError as exc:
+            raise ScopeError(f"Could not resolve target hostname {hostname!r}: {exc}") from exc
+
+    if not resolved:
+        raise ScopeError(f"Target hostname did not resolve to an address: {hostname}")
+
+    addresses: set[IPAddress] = set()
+
+    for raw_address in resolved:
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            raise ScopeError(f"Resolver returned an invalid IP address: {raw_address!r}") from exc
+
+        reason = _blocked_address_reason(
+            address,
+            allow_private=allow_private,
+        )
+
+        if reason is not None:
+            raise ScopeError(f"Target {hostname!r} resolved to blocked {reason}: {address}")
+
+        addresses.add(address)
+
+    ordered_addresses = tuple(
+        str(address)
+        for address in sorted(
+            addresses,
+            key=lambda item: (
+                item.version,
+                int(item),
+            ),
+        )
+    )
+
+    return PentestTarget(
+        original=raw_target,
+        url=normalized,
+        hostname=hostname,
+        port=port,
+        resolved_ips=ordered_addresses,
+    )
+
+
+def validate_targets(
+    raw_targets: Sequence[str],
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+    max_targets: int = 50,
+) -> tuple[PentestTarget, ...]:
+    """Validate and deduplicate a bounded set of active-scan targets."""
+    if not raw_targets:
+        raise ScopeError("At least one target is required.")
+
+    if len(raw_targets) > max_targets:
+        raise ScopeError(f"At most {max_targets} targets are allowed per scan.")
+
+    validated: list[PentestTarget] = []
+    seen: set[str] = set()
+
+    for raw_target in raw_targets:
+        target = validate_target(
+            raw_target,
+            allow_private=allow_private,
+            resolver=resolver,
+        )
+
+        if target.url in seen:
+            continue
+
+        seen.add(target.url)
+        validated.append(target)
+
+    return tuple(validated)

--- a/tests/pentest/test_nuclei.py
+++ b/tests/pentest/test_nuclei.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import nuguard.pentest.nuclei as nuclei_module
+from nuguard.pentest.engine import (
+    EngineExecutionError,
+    EngineUnavailableError,
+)
+from nuguard.pentest.models import (
+    PentestConfig,
+    PentestTarget,
+    ScanProfile,
+    Severity,
+)
+from nuguard.pentest.nuclei import (
+    NucleiEngine,
+    NucleiInspection,
+    build_nuclei_command,
+    inspect_nuclei,
+    parse_nuclei_jsonl,
+    parse_nuclei_version,
+    sanitized_environment,
+)
+
+_REQUIRED_HELP_FLAGS = (
+    "-list",
+    "-jsonl",
+    "-output",
+    "-config",
+    "-templates",
+    "-silent",
+    "-no-color",
+    "-severity",
+    "-type",
+    "-disable-unsigned-templates",
+    "-no-interactsh",
+    "-no-stdin",
+    "-disable-update-check",
+    "-disable-redirects",
+    "-restrict-local-network-access",
+    "-omit-raw",
+    "-omit-template",
+    "-exclude-tags",
+    "-rate-limit",
+    "-concurrency",
+    "-bulk-size",
+    "-retries",
+    "-timeout",
+    "-max-host-error",
+    "-response-size-read",
+    "-response-size-save",
+)
+
+
+def _fake_nuclei(
+    path: Path,
+    *,
+    version: str = "3.11.1",
+    output_line: str | None = None,
+    help_flags: tuple[str, ...] = _REQUIRED_HELP_FLAGS,
+) -> Path:
+    line = (
+        output_line
+        if output_line is not None
+        else json.dumps(
+            {
+                "template-id": "cloud-exposure",
+                "info": {
+                    "name": "Cloud exposure",
+                    "severity": "high",
+                    "description": ("A cloud endpoint is exposed."),
+                    "remediation": ("Restrict access."),
+                    "tags": [
+                        "cloud",
+                        "exposure",
+                    ],
+                    "reference": ["https://example.com/advisory"],
+                },
+                "type": "http",
+                "host": "https://example.com/",
+                "matched-at": ("https://example.com/?token=do-not-retain"),
+                "matcher-name": "status-code",
+                "extracted-results": ["Bearer do-not-retain-this"],
+                "request": ("Authorization: Bearer raw-request-secret"),
+                "response": ("raw-response-secret"),
+                "curl-command": ("curl -H 'Authorization: Bearer raw-curl-secret'"),
+            }
+        )
+    )
+
+    version_line = f"Nuclei Engine Version: v{version}"
+    help_text = "\n".join(help_flags)
+    output_text = line + "\n"
+
+    script = "\n".join(
+        (
+            "#!/usr/bin/env python3",
+            "from __future__ import annotations",
+            "",
+            "import pathlib",
+            "import sys",
+            "",
+            "args = sys.argv[1:]",
+            "",
+            'if "-version" in args:',
+            f"    print({version_line!r})",
+            "    raise SystemExit(0)",
+            "",
+            'if "-h" in args:',
+            f"    print({help_text!r})",
+            "    raise SystemExit(0)",
+            "",
+            ('output = pathlib.Path(args[args.index("-output") + 1])'),
+            (f"output.write_text({output_text!r}, encoding='utf-8')"),
+            "",
+        )
+    )
+
+    path.write_text(
+        script,
+        encoding="utf-8",
+    )
+    path.chmod(0o700)
+
+    return path
+
+
+def _target() -> PentestTarget:
+    return PentestTarget(
+        original="https://example.com/",
+        url="https://example.com/",
+        hostname="example.com",
+        port=443,
+        resolved_ips=("93.184.216.34",),
+    )
+
+
+def _config(
+    binary: Path,
+    **changes: Any,
+) -> PentestConfig:
+    values: dict[str, Any] = {
+        "targets": ("https://example.com/",),
+        "authorized": True,
+        "profile": ScanProfile.SAFE,
+        "nuclei_binary": str(binary),
+    }
+    values.update(changes)
+
+    return PentestConfig(**values)
+
+
+def test_version_parser_and_minimum_version(
+    tmp_path: Path,
+) -> None:
+    assert parse_nuclei_version("Nuclei Engine Version: v3.11.1") == (
+        3,
+        11,
+        1,
+    )
+
+    old_binary = _fake_nuclei(
+        tmp_path / "old-nuclei",
+        version="3.9.9",
+    )
+
+    with pytest.raises(EngineUnavailableError):
+        inspect_nuclei(str(old_binary))
+
+
+def test_missing_required_help_flag_is_rejected(
+    tmp_path: Path,
+) -> None:
+    binary = _fake_nuclei(
+        tmp_path / "incomplete-nuclei",
+        help_flags=tuple(flag for flag in _REQUIRED_HELP_FLAGS if flag != "-omit-raw"),
+    )
+
+    with pytest.raises(
+        EngineUnavailableError,
+        match=("missing required safety controls"),
+    ):
+        inspect_nuclei(str(binary))
+
+
+def test_world_writable_binary_is_rejected(
+    tmp_path: Path,
+) -> None:
+    binary = _fake_nuclei(tmp_path / "unsafe-nuclei")
+    binary.chmod(0o777)
+
+    with pytest.raises(EngineUnavailableError):
+        inspect_nuclei(str(binary))
+
+
+def test_environment_credentials_and_cloud_controls_are_isolated() -> None:
+    environment = sanitized_environment(
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/tmp/home",
+            "SAFE_VALUE": "retained",
+            "GITHUB_TOKEN": "removed",
+            "AWS_SECRET_ACCESS_KEY": ("removed"),
+            "OPENAI_API_KEY": "removed",
+            "PDCP_API_KEY": "removed",
+            "ENABLE_CLOUD_UPLOAD": "true",
+            ("DISABLE_NUCLEI_TEMPLATES_PUBLIC_DOWNLOAD"): "false",
+            "SSH_AUTH_SOCK": "/tmp/socket",
+        }
+    )
+
+    assert environment["PATH"] == "/usr/bin"
+    assert environment["SAFE_VALUE"] == "retained"
+    assert "GITHUB_TOKEN" not in environment
+    assert "AWS_SECRET_ACCESS_KEY" not in environment
+    assert "OPENAI_API_KEY" not in environment
+    assert "PDCP_API_KEY" not in environment
+    assert "ENABLE_CLOUD_UPLOAD" not in environment
+    assert "SSH_AUTH_SOCK" not in environment
+    assert environment["DISABLE_NUCLEI_TEMPLATES_PUBLIC_DOWNLOAD"] == "true"
+    assert environment["DISABLE_NUCLEI_TEMPLATES_GITHUB_DOWNLOAD"] == "true"
+
+
+def test_command_has_closed_http_only_safety_controls(
+    tmp_path: Path,
+) -> None:
+    binary = _fake_nuclei(tmp_path / "nuclei")
+    inspection = NucleiInspection(
+        binary=binary,
+        version=(
+            3,
+            11,
+            1,
+        ),
+        version_text="3.11.1",
+    )
+    config = _config(binary)
+
+    command = build_nuclei_command(
+        inspection,
+        config,
+        target_file=(tmp_path / "targets.txt"),
+        output_file=(tmp_path / "output.jsonl"),
+        config_file=(tmp_path / "config.yaml"),
+    )
+
+    for required in (
+        "-disable-unsigned-templates",
+        "-no-interactsh",
+        "-no-stdin",
+        "-disable-update-check",
+        "-disable-redirects",
+        "-restrict-local-network-access",
+        "-omit-raw",
+        "-omit-template",
+        "-max-host-error",
+    ):
+        assert required in command
+
+    type_index = command.index("-type")
+    assert command[type_index + 1] == "http"
+    assert "-exclude-type" not in command
+    assert "-scan-timeout" not in command
+    assert "-headless" not in command
+    assert "-code" not in command
+    assert "-allow-local-file-access" not in command
+    assert "-cloud-upload" not in command
+    assert "-dashboard" not in command
+
+    private_command = build_nuclei_command(
+        inspection,
+        _config(
+            binary,
+            allow_private=True,
+        ),
+        target_file=(tmp_path / "private-targets.txt"),
+        output_file=(tmp_path / "private-output.jsonl"),
+        config_file=(tmp_path / "private-config.yaml"),
+    )
+
+    assert "-restrict-local-network-access" not in private_command
+
+
+def test_jsonl_parser_redacts_and_omits_raw_http_data(
+    tmp_path: Path,
+) -> None:
+    secret_path = "A" * 48
+    path = tmp_path / "nuclei.jsonl"
+
+    path.write_text(
+        json.dumps(
+            {
+                "template-id": ("cloud-exposure"),
+                "info": {
+                    "name": ("Cloud exposure"),
+                    "severity": "high",
+                    "description": ("Sensitive endpoint exposed."),
+                    "tags": ("cloud,exposure"),
+                    "reference": [("https://example.com/advisory")],
+                },
+                "type": "http",
+                "host": ("https://example.com/"),
+                "matched-at": (f"https://user:password@example.com/{secret_path}?token=secret"),
+                "matcher-name": ("status-code"),
+                "extracted-results": [("Bearer very-secret-value-123456")],
+                "request": ("raw-request-secret"),
+                "response": ("raw-response-secret"),
+                "curl-command": ("raw-curl-secret"),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    findings = parse_nuclei_jsonl(
+        path,
+        engine_version="3.11.1",
+        max_output_bytes=(1024 * 1024),
+        max_line_bytes=(1024 * 1024),
+    )
+
+    assert len(findings) == 1
+
+    finding = findings[0]
+
+    assert finding.severity is Severity.HIGH
+
+    serialized = json.dumps(
+        finding.to_dict(),
+        sort_keys=True,
+    )
+
+    assert "raw-request-secret" not in serialized
+    assert "raw-response-secret" not in serialized
+    assert "raw-curl-secret" not in serialized
+    assert "user:password" not in serialized
+    assert "token=secret" not in serialized
+    assert secret_path not in serialized
+    assert "very-secret-value" not in serialized
+    assert "[REDACTED]" in serialized
+
+
+def test_malformed_jsonl_fails_closed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "malformed.jsonl"
+    path.write_text(
+        "{not-json\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        EngineExecutionError,
+        match="malformed JSONL",
+    ):
+        parse_nuclei_jsonl(
+            path,
+            engine_version="3.11.1",
+            max_output_bytes=1024,
+            max_line_bytes=1024,
+        )
+
+
+def test_total_output_limit_fails_closed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "oversized.jsonl"
+    path.write_bytes(b"x" * 1025)
+
+    with pytest.raises(
+        EngineExecutionError,
+        match="output exceeded",
+    ):
+        parse_nuclei_jsonl(
+            path,
+            engine_version="3.11.1",
+            max_output_bytes=1024,
+            max_line_bytes=2048,
+        )
+
+
+def test_jsonl_line_limit_fails_closed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "oversized-line.jsonl"
+    path.write_bytes(b'{"value":"' + (b"A" * 2048) + b'"}\n')
+
+    with pytest.raises(
+        EngineExecutionError,
+        match=("oversized JSONL record"),
+    ):
+        parse_nuclei_jsonl(
+            path,
+            engine_version="3.11.1",
+            max_output_bytes=4096,
+            max_line_bytes=256,
+        )
+
+
+def test_engine_runs_fake_binary_and_normalizes_finding(
+    tmp_path: Path,
+) -> None:
+    binary = _fake_nuclei(tmp_path / "nuclei")
+
+    report = NucleiEngine().run(
+        _config(binary),
+        (_target(),),
+    )
+
+    assert report.engine == "nuclei"
+    assert report.engine_version == "3.11.1"
+    assert len(report.findings) == 1
+    assert report.findings[0].rule_id == "nuclei:cloud-exposure"
+
+    serialized = json.dumps(
+        report.to_dict(),
+        sort_keys=True,
+    )
+
+    assert "raw-request-secret" not in serialized
+    assert "raw-response-secret" not in serialized
+    assert "raw-curl-secret" not in serialized
+    assert "do-not-retain" not in serialized
+
+
+def test_engine_enforces_outer_timeout_without_waiting_in_real_time(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary = _fake_nuclei(tmp_path / "nuclei")
+    inspection = NucleiInspection(
+        binary=binary,
+        version=(
+            3,
+            11,
+            1,
+        ),
+        version_text="3.11.1",
+    )
+    terminated: list[object] = []
+
+    class TimeoutProcess:
+        pid = 123456
+
+        def __init__(
+            self,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> None:
+            pass
+
+        def wait(
+            self,
+            timeout: float | None = None,
+        ) -> int:
+            raise subprocess.TimeoutExpired(
+                cmd="nuclei",
+                timeout=timeout or 0,
+            )
+
+        def poll(
+            self,
+        ) -> int | None:
+            return None
+
+    monkeypatch.setattr(
+        nuclei_module,
+        "inspect_nuclei",
+        lambda _binary_name: inspection,
+    )
+    monkeypatch.setattr(
+        nuclei_module.subprocess,
+        "Popen",
+        TimeoutProcess,
+    )
+    monkeypatch.setattr(
+        nuclei_module,
+        "_terminate_process",
+        lambda process: terminated.append(process),
+    )
+
+    with pytest.raises(
+        EngineExecutionError,
+        match="scan timeout",
+    ):
+        NucleiEngine().run(
+            _config(
+                binary,
+                scan_timeout_seconds=10,
+            ),
+            (_target(),),
+        )
+
+    assert len(terminated) == 1

--- a/tests/pentest/test_reporting.py
+++ b/tests/pentest/test_reporting.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from nuguard.pentest.engine import (
+    AuthorizationError,
+)
+from nuguard.pentest.models import (
+    PentestConfig,
+    PentestFinding,
+    PentestReport,
+    ReportFormat,
+    ScanProfile,
+    Severity,
+)
+from nuguard.pentest.reporting import (
+    render_report,
+    threshold_exit_code,
+    write_report,
+)
+from nuguard.pentest.runner import (
+    run_pentest,
+)
+
+
+def _finding(
+    severity: Severity = Severity.HIGH,
+) -> PentestFinding:
+    return PentestFinding(
+        finding_id="pentest:nuclei:123",
+        rule_id=("nuclei:cloud-exposure"),
+        title="Cloud exposure",
+        description=("An endpoint is exposed."),
+        severity=severity,
+        target="https://example.com/",
+        matched_at=("https://example.com/admin"),
+        engine="nuclei",
+        engine_version="3.11.1",
+        remediation="Restrict access.",
+        references=("https://example.com/advisory",),
+        tags=(
+            "cloud",
+            "exposure",
+        ),
+        evidence={"matcher_name": ("status-code")},
+    )
+
+
+def _report(
+    severity: Severity = Severity.HIGH,
+) -> PentestReport:
+    return PentestReport(
+        engine="nuclei",
+        engine_version="3.11.1",
+        profile="safe",
+        started_at=("2026-09-08T10:00:00+00:00"),
+        finished_at=("2026-09-08T10:00:01+00:00"),
+        duration_seconds=1.0,
+        targets=("https://example.com/",),
+        findings=(_finding(severity),),
+    )
+
+
+@pytest.mark.parametrize(
+    "report_format",
+    [
+        ReportFormat.TEXT,
+        ReportFormat.JSON,
+        ReportFormat.MARKDOWN,
+        ReportFormat.SARIF,
+    ],
+)
+def test_all_report_formats_are_rendered(
+    report_format: ReportFormat,
+) -> None:
+    rendered = render_report(
+        _report(),
+        report_format,
+    )
+
+    assert "Cloud exposure" in rendered
+    assert "cloud-exposure" in rendered
+
+    if report_format is ReportFormat.JSON:
+        document = json.loads(rendered)
+        assert document["summary"]["total"] == 1
+
+    if report_format is ReportFormat.SARIF:
+        document = json.loads(rendered)
+        assert document["version"] == "2.1.0"
+        assert document["runs"][0]["results"][0]["ruleId"] == "nuclei:cloud-exposure"
+
+
+def test_report_file_is_owner_only(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "pentest.json"
+
+    write_report(
+        destination,
+        render_report(
+            _report(),
+            ReportFormat.JSON,
+        ),
+    )
+
+    mode = stat.S_IMODE(destination.stat().st_mode)
+
+    assert mode == 0o600
+
+
+def test_report_writer_refuses_symlink(
+    tmp_path: Path,
+) -> None:
+    protected = tmp_path / "protected.txt"
+    protected.write_text(
+        "do not replace",
+        encoding="utf-8",
+    )
+
+    destination = tmp_path / "pentest.json"
+    destination.symlink_to(protected)
+
+    with pytest.raises(
+        OSError,
+        match="symlink",
+    ):
+        write_report(
+            destination,
+            render_report(
+                _report(),
+                ReportFormat.JSON,
+            ),
+        )
+
+    assert protected.read_text(encoding="utf-8") == "do not replace"
+
+
+def test_exit_threshold_is_deterministic() -> None:
+    report = _report(Severity.MEDIUM)
+
+    assert (
+        threshold_exit_code(
+            report,
+            Severity.HIGH,
+        )
+        == 0
+    )
+    assert (
+        threshold_exit_code(
+            report,
+            Severity.MEDIUM,
+        )
+        == 1
+    )
+    assert (
+        threshold_exit_code(
+            report,
+            None,
+        )
+        == 0
+    )
+
+
+def test_runner_requires_explicit_authorization() -> None:
+    config = PentestConfig(
+        targets=("https://example.com/",),
+        authorized=False,
+        profile=ScanProfile.SAFE,
+    )
+
+    with pytest.raises(AuthorizationError):
+        run_pentest(config)

--- a/tests/pentest/test_scope.py
+++ b/tests/pentest/test_scope.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+
+from nuguard.pentest.engine import ScopeError
+from nuguard.pentest.scope import (
+    sanitize_url_for_report,
+    validate_target,
+    validate_targets,
+)
+
+
+def _resolver(*addresses: str):
+    def resolve(
+        _hostname: str,
+        _port: int,
+    ) -> tuple[str, ...]:
+        return tuple(addresses)
+
+    return resolve
+
+
+def test_public_https_target_is_normalized() -> None:
+    target = validate_target(
+        "HTTPS://Example.COM/app",
+        resolver=_resolver("93.184.216.34"),
+    )
+
+    assert target.url == ("https://example.com/app")
+    assert target.hostname == "example.com"
+    assert target.port == 443
+    assert target.resolved_ips == ("93.184.216.34",)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ftp://example.com/",
+        "file:///etc/passwd",
+        "https://user:password@example.com/",
+        "https://example.com/#fragment",
+        "https://example.com/?token=secret",
+        "https://example.com/?api_key=secret",
+    ],
+)
+def test_unsafe_url_forms_are_rejected(
+    target: str,
+) -> None:
+    with pytest.raises(ScopeError):
+        validate_target(
+            target,
+            resolver=_resolver("93.184.216.34"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("hostname", "address"),
+    [
+        (
+            "localhost",
+            "127.0.0.1",
+        ),
+        (
+            "metadata.google.internal",
+            "169.254.169.254",
+        ),
+        (
+            "example.invalid",
+            "169.254.170.2",
+        ),
+        (
+            "example.invalid",
+            "100.100.100.200",
+        ),
+        (
+            "example.invalid",
+            "224.0.0.1",
+        ),
+        (
+            "example.invalid",
+            "192.0.2.1",
+        ),
+    ],
+)
+def test_control_plane_and_non_global_addresses_are_blocked(
+    hostname: str,
+    address: str,
+) -> None:
+    with pytest.raises(ScopeError):
+        validate_target(
+            f"https://{hostname}/",
+            resolver=_resolver(address),
+        )
+
+
+def test_private_target_requires_explicit_opt_in() -> None:
+    resolver = _resolver("10.20.30.40")
+
+    with pytest.raises(ScopeError):
+        validate_target(
+            "https://internal.example/",
+            resolver=resolver,
+        )
+
+    target = validate_target(
+        "https://internal.example/",
+        allow_private=True,
+        resolver=resolver,
+    )
+
+    assert target.resolved_ips == ("10.20.30.40",)
+
+
+def test_allow_private_does_not_allow_metadata_or_loopback() -> None:
+    for address in (
+        "127.0.0.1",
+        "169.254.169.254",
+    ):
+        with pytest.raises(ScopeError):
+            validate_target(
+                "https://internal.example/",
+                allow_private=True,
+                resolver=_resolver(address),
+            )
+
+
+def test_mixed_dns_answer_fails_closed() -> None:
+    with pytest.raises(ScopeError):
+        validate_target(
+            "https://mixed.example/",
+            resolver=_resolver(
+                "93.184.216.34",
+                "127.0.0.1",
+            ),
+        )
+
+
+def test_targets_are_deduplicated_and_bounded() -> None:
+    targets = validate_targets(
+        (
+            "https://example.com",
+            "https://example.com/",
+        ),
+        resolver=_resolver("93.184.216.34"),
+    )
+
+    assert len(targets) == 1
+
+    with pytest.raises(ScopeError):
+        validate_targets(
+            tuple(f"https://host-{index}.example/" for index in range(51)),
+            resolver=_resolver("93.184.216.34"),
+            max_targets=50,
+        )
+
+
+def test_report_url_redaction_removes_url_credentials_and_secrets() -> None:
+    secret_path = "A" * 48
+
+    sanitized = sanitize_url_for_report(
+        f"https://user:password@example.com/{secret_path}?token=secret&view=summary"
+    )
+
+    assert "user:password" not in sanitized
+    assert secret_path not in sanitized
+    assert "secret" not in sanitized
+    assert "[REDACTED]" in sanitized
+    assert "view=summary" in sanitized

--- a/tests/test_pentest_cli.py
+++ b/tests/test_pentest_cli.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nuguard.cli.main import app
+from nuguard.pentest.models import (
+    PentestFinding,
+    PentestReport,
+    Severity,
+)
+
+runner = CliRunner()
+
+
+def _report() -> PentestReport:
+    finding = PentestFinding(
+        finding_id=("pentest:nuclei:test"),
+        rule_id="nuclei:test-rule",
+        title="Test finding",
+        description=("A deterministic test finding."),
+        severity=Severity.HIGH,
+        target="https://example.com/",
+        matched_at=("https://example.com/admin"),
+        engine="nuclei",
+        engine_version="3.11.1",
+    )
+
+    return PentestReport(
+        engine="nuclei",
+        engine_version="3.11.1",
+        profile="safe",
+        started_at=("2026-09-08T10:00:00+00:00"),
+        finished_at=("2026-09-08T10:00:01+00:00"),
+        duration_seconds=1.0,
+        targets=("https://example.com/",),
+        findings=(finding,),
+    )
+
+
+def test_root_help_lists_pentest_command() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--help",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "pentest" in result.output
+
+
+def test_pentest_refuses_missing_authorization() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "pentest",
+            "--target",
+            "https://example.com/",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "explicit authorization" in result.output.casefold()
+
+
+def test_pentest_json_report_and_severity_exit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    command_module = importlib.import_module("nuguard.cli.commands.pentest")
+
+    monkeypatch.setattr(
+        command_module,
+        "run_pentest",
+        lambda _config: _report(),
+    )
+
+    output = tmp_path / "pentest.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "pentest",
+            "--target",
+            "https://example.com/",
+            "--acknowledge-authorization",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+            "--fail-on",
+            "high",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert output.is_file()
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+
+    assert document["summary"]["total"] == 1
+    assert document["findings"][0]["rule_id"] == "nuclei:test-rule"


### PR DESCRIPTION
## PR Type

- [ ] Bug fix
- [x] Feature

## What

- Add an explicit `nuguard pentest` command for conventional HTTP/HTTPS cloud-application testing.
- Add an engine-neutral `PentestEngine` interface and a safety-bounded ProjectDiscovery Nuclei implementation.
- Require explicit acknowledgement that the operator owns each target or has documented permission to test it.
- Validate and resolve every target before scanner execution.
- Block loopback, link-local, multicast, reserved, cloud metadata-service, and platform control-plane targets.
- Require `--allow-private` for RFC1918 and unique-local targets.
- Reject URL credentials, credential-like query parameters, fragments, control characters, mixed safe/unsafe DNS answers, and excessive target counts.
- Enforce bounded rate, concurrency, retries, request time, whole-scan time, response size, JSONL record size, and total output size.
- Require Nuclei 3.10.0 or newer and verify required safety controls before scanning.
- Use an HTTP-only template-type allowlist.
- Disable unsigned templates, OAST/Interactsh, updates, template downloads, redirects, stdin targets, raw output, and template-body output.
- Exclude denial-of-service, fuzzing, intrusive, brute-force, and default-login templates.
- Remove credential-bearing environment variables and inherited cloud-upload activation before starting Nuclei.
- Avoid arbitrary scanner-argument passthrough.
- Use owner-only temporary files and atomic owner-only report output.
- Reject symbolic-link report destinations.
- Normalize Nuclei JSONL into deterministic NuGuard findings.
- Discard raw requests, responses, curl commands, and template bodies.
- Parse report URLs before redaction so sensitive values are removed without deleting benign query parameters.
- Redact credentials, bearer values, API keys, sensitive query parameters, URL user information, and high-entropy URL path segments.
- Add text, JSON, Markdown, and SARIF reports.
- Add deterministic CI severity thresholds with distinct finding and operational-error exit codes.
- Add scope, engine, malformed-output, output-boundary, redaction, timeout, reporting, orchestration, and CLI tests.
- Add user documentation covering authorization, safety controls, profiles, reports, and CI usage.

## Why

NuGuard provides static application analysis and AI-focused behavior and red-team testing, but it did not provide an explicitly authorized conventional pentesting path for cloud-hosted web applications.

The underlying gap was architectural: there was no active-testing orchestration layer, external pentest-engine contract, target-scope policy, normalized pentest finding model, or CI-grade pentest report.

Adding active scanning silently to `nuguard analyze` would be unsafe because static analysis should not unexpectedly send attack traffic to a running application. Active testing needs a separate contract for authorization, network scope, private-network access, metadata-service protection, resource limits, scanner isolation, secret handling, reporting, and deterministic CI behavior.

Closes #510

## How

### Explicit command

```bash
nuguard pentest \
  --target https://staging.example.com \
  --acknowledge-authorization
```

The command is separate from static analysis and refuses to run without explicit authorization acknowledgement.

### Engine architecture

`PentestEngine` defines the engine boundary. Nuclei is the first implementation, allowing future engines without coupling CLI, scope, reporting, or CI behavior to Nuclei output.

### Target scope

Targets are resolved before execution. Every returned address must satisfy the scope policy, and a mixed DNS response containing any blocked address fails closed.

Public scans enable Nuclei's local-network restriction. That option is omitted only when the operator explicitly selects `--allow-private`.

Private opt-in still does not permit loopback, link-local, metadata-service, multicast, reserved, or platform control-plane targets.

### Nuclei safety policy

The integration uses a closed set of scanner options and does not expose arbitrary Nuclei arguments.

It requires:

- Nuclei 3.10.0 or newer
- a regular executable that is not group- or world-writable
- signed templates
- an HTTP-only template-type allowlist
- supported safety controls
- bounded resource use

It disables or excludes:

- unsigned templates
- OAST/Interactsh
- automatic updates and template downloads
- inherited cloud-upload activation
- redirect following
- stdin targets
- raw request and response output
- template-body output
- non-HTTP and executable template types
- denial-of-service, fuzzing, intrusive, brute-force, and default-login tags

The whole-scan deadline is enforced by NuGuard's parent-process watchdog.

### Process and secret isolation

The Nuclei process receives a sanitized environment with credential-bearing variables removed. Temporary scanner files are stored in an owner-only directory.

Reports are written atomically with owner-only permissions, and symbolic-link destinations are rejected.

Raw request, response, curl-command, and template fields are ignored during normalization. Report URLs are parsed before redaction, allowing sensitive components to be removed while preserving non-sensitive evidence such as ordinary query parameters.

### Reporting and CI

Supported formats:

- text
- JSON
- Markdown
- SARIF

Exit behavior:

- `0`: scan completed and no finding met the threshold
- `1`: scan completed and a finding met the threshold
- `2`: authorization, scope, configuration, engine, timeout, or malformed-output failure

## Test Steps

```bash
python3 -m compileall -q \
  nuguard/pentest \
  nuguard/cli/commands/pentest.py \
  tests/pentest \
  tests/test_pentest_cli.py

uv run ruff check \
  nuguard/cli/commands/pentest.py \
  nuguard/cli/main.py \
  nuguard/pentest \
  tests/pentest \
  tests/test_pentest_cli.py

uv run ruff format \
  --check \
  nuguard/cli/commands/pentest.py \
  nuguard/cli/main.py \
  nuguard/pentest \
  tests/pentest \
  tests/test_pentest_cli.py

uv run mypy \
  nuguard/pentest \
  nuguard/cli/commands/pentest.py \
  nuguard/cli/main.py

uv run pytest \
  tests/pentest/test_scope.py \
  tests/pentest/test_nuclei.py \
  tests/pentest/test_reporting.py \
  tests/test_pentest_cli.py \
  -v

uv run nuguard pentest --help

make lint
make test
make precommit-run

git diff --check
```

## Checks

- [x] New Python modules compile successfully
- [x] Public HTTP/HTTPS target-normalization tests pass
- [x] Literal-IP and DNS-resolution target paths pass
- [x] Private-target opt-in tests pass
- [x] Loopback, link-local, metadata-service, multicast, reserved, and control-plane blocking tests pass
- [x] Mixed DNS answers fail closed
- [x] URL credential and sensitive-query rejection tests pass
- [x] Sensitive URL values are redacted without deleting benign query parameters
- [x] Nuclei minimum-version tests pass
- [x] Missing safety-control tests pass
- [x] Unsafe executable-permission tests pass
- [x] HTTP-only template allowlist tests pass
- [x] Whole-scan timeout tests pass
- [x] Credential-bearing environment variables are removed
- [x] Inherited cloud-upload activation is removed
- [x] Automatic template downloads are disabled during scans
- [x] Raw request, response, curl-command, and template values are not retained
- [x] URL and extracted-value redaction tests pass
- [x] Malformed and oversized JSONL output fails closed
- [x] Text, JSON, Markdown, and SARIF report tests pass
- [x] Owner-only report-permission tests pass
- [x] Symbolic-link report destinations are rejected
- [x] CI severity-threshold tests pass
- [x] Missing authorization fails before scanner execution
- [x] Blocked targets fail before scanner execution
- [x] Root CLI help exposes `nuguard pentest`
- [x] All 40 focused pentest tests pass
- [x] Ruff checks pass
- [x] Mypy checks pass
- [x] Changed Python files pass targeted Ruff formatting checks
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make precommit-run` passes
- [x] `git diff --check` passes
- [x] Final patch is limited to the intended 14 files
- [x] Added user documentation
- [x] No arbitrary Nuclei argument passthrough is exposed
- [x] Active scanning is not added silently to static analysis

## Other Notes

- Nuclei is not installed or updated automatically.
- The scanner requires version 3.10.0 or newer.
- The default `safe` profile excludes informational templates.
- The `standard` profile adds informational templates while retaining the same protocol and intrusive-template restrictions.
- Private-network scanning requires explicit opt-in.
- Authentication headers and tokens are intentionally not accepted on the command line because they could leak through shell history, process listings, logs, or crash reports.
- Authenticated scans should later use NuGuard's secret-provider abstraction rather than arbitrary scanner arguments.
- Installed template updates remain an explicit operator or CI-image-management responsibility.
- Formatting was limited to files changed by this PR to avoid unrelated repository-wide churn.
- No live target was scanned during local validation.
- The implementation does not run Nuclei from `nuguard analyze`.
- No target is scanned unless the operator supplies both a target and the authorization acknowledgement.

## Release Note

Added `nuguard pentest`, a safety-bounded conventional web-application pentesting command with explicit authorization, strict target scoping, Nuclei integration, secret-safe normalized findings, SARIF/JSON/Markdown reports, and deterministic CI thresholds.