### PR TITLE
fix(sbom): consistently exclude LLM-soft-rejected nodes

### DIFF
--- a/documentation/docs/sbom-schema.md
+++ b/documentation/docs/sbom-schema.md
@@ -488,6 +488,7 @@ Scan-level metadata derived during extraction. Populated when `nuguard sbom gene
 | `modalities` | string[] | Supported I/O modalities in upper-case, e.g. `["TEXT", "VOICE"]` |
 | `modality_support` | object | Detailed modality flags: `{"text": true, "voice": false}` |
 | `node_counts` | object | Count of nodes per ComponentType, e.g. `{"AGENT": 3, "MODEL": 2}` |
+| `node_counts_soft_rejected` | object | Per-component counts for deterministic nodes retained for audit after LLM verification rejected them. These nodes are excluded from `node_counts` and red-team scenario generation. |
 | `total_loc` | integer | SBOM 1.5.0 total lines of source code scanned across all files in the repository |
 | `uses_streaming` | boolean | True when the app exposes streaming output endpoints. The behavior engine reads this to use streaming-aware turn execution. |
 | `streaming_endpoints` | string[] | Endpoint paths confirmed to serve streaming output, e.g. `["/run_sse", "/chat/stream"]` |

--- a/nuguard/analysis/plugins/nga_rules.py
+++ b/nuguard/analysis/plugins/nga_rules.py
@@ -45,6 +45,7 @@ from nuguard.analysis.graph import AnalysisGraph
 from nuguard.analysis.models import AnalysisResult
 from nuguard.analysis.plugin_base import AnalysisPlugin
 from nuguard.common.logging import get_logger
+from nuguard.common.soft_reject import is_soft_rejected as _is_soft_rejected
 
 _log = get_logger("analysis.nga_rules")
 
@@ -53,8 +54,15 @@ _SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "INFO": 4}
 
 # ── External LLM providers whose APIs leave your trust boundary ───────────────
 _EXTERNAL_PROVIDERS = {
-    "openai", "anthropic", "google", "cohere", "mistral",
-    "deepseek", "ai21", "amazon", "azure",
+    "openai",
+    "anthropic",
+    "google",
+    "cohere",
+    "mistral",
+    "deepseek",
+    "ai21",
+    "amazon",
+    "azure",
 }
 
 # ── Trusted model registries (NGA-008) ───────────────────────────────────────
@@ -80,15 +88,24 @@ _READ_ONLY_TOOL_PREFIXES = re.compile(
 # Any TOOL node with one of these scopes is always considered irreversible,
 # regardless of its name.
 _WRITE_PRIVILEGE_SCOPES = {
-    "DB_WRITE", "FILESYSTEM_WRITE", "CODE_EXECUTION",
-    "EMAIL_OUT", "SOCIAL_MEDIA_OUT",
+    "DB_WRITE",
+    "FILESYSTEM_WRITE",
+    "CODE_EXECUTION",
+    "EMAIL_OUT",
+    "SOCIAL_MEDIA_OUT",
 }
 
 # ── HITL pattern indicators in AGENT metadata (NGA-012) ──────────────────────
 _HITL_PATTERNS = {
-    "interrupt", "interrupt_before", "interrupt_after",
-    "human_input", "requires_action", "HumanApprovalCallbackHandler",
-    "hitl", "human_in_the_loop", "human_approval",
+    "interrupt",
+    "interrupt_before",
+    "interrupt_after",
+    "human_input",
+    "requires_action",
+    "HumanApprovalCallbackHandler",
+    "hitl",
+    "human_in_the_loop",
+    "human_approval",
 }
 
 # ── GitHub Actions patterns (NGA-010/011/014) ─────────────────────────────────
@@ -96,10 +113,8 @@ _PATTERN_PR_TARGET_INJECTION = re.compile(
     r"pull_request_target.*\$\{\{.*github\.event\.pull_request\.",
     re.DOTALL,
 )
-_PATTERN_GITHUB_ENV_INJECTION = re.compile(
-    r'echo\s+.*\$\{\{.*\}\}.*>>\s*\$GITHUB_ENV'
-)
-_PATTERN_DEBUG_SECRET = re.compile(r'ACTIONS_RUNNER_DEBUG')
+_PATTERN_GITHUB_ENV_INJECTION = re.compile(r"echo\s+.*\$\{\{.*\}\}.*>>\s*\$GITHUB_ENV")
+_PATTERN_DEBUG_SECRET = re.compile(r"ACTIONS_RUNNER_DEBUG")
 
 # ── Component type sets ──────────────────────────────────────────────────────
 _GUARDRAIL_TYPES = {"GUARDRAIL"}
@@ -114,19 +129,9 @@ _IAM_TYPES = {"IAM"}
 
 # ── Shared helpers ────────────────────────────────────────────────────────────
 
+
 def _node_extras(node: dict[str, Any]) -> dict[str, Any]:
     return node.get("metadata", {}).get("extras", {}) or {}
-
-
-def _is_soft_rejected(node: dict[str, Any]) -> bool:
-    """True when SBOM LLM verification flagged this node as a likely false positive.
-
-    Same convention as ``policy/checker.py``'s ``_is_soft_rejected`` and
-    ``behavior/runner.py``'s coverage-target filter: don't raise findings
-    against a component the SBOM's own verification step already flagged as
-    not real (e.g. a mock model/order-ID string in a unit test).
-    """
-    return bool(_node_extras(node).get("llm_soft_rejected"))
 
 
 def _depl_meta(node: dict[str, Any]) -> dict[str, Any]:
@@ -135,12 +140,27 @@ def _depl_meta(node: dict[str, Any]) -> dict[str, Any]:
     extras: dict[str, Any] = meta.get("extras") or {}
     merged = dict(extras)
     for key in (
-        "deployment_target", "secret_store", "encryption_at_rest",
-        "encryption_key_ref", "runs_as_root", "has_health_check",
-        "has_resource_limits", "no_resource_limits", "ha_mode", "availability_zones",
-        "iam_type", "permissions", "iam_scope", "trust_principals",
-        "base_image", "image_name", "image_tag",
-        "has_network_policy", "source_url", "integrity_hash", "checksum",
+        "deployment_target",
+        "secret_store",
+        "encryption_at_rest",
+        "encryption_key_ref",
+        "runs_as_root",
+        "has_health_check",
+        "has_resource_limits",
+        "no_resource_limits",
+        "ha_mode",
+        "availability_zones",
+        "iam_type",
+        "permissions",
+        "iam_scope",
+        "trust_principals",
+        "base_image",
+        "image_name",
+        "image_tag",
+        "has_network_policy",
+        "source_url",
+        "integrity_hash",
+        "checksum",
     ):
         v = meta.get(key)
         if v is not None:
@@ -227,9 +247,7 @@ def _rule_nga001_phi_to_external_llm(
             continue
         extras = _node_extras(n)
         provider = (
-            extras.get("provider")
-            or (n.get("metadata") or {}).get("provider")
-            or ""
+            extras.get("provider") or (n.get("metadata") or {}).get("provider") or ""
         ).lower()
         if any(ep in provider for ep in _EXTERNAL_PROVIDERS):
             external_model_map[str(n["id"])] = (n, provider)
@@ -267,10 +285,12 @@ def _rule_nga001_phi_to_external_llm(
                     ds_name = ds.get("name", "")
                     interm_name = interm.get("name", "") if interm else None
                     if interm_name:
-                        path = (f"'{agent_name}' → CALLS → '{interm_name}' "
-                                f"→ ACCESSES[{access_type or 'read'}] → '{ds_name}' "
-                                f"(data_classification={ds_labels}) "
-                                f"→ USES → '{model_name}' (provider={provider_str})")
+                        path = (
+                            f"'{agent_name}' → CALLS → '{interm_name}' "
+                            f"→ ACCESSES[{access_type or 'read'}] → '{ds_name}' "
+                            f"(data_classification={ds_labels}) "
+                            f"→ USES → '{model_name}' (provider={provider_str})"
+                        )
                         affected = [agent_name, interm_name, ds_name, model_name]
                         remediation = (
                             f"Add output filtering on '{interm_name}' before data reaches "
@@ -278,25 +298,30 @@ def _rule_nga001_phi_to_external_llm(
                             f"'{interm_name}' output before the '{model_name}' call."
                         )
                     else:
-                        path = (f"'{agent_name}' → ACCESSES[{access_type or 'read'}] "
-                                f"→ '{ds_name}' (data_classification={ds_labels}) "
-                                f"→ USES → '{model_name}' (provider={provider_str})")
+                        path = (
+                            f"'{agent_name}' → ACCESSES[{access_type or 'read'}] "
+                            f"→ '{ds_name}' (data_classification={ds_labels}) "
+                            f"→ USES → '{model_name}' (provider={provider_str})"
+                        )
                         affected = [agent_name, ds_name, model_name]
                         remediation = (
                             f"Add output filtering on '{agent_name}' before data reaches "
                             f"'{model_name}'. Mask or redact {ds_labels} fields before "
                             f"the '{model_name}' call."
                         )
-                    findings.append(_finding(
-                        "NGA-001", "CRITICAL",
-                        f"PII/PHI data flow to external LLM: '{agent_name}' → '{model_name}'",
-                        f"Data flow detected: {path}. Regulated data (PII/PHI) may be "
-                        "transmitted outside your trust boundary, potentially violating "
-                        "applicable data protection regulations.",
-                        affected,
-                        remediation,
-                        evidence=path,
-                    ))
+                    findings.append(
+                        _finding(
+                            "NGA-001",
+                            "CRITICAL",
+                            f"PII/PHI data flow to external LLM: '{agent_name}' → '{model_name}'",
+                            f"Data flow detected: {path}. Regulated data (PII/PHI) may be "
+                            "transmitted outside your trust boundary, potentially violating "
+                            "applicable data protection regulations.",
+                            affected,
+                            remediation,
+                            evidence=path,
+                        )
+                    )
         if findings:
             return findings
         # Agent→Model edges present but no datastore paths found: fall through to summary check
@@ -306,7 +331,8 @@ def _rule_nga001_phi_to_external_llm(
     external_model_names = [n.get("name", "") for n, _ in external_model_map.values()]
     return [
         _finding(
-            "NGA-001", "CRITICAL",
+            "NGA-001",
+            "CRITICAL",
             "PII/PHI data handled by external LLM providers",
             f"The SBOM contains {', '.join(sorted(set(dc_labels)))} data "
             f"({len(phi_tables)} classified table(s)) and calls external LLM "
@@ -341,9 +367,7 @@ def _rule_nga002_insufficient_guardrails(
     findings: list[dict[str, Any]] = []
 
     # Count global guardrail nodes to detect potential SBOM extraction gaps.
-    global_guardrail_count = sum(
-        1 for n in nodes if n.get("component_type") in _GUARDRAIL_TYPES
-    )
+    global_guardrail_count = sum(1 for n in nodes if n.get("component_type") in _GUARDRAIL_TYPES)
 
     def _gap_note(description: str) -> str:
         """Append an SBOM modeling gap note when guardrail nodes exist without PROTECTS edges."""
@@ -364,7 +388,9 @@ def _rule_nga002_insufficient_guardrails(
                 continue
             if graph.has_protection(str(model["id"])):
                 continue
-            using_agents = [a for a in graph.sources(str(model["id"]), "USES") if not _is_soft_rejected(a)]
+            using_agents = [
+                a for a in graph.sources(str(model["id"]), "USES") if not _is_soft_rejected(a)
+            ]
             unprotected_agents = [a for a in using_agents if not graph.has_protection(str(a["id"]))]
             if using_agents and len(unprotected_agents) < len(using_agents):
                 # At least one calling agent is protected — model is covered
@@ -376,16 +402,19 @@ def _rule_nga002_insufficient_guardrails(
                 f"MODEL '{model_name}' has no GUARDRAIL on its PROTECTS path. "
                 f"Used by: {agent_names or ['(no agent edges)']}"
             )
-            findings.append(_finding(
-                "NGA-002", "HIGH",
-                f"LLM model '{model_name}' has no output guardrail (sub-check A)",
-                _gap_note(evidence),
-                affected,
-                f"Attach a guardrail (e.g. LlamaGuard, NeMo Guardrails) to "
-                f"'{model_name}' or to each calling agent: {agent_names or ['unknown']}.",
-                evidence=evidence,
-                modeling_gap_risk=bool(global_guardrail_count),
-            ))
+            findings.append(
+                _finding(
+                    "NGA-002",
+                    "HIGH",
+                    f"LLM model '{model_name}' has no output guardrail (sub-check A)",
+                    _gap_note(evidence),
+                    affected,
+                    f"Attach a guardrail (e.g. LlamaGuard, NeMo Guardrails) to "
+                    f"'{model_name}' or to each calling agent: {agent_names or ['unknown']}.",
+                    evidence=evidence,
+                    modeling_gap_risk=bool(global_guardrail_count),
+                )
+            )
 
         # Sub-check B: per unauthenticated API_ENDPOINT exposing an AGENT
         for ep in graph.nodes_of_type("API_ENDPOINT"):
@@ -396,7 +425,8 @@ def _rule_nga002_insufficient_guardrails(
             # Find agents the endpoint protects or that call it
             exposed_agents = graph.sources(ep_id, "PROTECTS") + graph.targets(ep_id, "CALLS")
             agent_exposed = [
-                a for a in exposed_agents
+                a
+                for a in exposed_agents
                 if (a.get("component_type") or "").upper() == "AGENT" and not _is_soft_rejected(a)
             ]
             if not agent_exposed:
@@ -413,15 +443,18 @@ def _rule_nga002_insufficient_guardrails(
                     f"Endpoint '{ep_name}' is publicly reachable and exposes "
                     f"agent '{agent_name}' without a guardrail."
                 )
-                findings.append(_finding(
-                    "NGA-002", "HIGH",
-                    f"Internet-capable agent '{agent_name}' has no output guardrail (sub-check B)",
-                    _gap_note(evidence),
-                    [ep_name, agent_name],
-                    f"Place a guardrail before '{agent_name}' on endpoint '{ep_name}'.",
-                    evidence=evidence,
-                    modeling_gap_risk=bool(global_guardrail_count),
-                ))
+                findings.append(
+                    _finding(
+                        "NGA-002",
+                        "HIGH",
+                        f"Internet-capable agent '{agent_name}' has no output guardrail (sub-check B)",
+                        _gap_note(evidence),
+                        [ep_name, agent_name],
+                        f"Place a guardrail before '{agent_name}' on endpoint '{ep_name}'.",
+                        evidence=evidence,
+                        modeling_gap_risk=bool(global_guardrail_count),
+                    )
+                )
 
         # Sub-check C: DELEGATES_TO edges where neither side is protected
         for src_agent in graph.nodes_of_type("AGENT"):
@@ -439,40 +472,45 @@ def _rule_nga002_insufficient_guardrails(
                 evidence = (
                     f"'{src_name}' DELEGATES_TO '{tgt_name}' with no guardrail on either agent."
                 )
-                findings.append(_finding(
-                    "NGA-002", "HIGH",
-                    f"Unguarded delegation: '{src_name}' → '{tgt_name}' (sub-check C)",
-                    _gap_note(evidence),
-                    [src_name, tgt_name],
-                    f"Add a guardrail between '{src_name}' and '{tgt_name}' to prevent "
-                    "prompt injection from propagating across the delegation boundary.",
-                    evidence=evidence,
-                    modeling_gap_risk=bool(global_guardrail_count),
-                ))
+                findings.append(
+                    _finding(
+                        "NGA-002",
+                        "HIGH",
+                        f"Unguarded delegation: '{src_name}' → '{tgt_name}' (sub-check C)",
+                        _gap_note(evidence),
+                        [src_name, tgt_name],
+                        f"Add a guardrail between '{src_name}' and '{tgt_name}' to prevent "
+                        "prompt injection from propagating across the delegation boundary.",
+                        evidence=evidence,
+                        modeling_gap_risk=bool(global_guardrail_count),
+                    )
+                )
 
         return findings
 
     # Fallback: flat-list checks (no graph available)
     guardrail_ids = {n["id"] for n in nodes if n.get("component_type") in _GUARDRAIL_TYPES}
     model_nodes = [
-        n for n in nodes
-        if n.get("component_type") in _MODEL_TYPES and not _is_soft_rejected(n)
+        n for n in nodes if n.get("component_type") in _MODEL_TYPES and not _is_soft_rejected(n)
     ]
     if model_nodes and not guardrail_ids:
         desc = (
             f"{len(model_nodes)} LLM model node(s) produce output with no output-validation "
             "or guardrail step detected anywhere in the SBOM graph."
         )
-        findings.append(_finding(
-            "NGA-002", "HIGH",
-            "LLM models with no output guardrail (sub-check A)",
-            _gap_note(desc),
-            [n.get("name", "") for n in model_nodes],
-            "Implement structured output parsing and validation. Add a GUARDRAIL component "
-            "(response classifier, PII filter, or output validator) between model output "
-            "and downstream consumers.",
-            modeling_gap_risk=bool(global_guardrail_count),
-        ))
+        findings.append(
+            _finding(
+                "NGA-002",
+                "HIGH",
+                "LLM models with no output guardrail (sub-check A)",
+                _gap_note(desc),
+                [n.get("name", "") for n in model_nodes],
+                "Implement structured output parsing and validation. Add a GUARDRAIL component "
+                "(response classifier, PII filter, or output validator) between model output "
+                "and downstream consumers.",
+                modeling_gap_risk=bool(global_guardrail_count),
+            )
+        )
     api_endpoint_ids = {n["id"] for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES}
     if api_endpoint_ids and not guardrail_ids:
         agents_with_outbound = set()
@@ -480,7 +518,8 @@ def _rule_nga002_insufficient_guardrails(
             if e.get("target") in api_endpoint_ids:
                 agents_with_outbound.add(e.get("source", ""))
         agent_nodes_outbound = [
-            n for n in nodes
+            n
+            for n in nodes
             if n.get("component_type") in _AGENT_TYPES
             and n["id"] in agents_with_outbound
             and not _is_soft_rejected(n)
@@ -491,15 +530,18 @@ def _rule_nga002_insufficient_guardrails(
                 "guardrail detected. Internet-capable agents without output filtering can "
                 "exfiltrate data or be manipulated by adversarial external content."
             )
-            findings.append(_finding(
-                "NGA-002", "HIGH",
-                "Internet-capable agent with no output guardrail (sub-check B)",
-                _gap_note(desc),
-                [n.get("name", "") for n in agent_nodes_outbound],
-                "Add an output guardrail or content filter between the agent and any external "
-                "API endpoints it calls. Log all outbound requests for audit purposes.",
-                modeling_gap_risk=bool(global_guardrail_count),
-            ))
+            findings.append(
+                _finding(
+                    "NGA-002",
+                    "HIGH",
+                    "Internet-capable agent with no output guardrail (sub-check B)",
+                    _gap_note(desc),
+                    [n.get("name", "") for n in agent_nodes_outbound],
+                    "Add an output guardrail or content filter between the agent and any external "
+                    "API endpoints it calls. Log all outbound requests for audit purposes.",
+                    modeling_gap_risk=bool(global_guardrail_count),
+                )
+            )
     return findings
 
 
@@ -541,7 +583,8 @@ def _rule_nga003_secrets_in_env(
     )
     return [
         _finding(
-            "NGA-003", "HIGH",
+            "NGA-003",
+            "HIGH",
             "Secrets exposed as env vars or no secret store configured",
             detail,
             affected,
@@ -561,7 +604,8 @@ def _rule_nga004_runs_as_root(
     """HIGH — Container images or K8s workloads running as root."""
     security_findings: list[str] = summary.get("security_findings") or []
     root_nodes = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in ("DEPLOYMENT", "CONTAINER_IMAGE")
         and _depl_meta(n).get("runs_as_root") is True
     ]
@@ -573,7 +617,8 @@ def _rule_nga004_runs_as_root(
         return []
     return [
         _finding(
-            "NGA-004", "HIGH",
+            "NGA-004",
+            "HIGH",
             "Containers running as root",
             f"{len(root_nodes)} container/workload node(s) run as root (UID 0). "
             "Root containers can write to the host filesystem via volume mounts and "
@@ -603,7 +648,8 @@ def _rule_nga005_unencrypted_pii_datastore(
         return []
 
     unencrypted = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _DATASTORE_TYPES
         and _depl_meta(n).get("encryption_at_rest") is False
     ]
@@ -635,21 +681,24 @@ def _rule_nga005_unencrypted_pii_datastore(
             f"{node_labels}.{write_note}"
         )
         affected = [ds_name] + write_agent_names
-        findings.append(_finding(
-            "NGA-005", "HIGH",
-            f"Unencrypted datastore '{ds_name}' contains PII/PHI",
-            evidence,
-            affected,
-            f"Enable encryption at rest for '{ds_name}'. "
-            + (
-                f"Restrict write access — currently granted to: {', '.join(write_agent_names)}. "
-                if write_agent_names
-                else ""
+        findings.append(
+            _finding(
+                "NGA-005",
+                "HIGH",
+                f"Unencrypted datastore '{ds_name}' contains PII/PHI",
+                evidence,
+                affected,
+                f"Enable encryption at rest for '{ds_name}'. "
+                + (
+                    f"Restrict write access — currently granted to: {', '.join(write_agent_names)}. "
+                    if write_agent_names
+                    else ""
+                )
+                + "Rotate encryption keys on a schedule and store them "
+                "in a dedicated key management service (KMS).",
+                evidence=evidence,
             )
-            + "Rotate encryption keys on a schedule and store them "
-            "in a dedicated key management service (KMS).",
-            evidence=evidence,
-        ))
+        )
     return findings
 
 
@@ -665,10 +714,13 @@ def _rule_nga006_missing_auth_on_api_endpoint(
     """HIGH — Missing authentication on external AI API endpoint."""
     auth_ids = {n["id"] for n in nodes if n.get("component_type") == "AUTH"}
     guardrail_ids = {n["id"] for n in nodes if n.get("component_type") in _GUARDRAIL_TYPES}
-    protected_targets = {e.get("target") for e in edges if e.get("source") in auth_ids | guardrail_ids}
+    protected_targets = {
+        e.get("target") for e in edges if e.get("source") in auth_ids | guardrail_ids
+    }
 
     unprotected = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _API_ENDPOINT_TYPES
         and n["id"] not in protected_targets
         and (
@@ -687,11 +739,18 @@ def _rule_nga006_missing_auth_on_api_endpoint(
             ep_name = ep.get("name", "")
             ep_id = str(ep["id"])
             # Find agents exposed via this endpoint
-            exposed = (
-                graph.sources(ep_id, "PROTECTS")
-                + [n for n in graph.targets(ep_id, "CALLS") if (n.get("component_type") or "").upper() == "AGENT"]
+            exposed = graph.sources(ep_id, "PROTECTS") + [
+                n
+                for n in graph.targets(ep_id, "CALLS")
+                if (n.get("component_type") or "").upper() == "AGENT"
+            ]
+            exposed_agent_names = list(
+                {
+                    a.get("name", "")
+                    for a in exposed
+                    if (a.get("component_type") or "").upper() == "AGENT"
+                }
             )
-            exposed_agent_names = list({a.get("name", "") for a in exposed if (a.get("component_type") or "").upper() == "AGENT"})
             # Note if any exposed agent touches PII data
             pii_note = ""
             if graph and exposed_agent_names:
@@ -714,25 +773,29 @@ def _rule_nga006_missing_auth_on_api_endpoint(
                 + pii_note
             )
             affected = [ep_name] + exposed_agent_names
-            findings.append(_finding(
-                "NGA-006", "HIGH",
-                f"Missing authentication on API endpoint '{ep_name}'",
-                evidence,
-                affected,
-                f"Add authentication middleware (API key, JWT, OAuth 2.0) to '{ep_name}'. "
-                + (
-                    f"The exposed agents ({', '.join(exposed_agent_names)}) require "
-                    "verified caller identity before processing requests."
-                    if exposed_agent_names
-                    else "Use an API gateway to centralise auth enforcement."
-                ),
-                evidence=evidence,
-            ))
+            findings.append(
+                _finding(
+                    "NGA-006",
+                    "HIGH",
+                    f"Missing authentication on API endpoint '{ep_name}'",
+                    evidence,
+                    affected,
+                    f"Add authentication middleware (API key, JWT, OAuth 2.0) to '{ep_name}'. "
+                    + (
+                        f"The exposed agents ({', '.join(exposed_agent_names)}) require "
+                        "verified caller identity before processing requests."
+                        if exposed_agent_names
+                        else "Use an API gateway to centralise auth enforcement."
+                    ),
+                    evidence=evidence,
+                )
+            )
         return findings
 
     return [
         _finding(
-            "NGA-006", "HIGH",
+            "NGA-006",
+            "HIGH",
             "Missing authentication on external AI API endpoint",
             f"{len(unprotected)} API endpoint(s) lack an AUTH or GUARDRAIL edge "
             "in the SBOM graph, indicating no authentication layer was detected. "
@@ -779,7 +842,8 @@ def _rule_nga007_overly_permissive_iam(
 
     return [
         _finding(
-            "NGA-007", "HIGH",
+            "NGA-007",
+            "HIGH",
             "Overly permissive IAM role for AI workload",
             f"{len(overpermissive)} IAM role(s) attached to AI deployment(s) grant "
             "wildcard ('*') or admin-level permissions. AI workloads with excessive IAM "
@@ -800,27 +864,19 @@ def _rule_nga008_untrusted_model_registry(
     nodes: list[dict[str, Any]], summary: dict[str, Any], **_: Any
 ) -> list[dict[str, Any]]:
     """HIGH — LLM model weight loaded from untrusted registry."""
-    trusted: set[str] = _DEFAULT_TRUSTED_REGISTRIES | set(
-        summary.get("trusted_registries") or []
-    )
+    trusted: set[str] = _DEFAULT_TRUSTED_REGISTRIES | set(summary.get("trusted_registries") or [])
 
     untrusted = []
     for n in nodes:
         if n.get("component_type") not in _MODEL_TYPES:
             continue
         meta = n.get("metadata") or {}
-        source_url: str = (
-            meta.get("source_url")
-            or meta.get("extras", {}).get("source_url")
-            or ""
-        )
+        source_url: str = meta.get("source_url") or meta.get("extras", {}).get("source_url") or ""
         if not source_url:
             continue
         is_trusted = any(r in source_url for r in trusted)
         has_digest = bool(
-            meta.get("digest")
-            or meta.get("extras", {}).get("digest")
-            or meta.get("checksum")
+            meta.get("digest") or meta.get("extras", {}).get("digest") or meta.get("checksum")
         )
         if not is_trusted and not has_digest:
             untrusted.append(n)
@@ -830,7 +886,8 @@ def _rule_nga008_untrusted_model_registry(
 
     return [
         _finding(
-            "NGA-008", "HIGH",
+            "NGA-008",
+            "HIGH",
             "LLM model weights loaded from untrusted registry",
             f"{len(untrusted)} model(s) are loaded from sources not in the trusted registry "
             f"allowlist ({', '.join(sorted(trusted))}) and have no checksum/digest for "
@@ -847,12 +904,19 @@ def _rule_nga008_untrusted_model_registry(
 # ── NGA-009 ──────────────────────────────────────────────────────────────────
 
 _AUDIT_LIBS = {
-    "opentelemetry", "langfuse", "arize", "whylogs",
-    "mlflow", "wandb", "helicone",
+    "opentelemetry",
+    "langfuse",
+    "arize",
+    "whylogs",
+    "mlflow",
+    "wandb",
+    "helicone",
 }
 _AUDIT_MIDDLEWARE = {
-    "RequestLoggingMiddleware", "AuditLogHandler",
-    "RotatingFileHandler", "TimedRotatingFileHandler",
+    "RequestLoggingMiddleware",
+    "AuditLogHandler",
+    "RotatingFileHandler",
+    "TimedRotatingFileHandler",
 }
 
 
@@ -869,9 +933,7 @@ def _rule_nga009_no_audit_logging(
 
     has_audit_lib = any(lib in frameworks for lib in _AUDIT_LIBS)
     has_log_paths = bool(log_paths)
-    has_middleware = any(
-        mw in str(summary) for mw in _AUDIT_MIDDLEWARE
-    )
+    has_middleware = any(mw in str(summary) for mw in _AUDIT_MIDDLEWARE)
     has_instrumentation = bool(summary.get("instrumentation"))
 
     if has_audit_lib or has_log_paths or has_middleware or has_instrumentation:
@@ -879,7 +941,8 @@ def _rule_nga009_no_audit_logging(
 
     return [
         _finding(
-            "NGA-009", "HIGH",
+            "NGA-009",
+            "HIGH",
             "AI application has no audit logging enabled",
             f"{len(agent_nodes)} agent(s) detected but no audit logging evidence found "
             "(no log paths, no logging middleware, no observability library such as "
@@ -904,14 +967,16 @@ def _rule_nga010_pr_target_injection(
     """HIGH — GitHub Actions: pull_request_target with untrusted context injection."""
     # Preferred: structured findings emitted by GitHubActionsAdapter
     structured = [
-        f for f in (summary.get("workflow_security_findings") or [])
+        f
+        for f in (summary.get("workflow_security_findings") or [])
         if f.get("rule_signal") == "NGA-010"
     ]
     if structured:
         first = structured[0]
         return [
             _finding(
-                "NGA-010", "HIGH",
+                "NGA-010",
+                "HIGH",
                 "GitHub Actions: pull_request_target with untrusted context injection",
                 f"Detected in {first['path']} (line {first['line']}): {first['snippet']}",
                 ["GitHub Actions workflow"],
@@ -938,7 +1003,8 @@ def _rule_nga010_pr_target_injection(
 
     return [
         _finding(
-            "NGA-010", "HIGH",
+            "NGA-010",
+            "HIGH",
             "GitHub Actions: pull_request_target with untrusted context injection",
             "A workflow uses the 'pull_request_target' trigger and references "
             "'${{ github.event.pull_request... }}' in run steps or env — this allows "
@@ -962,14 +1028,16 @@ def _rule_nga011_github_env_injection(
     """HIGH — GitHub Actions: GITHUB_ENV written from untrusted input."""
     # Preferred: structured findings emitted by GitHubActionsAdapter
     structured = [
-        f for f in (summary.get("workflow_security_findings") or [])
+        f
+        for f in (summary.get("workflow_security_findings") or [])
         if f.get("rule_signal") == "NGA-011"
     ]
     if structured:
         first = structured[0]
         return [
             _finding(
-                "NGA-011", "HIGH",
+                "NGA-011",
+                "HIGH",
                 "GitHub Actions: GITHUB_ENV written from untrusted input",
                 f"Detected in {first['path']} (line {first['line']}): {first['snippet']}",
                 ["GitHub Actions workflow"],
@@ -994,7 +1062,8 @@ def _rule_nga011_github_env_injection(
 
     return [
         _finding(
-            "NGA-011", "HIGH",
+            "NGA-011",
+            "HIGH",
             "GitHub Actions: GITHUB_ENV written from untrusted input",
             "A workflow step writes to '$GITHUB_ENV' using an expression that includes "
             "untrusted input (e.g. PR title, body, or comment). This allows an attacker "
@@ -1053,9 +1122,7 @@ def _rule_nga012_missing_hitl(
             agent_name = agent.get("name", "")
             agent_id = str(agent["id"])
             # O(n) indexed BFS follows CALLS and DELEGATES_TO edges
-            reachable_tools = graph.reachable_of_type(
-                agent_id, ["CALLS", "DELEGATES_TO"], "TOOL"
-            )
+            reachable_tools = graph.reachable_of_type(agent_id, ["CALLS", "DELEGATES_TO"], "TOOL")
             for tool in reachable_tools:
                 is_irrev, matched = _tool_is_irreversible(tool)
                 if not is_irrev:
@@ -1069,17 +1136,20 @@ def _rule_nga012_missing_hitl(
                     f"'{agent_name}' can reach irreversible tool '{tool_name}' "
                     f"(matched pattern: '{matched}') without a HITL checkpoint."
                 )
-                findings.append(_finding(
-                    "NGA-012", "HIGH",
-                    f"Agent '{agent_name}' can invoke '{tool_name}' without HITL approval",
-                    evidence,
-                    [agent_name, tool_name],
-                    f"Add an interrupt/approval step in '{agent_name}' before calling "
-                    f"'{tool_name}'. Use LangGraph 'interrupt_before', CrewAI 'human_input=True', "
-                    "OpenAI Assistants 'requires_action' event, or LangChain "
-                    "'HumanApprovalCallbackHandler'. Log all irreversible tool calls.",
-                    evidence=evidence,
-                ))
+                findings.append(
+                    _finding(
+                        "NGA-012",
+                        "HIGH",
+                        f"Agent '{agent_name}' can invoke '{tool_name}' without HITL approval",
+                        evidence,
+                        [agent_name, tool_name],
+                        f"Add an interrupt/approval step in '{agent_name}' before calling "
+                        f"'{tool_name}'. Use LangGraph 'interrupt_before', CrewAI 'human_input=True', "
+                        "OpenAI Assistants 'requires_action' event, or LangChain "
+                        "'HumanApprovalCallbackHandler'. Log all irreversible tool calls.",
+                        evidence=evidence,
+                    )
+                )
         return findings
 
     # Fallback: O(n²) BFS (no graph)
@@ -1090,14 +1160,17 @@ def _rule_nga012_missing_hitl(
         if _agent_has_hitl(agent):
             continue
         reachable = _nodes_reachable_from(agent["id"], edges, nodes_by_id)
-        reachable_tools = [nodes_by_id[nid] for nid in reachable if nid in tool_ids and nid in nodes_by_id]
+        reachable_tools = [
+            nodes_by_id[nid] for nid in reachable if nid in tool_ids and nid in nodes_by_id
+        ]
         if any(_tool_is_irreversible(t)[0] for t in reachable_tools):
             risky_agents.append(agent)
     if not risky_agents:
         return []
     return [
         _finding(
-            "NGA-012", "HIGH",
+            "NGA-012",
+            "HIGH",
             "Agent pipeline lacks HITL approval for high-risk tool actions",
             f"{len(risky_agents)} agent(s) can invoke irreversible or high-impact tools "
             "(email send, database write/delete, payment, file deletion, external API mutation) "
@@ -1122,7 +1195,8 @@ def _rule_nga013_no_k8s_network_policy(
 ) -> list[dict[str, Any]]:
     """MEDIUM — No network policy for AI workload in K8s."""
     k8s_deployments = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _DEPLOYMENT_TYPES
         and (
             _depl_meta(n).get("deployment_target", "").lower() in ("kubernetes", "k8s")
@@ -1138,16 +1212,19 @@ def _rule_nga013_no_k8s_network_policy(
     policy_namespaces: set[str] = set(summary.get("k8s_network_policy_namespaces") or [])
 
     no_netpol = [
-        n for n in k8s_deployments
+        n
+        for n in k8s_deployments
         if not _depl_meta(n).get("has_network_policy")  # same-file coverage
-        and (n.get("metadata") or {}).get("extras", {}).get("k8s_namespace", "") not in policy_namespaces
+        and (n.get("metadata") or {}).get("extras", {}).get("k8s_namespace", "")
+        not in policy_namespaces
     ]
     if not no_netpol:
         return []
 
     return [
         _finding(
-            "NGA-013", "MEDIUM",
+            "NGA-013",
+            "MEDIUM",
             "No Kubernetes NetworkPolicy for AI workload",
             f"{len(no_netpol)} K8s deployment(s) have no NetworkPolicy detected. "
             "Without network policies, any compromised pod in the cluster can reach "
@@ -1169,14 +1246,16 @@ def _rule_nga014_actions_runner_debug(
     """MEDIUM — GitHub Actions: ACTIONS_RUNNER_DEBUG secret exposed."""
     # Preferred: structured findings emitted by GitHubActionsAdapter
     structured = [
-        f for f in (summary.get("workflow_security_findings") or [])
+        f
+        for f in (summary.get("workflow_security_findings") or [])
         if f.get("rule_signal") == "NGA-014"
     ]
     if structured:
         first = structured[0]
         return [
             _finding(
-                "NGA-014", "MEDIUM",
+                "NGA-014",
+                "MEDIUM",
                 "GitHub Actions: ACTIONS_RUNNER_DEBUG secret exposed",
                 f"Detected in {first['path']} (line {first['line']}): {first['snippet']}",
                 ["GitHub Actions workflow"],
@@ -1200,7 +1279,8 @@ def _rule_nga014_actions_runner_debug(
 
     return [
         _finding(
-            "NGA-014", "MEDIUM",
+            "NGA-014",
+            "MEDIUM",
             "GitHub Actions: ACTIONS_RUNNER_DEBUG secret exposed",
             "The workflow references 'ACTIONS_RUNNER_DEBUG'. When set to 'true', "
             "this leaks verbose runner debug output to public workflow logs, including "
@@ -1235,7 +1315,8 @@ def _rule_nga015_no_resource_limits(
     affected = limited_nodes if limited_nodes else depl_nodes
     return [
         _finding(
-            "NGA-015", "LOW",
+            "NGA-015",
+            "LOW",
             "AI workloads without resource limits",
             f"{len(affected)} deployment node(s) have no CPU or memory resource limits "
             "configured. Unbounded AI workloads can starve co-located services, "
@@ -1253,12 +1334,11 @@ def _rule_nga015_no_resource_limits(
 # ── NGA-016 ──────────────────────────────────────────────────────────────────
 
 
-def _rule_nga016_latest_image_tag(
-    nodes: list[dict[str, Any]], **_: Any
-) -> list[dict[str, Any]]:
+def _rule_nga016_latest_image_tag(nodes: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
     """LOW — Container image using 'latest' tag."""
     latest_images = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _CONTAINER_TYPES
         and (
             _depl_meta(n).get("image_tag", "").lower() in ("latest", "")
@@ -1271,7 +1351,8 @@ def _rule_nga016_latest_image_tag(
 
     return [
         _finding(
-            "NGA-016", "LOW",
+            "NGA-016",
+            "LOW",
             "Container image using 'latest' tag",
             f"{len(latest_images)} container image(s) use the 'latest' tag or have no "
             "explicit tag. The 'latest' tag is mutable — a registry push can silently "
@@ -1293,7 +1374,8 @@ def _rule_nga017_missing_health_check(
 ) -> list[dict[str, Any]]:
     """LOW — AI workload missing health check."""
     no_health = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in (_DEPLOYMENT_TYPES | _CONTAINER_TYPES)
         and not _depl_meta(n).get("has_health_check")
     ]
@@ -1302,7 +1384,8 @@ def _rule_nga017_missing_health_check(
 
     return [
         _finding(
-            "NGA-017", "LOW",
+            "NGA-017",
+            "LOW",
             "AI workload missing health check",
             f"{len(no_health)} deployment/container node(s) have no health check configured. "
             "Without a health check, orchestration platforms cannot detect a hung or "
@@ -1357,28 +1440,28 @@ def _rule_nga018_shared_datastore_no_iam_isolation(
                 affected_names.append(agent_name)
                 if interm is not None:
                     indirect_paths.append(
-                        f"'{agent_name}'→CALLS→'{interm.get('name', '')}'"
-                        f"→ACCESSES→'{ds_name}'"
+                        f"'{agent_name}'→CALLS→'{interm.get('name', '')}'→ACCESSES→'{ds_name}'"
                     )
             indirect_note = (
-                f" Indirect paths: {'; '.join(indirect_paths)}."
-                if indirect_paths
-                else ""
+                f" Indirect paths: {'; '.join(indirect_paths)}." if indirect_paths else ""
             )
             agent_names = [a.get("name", "") for a, _ in agent_map.values()]
             evidence = (
                 f"Datastore '{ds_name}' is accessible by {len(agent_map)} agents "
                 f"without IAM isolation: {', '.join(agent_names)}.{indirect_note}"
             )
-            findings.append(_finding(
-                "NGA-018", "LOW",
-                f"Agents share datastore '{ds_name}' with no IAM isolation",
-                evidence,
-                affected_names,
-                f"Add IAM policies to scope each agent's access to '{ds_name}'. "
-                "Consider separate datastores or row-level security per tenant.",
-                evidence=evidence,
-            ))
+            findings.append(
+                _finding(
+                    "NGA-018",
+                    "LOW",
+                    f"Agents share datastore '{ds_name}' with no IAM isolation",
+                    evidence,
+                    affected_names,
+                    f"Add IAM policies to scope each agent's access to '{ds_name}'. "
+                    "Consider separate datastores or row-level security per tenant.",
+                    evidence=evidence,
+                )
+            )
         return findings
 
     # Fallback: direct-edge-only check
@@ -1392,19 +1475,17 @@ def _rule_nga018_shared_datastore_no_iam_isolation(
         elif tgt in agent_ids_set and src in datastore_ids:
             ds_to_agents[src].add(tgt)
     shared_no_iam = [
-        ds_id for ds_id, agents in ds_to_agents.items()
-        if len(agents) >= 2 and not iam_ids
+        ds_id for ds_id, agents in ds_to_agents.items() if len(agents) >= 2 and not iam_ids
     ]
     if not shared_no_iam:
         return []
     affected_names = [
-        n.get("name", ds_id)
-        for ds_id in shared_no_iam
-        for n in nodes if n["id"] == ds_id
+        n.get("name", ds_id) for ds_id in shared_no_iam for n in nodes if n["id"] == ds_id
     ]
     return [
         _finding(
-            "NGA-018", "LOW",
+            "NGA-018",
+            "LOW",
             "Multiple agents share a datastore with no IAM isolation",
             f"{len(shared_no_iam)} datastore(s) are accessed by 2 or more agent(s) "
             "with no IAM node detected to differentiate access rights. A compromised "
@@ -1462,9 +1543,11 @@ def _rule_nga019_unguarded_write_to_sensitive_datastore(
                 continue
             interm_name = interm.get("name", "") if interm else None
             if interm_name:
-                path = (f"'{agent_name}' → CALLS → '{interm_name}' "
-                        f"→ ACCESSES[{access_type}] → '{ds_name}' "
-                        f"(data_classification={ds_labels}). No guardrail on this path.")
+                path = (
+                    f"'{agent_name}' → CALLS → '{interm_name}' "
+                    f"→ ACCESSES[{access_type}] → '{ds_name}' "
+                    f"(data_classification={ds_labels}). No guardrail on this path."
+                )
                 affected = [agent_name, interm_name, ds_name]
                 remediation = (
                     f"Add a guardrail or validation step on '{interm_name}' before "
@@ -1472,22 +1555,27 @@ def _rule_nga019_unguarded_write_to_sensitive_datastore(
                     "access control, and audit logging for all write operations."
                 )
             else:
-                path = (f"'{agent_name}' → ACCESSES[{access_type}] → '{ds_name}' "
-                        f"(data_classification={ds_labels}). No guardrail on this path.")
+                path = (
+                    f"'{agent_name}' → ACCESSES[{access_type}] → '{ds_name}' "
+                    f"(data_classification={ds_labels}). No guardrail on this path."
+                )
                 affected = [agent_name, ds_name]
                 remediation = (
                     f"Add a guardrail or validation step before '{agent_name}' "
                     f"writes to '{ds_name}'. Apply schema validation, field-level "
                     "access control, and audit logging for all write operations."
                 )
-            findings.append(_finding(
-                "NGA-019", "HIGH",
-                f"Unguarded write path to sensitive datastore: '{ds_name}'",
-                path,
-                affected,
-                remediation,
-                evidence=path,
-            ))
+            findings.append(
+                _finding(
+                    "NGA-019",
+                    "HIGH",
+                    f"Unguarded write path to sensitive datastore: '{ds_name}'",
+                    path,
+                    affected,
+                    remediation,
+                    evidence=path,
+                )
+            )
     return findings
 
 
@@ -1521,15 +1609,18 @@ def _rule_nga020_unguarded_agent_delegation(
                 f"'{src_name}' DELEGATES_TO '{tgt_name}'. "
                 "Neither agent has a GUARDRAIL on its PROTECTS path."
             )
-            findings.append(_finding(
-                "NGA-020", "MEDIUM",
-                f"Unguarded delegation: '{src_name}' → '{tgt_name}'",
-                evidence,
-                [src_name, tgt_name],
-                f"Insert a guardrail between '{src_name}' and '{tgt_name}' to block "
-                "prompt injection from propagating across the delegation boundary.",
-                evidence=evidence,
-            ))
+            findings.append(
+                _finding(
+                    "NGA-020",
+                    "MEDIUM",
+                    f"Unguarded delegation: '{src_name}' → '{tgt_name}'",
+                    evidence,
+                    [src_name, tgt_name],
+                    f"Insert a guardrail between '{src_name}' and '{tgt_name}' to block "
+                    "prompt injection from propagating across the delegation boundary.",
+                    evidence=evidence,
+                )
+            )
     return findings
 
 
@@ -1561,16 +1652,19 @@ def _rule_nga021_idor_surface_no_protection(
             "or GUARDRAIL node protects it — a caller could substitute another "
             "user's identifier to access their data."
         )
-        findings.append(_finding(
-            "NGA-021", "HIGH",
-            f"IDOR-prone endpoint without authorization checks: '{ep_name}'",
-            evidence,
-            [ep_name],
-            f"Add object-level authorization checks on '{ep_name}' so the caller's "
-            "authenticated identity is verified against the requested path parameter "
-            "(e.g. reject requests where the session user does not own the resource).",
-            evidence=evidence,
-        ))
+        findings.append(
+            _finding(
+                "NGA-021",
+                "HIGH",
+                f"IDOR-prone endpoint without authorization checks: '{ep_name}'",
+                evidence,
+                [ep_name],
+                f"Add object-level authorization checks on '{ep_name}' so the caller's "
+                "authenticated identity is verified against the requested path parameter "
+                "(e.g. reject requests where the session user does not own the resource).",
+                evidence=evidence,
+            )
+        )
     return findings
 
 
@@ -1578,7 +1672,8 @@ def _rule_nga021_idor_surface_no_protection(
 
 # Known vector/embedding store technology names (mirrors registry.py's regex adapter)
 _VECTOR_STORE_NAMES = re.compile(
-    r"pinecone|faiss|chroma|chromadb|weaviate|qdrant|milvus", re.IGNORECASE,
+    r"pinecone|faiss|chroma|chromadb|weaviate|qdrant|milvus",
+    re.IGNORECASE,
 )
 
 
@@ -1606,7 +1701,8 @@ def _rule_nga022_untrusted_mcp_tool(
 
     return [
         _finding(
-            "NGA-022", "HIGH",
+            "NGA-022",
+            "HIGH",
             "Tool sourced from an untrusted MCP server",
             f"{len(untrusted)} tool(s) are exposed by an MCP server not on the trusted "
             "allowlist and have no GUARDRAIL/AUTH node protecting them. A malicious or "
@@ -1636,9 +1732,7 @@ def _rule_nga023_unprotected_vector_store(
         if not _VECTOR_STORE_NAMES.search(datastore_type):
             continue
         has_auth = bool(meta.get("auth_detail") or meta.get("auth_type"))
-        has_encryption = bool(
-            meta.get("encryption_detail") or meta.get("encryption_at_rest")
-        )
+        has_encryption = bool(meta.get("encryption_detail") or meta.get("encryption_at_rest"))
         if has_auth and has_encryption:
             continue
         unprotected.append(n)
@@ -1648,7 +1742,8 @@ def _rule_nga023_unprotected_vector_store(
 
     return [
         _finding(
-            "NGA-023", "HIGH",
+            "NGA-023",
+            "HIGH",
             "Vector/embedding store without auth or encryption",
             f"{len(unprotected)} vector/embedding datastore(s) have no authentication "
             "and/or encryption posture recorded. Retrieved embeddings can be inverted "
@@ -1695,16 +1790,19 @@ def _rule_nga024_unauthenticated_agent_delegation(
                 f"'{src_name}' DELEGATES_TO '{tgt_name}', which carries no auth or "
                 "encryption metadata for the receiving side of the delegation."
             )
-            findings.append(_finding(
-                "NGA-024", "MEDIUM",
-                f"Unauthenticated inter-agent delegation: '{src_name}' → '{tgt_name}'",
-                evidence,
-                [src_name, tgt_name],
-                f"Require mutual authentication (e.g. mTLS or signed tokens) and "
-                f"encryption between '{src_name}' and '{tgt_name}' so a network "
-                "position cannot spoof or tamper with delegated instructions.",
-                evidence=evidence,
-            ))
+            findings.append(
+                _finding(
+                    "NGA-024",
+                    "MEDIUM",
+                    f"Unauthenticated inter-agent delegation: '{src_name}' → '{tgt_name}'",
+                    evidence,
+                    [src_name, tgt_name],
+                    f"Require mutual authentication (e.g. mTLS or signed tokens) and "
+                    f"encryption between '{src_name}' and '{tgt_name}' so a network "
+                    "position cannot spoof or tamper with delegated instructions.",
+                    evidence=evidence,
+                )
+            )
     return findings
 
 
@@ -1712,10 +1810,10 @@ def _rule_nga024_unauthenticated_agent_delegation(
 
 # Credential/secret-like patterns to catch when embedded in prompt text
 _PROMPT_SECRET_PATTERNS = re.compile(
-    r"AKIA[0-9A-Z]{16}|"                                  # AWS access key
-    r"sk-[A-Za-z0-9]{20,}|"                                # OpenAI-style secret key
-    r"ghp_[A-Za-z0-9]{20,}|"                                # GitHub token
-    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|"                 # PEM private key
+    r"AKIA[0-9A-Z]{16}|"  # AWS access key
+    r"sk-[A-Za-z0-9]{20,}|"  # OpenAI-style secret key
+    r"ghp_[A-Za-z0-9]{20,}|"  # GitHub token
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|"  # PEM private key
     r"(?:api[_-]?key|secret|password|token)\s*[:=]\s*['\"]?[A-Za-z0-9_\-]{8,}",
     re.IGNORECASE,
 )
@@ -1742,7 +1840,8 @@ def _rule_nga025_hidden_context_secret_leak(
 
     return [
         _finding(
-            "NGA-025", "HIGH",
+            "NGA-025",
+            "HIGH",
             "Credential embedded in system prompt / hidden context",
             f"{len(leaking)} prompt/agent node(s) contain what looks like a credential, "
             "API key, or secret literal inside the prompt text. Hidden context is "
@@ -1764,7 +1863,8 @@ def _rule_nga026_endpoint_no_rate_limit(
 ) -> list[dict[str, Any]]:
     """MEDIUM — AI-facing API endpoint with no application-level rate limiting."""
     unlimited = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _API_ENDPOINT_TYPES
         and (n.get("metadata") or {}).get("rate_limited") is not True
         and not (n.get("metadata") or {}).get("rate_limit_detail")
@@ -1774,7 +1874,8 @@ def _rule_nga026_endpoint_no_rate_limit(
 
     return [
         _finding(
-            "NGA-026", "MEDIUM",
+            "NGA-026",
+            "MEDIUM",
             "AI endpoint without application-level rate limiting",
             f"{len(unlimited)} API endpoint(s) serving AI traffic have no rate-limiting "
             "or budget ceiling configured. Attackers can trigger disproportionately "
@@ -1796,7 +1897,8 @@ def _rule_nga027_missing_security_headers(
 ) -> list[dict[str, Any]]:
     """MEDIUM — AI-facing API endpoint missing HTTP security headers."""
     unprotected = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _API_ENDPOINT_TYPES
         and (
             not (n.get("metadata") or {}).get("security_headers_detail")
@@ -1808,7 +1910,8 @@ def _rule_nga027_missing_security_headers(
 
     return [
         _finding(
-            "NGA-027", "MEDIUM",
+            "NGA-027",
+            "MEDIUM",
             "AI endpoint missing security headers (CSP/X-Frame-Options/HSTS)",
             f"{len(unprotected)} API endpoint(s) serving AI traffic have no confirmed "
             "Content-Security-Policy, X-Frame-Options, or Strict-Transport-Security "
@@ -1827,12 +1930,11 @@ def _rule_nga027_missing_security_headers(
 # ── NGA-028 ──────────────────────────────────────────────────────────────────
 
 
-def _rule_nga028_permissive_cors(
-    nodes: list[dict[str, Any]], **_: Any
-) -> list[dict[str, Any]]:
+def _rule_nga028_permissive_cors(nodes: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
     """HIGH — API endpoint has an overly permissive CORS policy."""
     permissive = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _API_ENDPOINT_TYPES
         and ((n.get("metadata") or {}).get("cors_policy") or {}).get("origin") == "*"
     ]
@@ -1840,14 +1942,16 @@ def _rule_nga028_permissive_cors(
         return []
 
     wildcard_with_creds = [
-        n for n in permissive
+        n
+        for n in permissive
         if ((n.get("metadata") or {}).get("cors_policy") or {}).get("wildcard_with_credentials")
     ]
     severity = "HIGH" if wildcard_with_creds else "MEDIUM"
 
     return [
         _finding(
-            "NGA-028", severity,
+            "NGA-028",
+            severity,
             "API endpoint has an overly permissive CORS policy",
             f"{len(permissive)} API endpoint(s) allow requests from any origin (`*`)"
             + (
@@ -1868,12 +1972,11 @@ def _rule_nga028_permissive_cors(
 # ── NGA-029 ──────────────────────────────────────────────────────────────────
 
 
-def _rule_nga029_verbose_error_leak(
-    nodes: list[dict[str, Any]], **_: Any
-) -> list[dict[str, Any]]:
+def _rule_nga029_verbose_error_leak(nodes: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
     """MEDIUM — API endpoint's error handler leaks stack traces."""
     leaking = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") in _API_ENDPOINT_TYPES
         and (n.get("metadata") or {}).get("debug_error_leak") is True
     ]
@@ -1882,7 +1985,8 @@ def _rule_nga029_verbose_error_leak(
 
     return [
         _finding(
-            "NGA-029", "MEDIUM",
+            "NGA-029",
+            "MEDIUM",
             "API endpoint's error handler leaks stack traces",
             f"{len(leaking)} API endpoint(s) are served by an application running in "
             "debug/verbose-error mode. Unhandled exceptions in this mode return raw "
@@ -1911,12 +2015,11 @@ def _rule_nga030_jwt_no_algorithm_restriction(
     Either lets an attacker forge a token that passes verification.
     """
     unrestricted = [
-        n for n in nodes
+        n
+        for n in nodes
         if n.get("component_type") == "AUTH"
         and (n.get("metadata") or {}).get("auth_type") == "jwt"
-        and ((n.get("metadata") or {}).get("auth_detail") or {}).get(
-            "jwt_algorithm_restricted"
-        )
+        and ((n.get("metadata") or {}).get("auth_detail") or {}).get("jwt_algorithm_restricted")
         is not True
     ]
     if not unrestricted:
@@ -1924,7 +2027,8 @@ def _rule_nga030_jwt_no_algorithm_restriction(
 
     return [
         _finding(
-            "NGA-030", "HIGH",
+            "NGA-030",
+            "HIGH",
             "JWT verification with no pinned algorithm allow-list",
             f"{len(unrestricted)} JWT auth mechanism(s) have no confirmed "
             "`algorithms:` allow-list on their verification call. Without one, "
@@ -1944,216 +2048,246 @@ def _rule_nga030_jwt_no_algorithm_restriction(
 # ── Rule registry ─────────────────────────────────────────────────────────────
 
 _RULES: list[Callable[..., list[dict[str, Any]]]] = [
-    _rule_nga001_phi_to_external_llm,           # NGA-001 CRITICAL
-    _rule_nga002_insufficient_guardrails,        # NGA-002 HIGH
-    _rule_nga003_secrets_in_env,                 # NGA-003 HIGH
-    _rule_nga004_runs_as_root,                   # NGA-004 HIGH
-    _rule_nga005_unencrypted_pii_datastore,      # NGA-005 HIGH
-    _rule_nga006_missing_auth_on_api_endpoint,   # NGA-006 HIGH
-    _rule_nga007_overly_permissive_iam,          # NGA-007 HIGH
-    _rule_nga008_untrusted_model_registry,       # NGA-008 HIGH
-    _rule_nga009_no_audit_logging,               # NGA-009 HIGH
-    _rule_nga010_pr_target_injection,            # NGA-010 HIGH
-    _rule_nga011_github_env_injection,           # NGA-011 HIGH
-    _rule_nga012_missing_hitl,                   # NGA-012 HIGH
-    _rule_nga013_no_k8s_network_policy,          # NGA-013 MEDIUM
-    _rule_nga014_actions_runner_debug,           # NGA-014 MEDIUM
-    _rule_nga015_no_resource_limits,             # NGA-015 LOW
-    _rule_nga016_latest_image_tag,               # NGA-016 LOW
-    _rule_nga017_missing_health_check,           # NGA-017 LOW
+    _rule_nga001_phi_to_external_llm,  # NGA-001 CRITICAL
+    _rule_nga002_insufficient_guardrails,  # NGA-002 HIGH
+    _rule_nga003_secrets_in_env,  # NGA-003 HIGH
+    _rule_nga004_runs_as_root,  # NGA-004 HIGH
+    _rule_nga005_unencrypted_pii_datastore,  # NGA-005 HIGH
+    _rule_nga006_missing_auth_on_api_endpoint,  # NGA-006 HIGH
+    _rule_nga007_overly_permissive_iam,  # NGA-007 HIGH
+    _rule_nga008_untrusted_model_registry,  # NGA-008 HIGH
+    _rule_nga009_no_audit_logging,  # NGA-009 HIGH
+    _rule_nga010_pr_target_injection,  # NGA-010 HIGH
+    _rule_nga011_github_env_injection,  # NGA-011 HIGH
+    _rule_nga012_missing_hitl,  # NGA-012 HIGH
+    _rule_nga013_no_k8s_network_policy,  # NGA-013 MEDIUM
+    _rule_nga014_actions_runner_debug,  # NGA-014 MEDIUM
+    _rule_nga015_no_resource_limits,  # NGA-015 LOW
+    _rule_nga016_latest_image_tag,  # NGA-016 LOW
+    _rule_nga017_missing_health_check,  # NGA-017 LOW
     _rule_nga018_shared_datastore_no_iam_isolation,  # NGA-018 LOW
     _rule_nga019_unguarded_write_to_sensitive_datastore,  # NGA-019 HIGH
-    _rule_nga020_unguarded_agent_delegation,         # NGA-020 MEDIUM
-    _rule_nga021_idor_surface_no_protection,         # NGA-021 HIGH
-    _rule_nga022_untrusted_mcp_tool,                 # NGA-022 HIGH
-    _rule_nga023_unprotected_vector_store,           # NGA-023 HIGH
-    _rule_nga024_unauthenticated_agent_delegation,   # NGA-024 MEDIUM
-    _rule_nga025_hidden_context_secret_leak,         # NGA-025 HIGH
-    _rule_nga026_endpoint_no_rate_limit,             # NGA-026 MEDIUM
-    _rule_nga027_missing_security_headers,           # NGA-027 MEDIUM
-    _rule_nga028_permissive_cors,                    # NGA-028 HIGH
-    _rule_nga029_verbose_error_leak,                 # NGA-029 MEDIUM
-    _rule_nga030_jwt_no_algorithm_restriction,       # NGA-030 HIGH
+    _rule_nga020_unguarded_agent_delegation,  # NGA-020 MEDIUM
+    _rule_nga021_idor_surface_no_protection,  # NGA-021 HIGH
+    _rule_nga022_untrusted_mcp_tool,  # NGA-022 HIGH
+    _rule_nga023_unprotected_vector_store,  # NGA-023 HIGH
+    _rule_nga024_unauthenticated_agent_delegation,  # NGA-024 MEDIUM
+    _rule_nga025_hidden_context_secret_leak,  # NGA-025 HIGH
+    _rule_nga026_endpoint_no_rate_limit,  # NGA-026 MEDIUM
+    _rule_nga027_missing_security_headers,  # NGA-027 MEDIUM
+    _rule_nga028_permissive_cors,  # NGA-028 HIGH
+    _rule_nga029_verbose_error_leak,  # NGA-029 MEDIUM
+    _rule_nga030_jwt_no_algorithm_restriction,  # NGA-030 HIGH
 ]
 
 # Per-rule metadata used by verbose audit mode (parallel to _RULES).
 _RULE_META: list[dict[str, str]] = [
     {
-        "rule_id": "NGA-001", "severity": "CRITICAL",
+        "rule_id": "NGA-001",
+        "severity": "CRITICAL",
         "title": "PII/PHI data handled by external LLM providers",
         "checks": "SBOM data_classification × MODEL nodes with external provider",
         "pass_reason": "No PII/PHI data classification found, or no external MODEL provider detected",
     },
     {
-        "rule_id": "NGA-002", "severity": "HIGH",
+        "rule_id": "NGA-002",
+        "severity": "HIGH",
         "title": "Insufficient guardrail coverage",
         "checks": "MODEL nodes and AGENT→API_ENDPOINT edges vs. GUARDRAIL nodes",
         "pass_reason": "All MODEL/AGENT paths have at least one GUARDRAIL node",
     },
     {
-        "rule_id": "NGA-003", "severity": "HIGH",
+        "rule_id": "NGA-003",
+        "severity": "HIGH",
         "title": "Secrets or credentials exposed in environment variables",
         "checks": "SBOM env_vars for high-entropy or secret-named values",
         "pass_reason": "No secret-like environment variables detected in SBOM",
     },
     {
-        "rule_id": "NGA-004", "severity": "HIGH",
+        "rule_id": "NGA-004",
+        "severity": "HIGH",
         "title": "Container runs as root",
         "checks": "CONTAINER_IMAGE nodes for runs_as_root flag or missing non-root user",
         "pass_reason": "No containers detected running as root",
     },
     {
-        "rule_id": "NGA-005", "severity": "HIGH",
+        "rule_id": "NGA-005",
+        "severity": "HIGH",
         "title": "PII/PHI stored in unencrypted datastore",
         "checks": "DATASTORE nodes for encryption_at_rest flag × PII/PHI data classification",
         "pass_reason": "All datastores have encryption at rest, or no PII/PHI classification found",
     },
     {
-        "rule_id": "NGA-006", "severity": "HIGH",
+        "rule_id": "NGA-006",
+        "severity": "HIGH",
         "title": "API endpoint missing authentication",
         "checks": "API_ENDPOINT nodes for missing AUTH edge coverage",
         "pass_reason": "All API endpoints are covered by at least one AUTH node",
     },
     {
-        "rule_id": "NGA-007", "severity": "HIGH",
+        "rule_id": "NGA-007",
+        "severity": "HIGH",
         "title": "Overly permissive IAM role",
         "checks": "IAM nodes for wildcard permissions or admin-level grants",
         "pass_reason": "No IAM nodes with wildcard or admin permissions detected",
     },
     {
-        "rule_id": "NGA-008", "severity": "HIGH",
+        "rule_id": "NGA-008",
+        "severity": "HIGH",
         "title": "Model loaded from untrusted or unverified registry",
         "checks": "MODEL nodes for registry source and integrity verification",
         "pass_reason": "All MODEL nodes sourced from trusted registries with verification",
     },
     {
-        "rule_id": "NGA-009", "severity": "HIGH",
+        "rule_id": "NGA-009",
+        "severity": "HIGH",
         "title": "No audit logging configured",
         "checks": "SBOM for audit_logging flag and DATASTORE/API_ENDPOINT coverage",
         "pass_reason": "Audit logging is configured in the SBOM",
     },
     {
-        "rule_id": "NGA-010", "severity": "HIGH",
+        "rule_id": "NGA-010",
+        "severity": "HIGH",
         "title": "GitHub Actions pull_request_target injection risk",
         "checks": "GitHub Actions workflow files for pull_request_target trigger with dangerous patterns",
         "pass_reason": "No pull_request_target injection patterns found in CI workflows",
     },
     {
-        "rule_id": "NGA-011", "severity": "HIGH",
+        "rule_id": "NGA-011",
+        "severity": "HIGH",
         "title": "GitHub Actions environment variable injection",
         "checks": "GitHub Actions workflow files for unsanitised env variable injection",
         "pass_reason": "No environment variable injection patterns found in CI workflows",
     },
     {
-        "rule_id": "NGA-012", "severity": "HIGH",
+        "rule_id": "NGA-012",
+        "severity": "HIGH",
         "title": "Agent pipeline lacks HITL approval for high-risk tool actions",
         "checks": "AGENT nodes with irreversible/high-impact TOOL edges for HITL approval gates",
         "pass_reason": "All high-risk tool invocations have a human-in-the-loop approval gate",
     },
     {
-        "rule_id": "NGA-013", "severity": "MEDIUM",
+        "rule_id": "NGA-013",
+        "severity": "MEDIUM",
         "title": "Kubernetes deployment missing NetworkPolicy",
         "checks": "Kubernetes DEPLOYMENT nodes for NetworkPolicy coverage",
         "pass_reason": "All Kubernetes deployments have NetworkPolicy configured",
     },
     {
-        "rule_id": "NGA-014", "severity": "MEDIUM",
+        "rule_id": "NGA-014",
+        "severity": "MEDIUM",
         "title": "GitHub Actions runner debug mode enabled",
         "checks": "GitHub Actions workflows for ACTIONS_RUNNER_DEBUG or ACTIONS_STEP_DEBUG set to true",
         "pass_reason": "No debug mode enabled in GitHub Actions runner configuration",
     },
     {
-        "rule_id": "NGA-015", "severity": "LOW",
+        "rule_id": "NGA-015",
+        "severity": "LOW",
         "title": "Container missing resource limits",
         "checks": "CONTAINER_IMAGE / DEPLOYMENT nodes for CPU/memory resource limits",
         "pass_reason": "All containers have CPU and memory resource limits defined",
     },
     {
-        "rule_id": "NGA-016", "severity": "LOW",
+        "rule_id": "NGA-016",
+        "severity": "LOW",
         "title": "Container image uses 'latest' tag",
         "checks": "CONTAINER_IMAGE nodes for unversioned 'latest' image tag",
         "pass_reason": "All container images use pinned version tags",
     },
     {
-        "rule_id": "NGA-017", "severity": "LOW",
+        "rule_id": "NGA-017",
+        "severity": "LOW",
         "title": "Container missing health check",
         "checks": "CONTAINER_IMAGE / DEPLOYMENT nodes for health check configuration",
         "pass_reason": "All containers have health checks configured",
     },
     {
-        "rule_id": "NGA-018", "severity": "LOW",
+        "rule_id": "NGA-018",
+        "severity": "LOW",
         "title": "Shared datastore without IAM isolation",
         "checks": "DATASTORE nodes shared across AGENT/TOOL boundaries for IAM isolation",
         "pass_reason": "All shared datastores have IAM isolation or are not cross-boundary",
     },
     {
-        "rule_id": "NGA-019", "severity": "HIGH",
+        "rule_id": "NGA-019",
+        "severity": "HIGH",
         "title": "Unguarded write path to sensitive datastore",
         "checks": "AGENT→[CALLS→TOOL]→ACCESSES[write]→DATASTORE[PII/PHI] paths with no guardrail",
         "pass_reason": "No unguarded write paths to PII/PHI datastores detected",
     },
     {
-        "rule_id": "NGA-020", "severity": "MEDIUM",
+        "rule_id": "NGA-020",
+        "severity": "MEDIUM",
         "title": "Unguarded agent delegation chain",
         "checks": "AGENT→DELEGATES_TO→AGENT edges where neither side has guardrail coverage",
         "pass_reason": "All agent delegation chains have at least one guardrail boundary",
     },
     {
-        "rule_id": "NGA-021", "severity": "HIGH",
+        "rule_id": "NGA-021",
+        "severity": "HIGH",
         "title": "IDOR-prone endpoint without authorization checks",
         "checks": "API_ENDPOINT nodes with idor_surface path params and no AUTH/GUARDRAIL protection",
         "pass_reason": "No IDOR-prone endpoints found, or all are protected by an AUTH/GUARDRAIL node",
     },
     {
-        "rule_id": "NGA-022", "severity": "HIGH",
+        "rule_id": "NGA-022",
+        "severity": "HIGH",
         "title": "Tool sourced from an untrusted MCP server",
         "checks": "TOOL nodes with mcp_server_url set and trust_level=untrusted, no GUARDRAIL/AUTH protection",
         "pass_reason": "No untrusted-MCP tools found, or all are protected by a GUARDRAIL/AUTH node",
     },
     {
-        "rule_id": "NGA-023", "severity": "HIGH",
+        "rule_id": "NGA-023",
+        "severity": "HIGH",
         "title": "Vector/embedding store without auth or encryption",
         "checks": "DATASTORE nodes matching known vector-store tech names vs. auth_detail/encryption_detail",
         "pass_reason": "No vector/embedding stores found, or all have auth and encryption posture recorded",
     },
     {
-        "rule_id": "NGA-024", "severity": "MEDIUM",
+        "rule_id": "NGA-024",
+        "severity": "MEDIUM",
         "title": "Unauthenticated inter-agent delegation",
         "checks": "DELEGATES_TO edge targets vs. target AGENT's auth_detail/encryption_detail",
         "pass_reason": "No delegation targets found, or all have auth/encryption metadata recorded",
     },
     {
-        "rule_id": "NGA-025", "severity": "HIGH",
+        "rule_id": "NGA-025",
+        "severity": "HIGH",
         "title": "Credential embedded in system prompt / hidden context",
         "checks": "PROMPT extras.content and AGENT system_prompt_excerpt vs. credential-like patterns",
         "pass_reason": "No credential-like patterns found in prompt or hidden-context text",
     },
     {
-        "rule_id": "NGA-026", "severity": "MEDIUM",
+        "rule_id": "NGA-026",
+        "severity": "MEDIUM",
         "title": "AI endpoint without application-level rate limiting",
         "checks": "API_ENDPOINT nodes vs. rate_limited / rate_limit_detail",
         "pass_reason": "No AI-facing endpoints found, or all have rate limiting configured",
     },
     {
-        "rule_id": "NGA-027", "severity": "MEDIUM",
+        "rule_id": "NGA-027",
+        "severity": "MEDIUM",
         "title": "AI endpoint missing security headers (CSP/X-Frame-Options/HSTS)",
         "checks": "API_ENDPOINT nodes vs. security_headers_detail",
         "pass_reason": "No AI-facing endpoints found, or all confirm CSP/X-Frame-Options/HSTS",
     },
     {
-        "rule_id": "NGA-028", "severity": "HIGH",
+        "rule_id": "NGA-028",
+        "severity": "HIGH",
         "title": "API endpoint has an overly permissive CORS policy",
         "checks": "API_ENDPOINT nodes vs. cors_policy.origin / wildcard_with_credentials",
         "pass_reason": "No AI-facing endpoints found, or none allow a wildcard CORS origin",
     },
     {
-        "rule_id": "NGA-029", "severity": "MEDIUM",
+        "rule_id": "NGA-029",
+        "severity": "MEDIUM",
         "title": "API endpoint's error handler leaks stack traces",
         "checks": "API_ENDPOINT nodes vs. debug_error_leak",
         "pass_reason": "No AI-facing endpoints found, or none run in debug/verbose-error mode",
     },
     {
-        "rule_id": "NGA-030", "severity": "HIGH",
+        "rule_id": "NGA-030",
+        "severity": "HIGH",
         "title": "JWT verification with no pinned algorithm allow-list",
         "checks": "AUTH nodes (auth_type=jwt) vs. auth_detail.jwt_algorithm_restricted",
         "pass_reason": "No JWT auth mechanism found, or all verify calls pin an algorithms allow-list",
@@ -2189,22 +2323,32 @@ def _build_pass_evidence(
 
     if rule_id == "NGA-002":
         return {
-            "guardrail_nodes": [n.get("name", "") for n in nodes if n.get("component_type") in _GUARDRAIL_TYPES],
-            "model_nodes": [n.get("name", "") for n in nodes if n.get("component_type") in _MODEL_TYPES],
-            "agent_nodes": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
+            "guardrail_nodes": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _GUARDRAIL_TYPES
+            ],
+            "model_nodes": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _MODEL_TYPES
+            ],
+            "agent_nodes": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
         }
 
     if rule_id == "NGA-003":
         return {
-            "deployment_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") == "DEPLOYMENT"],
+            "deployment_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") == "DEPLOYMENT"
+            ],
             "secret_stores_configured": summary.get("secret_stores") or [],
-            "secrets_in_env_found": "secrets_in_env_vars" in (summary.get("security_findings") or []),
+            "secrets_in_env_found": "secrets_in_env_vars"
+            in (summary.get("security_findings") or []),
         }
 
     if rule_id == "NGA-004":
         return {
             "container_or_deployment_nodes_checked": [
-                n.get("name", "") for n in nodes
+                n.get("name", "")
+                for n in nodes
                 if n.get("component_type") in ("DEPLOYMENT", "CONTAINER_IMAGE")
             ],
             "runs_as_root_detected": False,
@@ -2214,14 +2358,20 @@ def _build_pass_evidence(
         dc_labels = summary.get("data_classification") or []
         return {
             "data_classification_labels": dc_labels or ["none"],
-            "datastore_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES],
+            "datastore_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES
+            ],
             "unencrypted_datastores_found": 0,
         }
 
     if rule_id == "NGA-006":
         return {
-            "api_endpoints_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES],
-            "auth_nodes_found": [n.get("name", "") for n in nodes if n.get("component_type") == "AUTH"],
+            "api_endpoints_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES
+            ],
+            "auth_nodes_found": [
+                n.get("name", "") for n in nodes if n.get("component_type") == "AUTH"
+            ],
         }
 
     if rule_id == "NGA-007":
@@ -2237,7 +2387,9 @@ def _build_pass_evidence(
                 if src and src.get("component_type") in _IAM_TYPES:
                     iam_attached.append(src.get("name", ""))
         return {
-            "deployment_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _DEPLOYMENT_TYPES],
+            "deployment_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _DEPLOYMENT_TYPES
+            ],
             "iam_nodes_checked": list(set(iam_attached)),
             "overpermissive_roles_found": 0,
         }
@@ -2245,14 +2397,18 @@ def _build_pass_evidence(
     if rule_id == "NGA-008":
         trusted = _DEFAULT_TRUSTED_REGISTRIES | set(summary.get("trusted_registries") or [])
         return {
-            "model_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _MODEL_TYPES],
+            "model_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _MODEL_TYPES
+            ],
             "trusted_registries": sorted(trusted),
         }
 
     if rule_id == "NGA-009":
         frameworks = [f.lower() for f in (summary.get("frameworks") or [])]
         return {
-            "agent_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
+            "agent_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
             "audit_libraries_found": [lib for lib in _AUDIT_LIBS if lib in frameworks],
             "log_paths_found": summary.get("log_paths") or [],
         }
@@ -2272,19 +2428,25 @@ def _build_pass_evidence(
     if rule_id == "NGA-012":
         tool_names = [n.get("name", "") for n in nodes if n.get("component_type") == "TOOL"]
         irreversible_tools = [
-            n.get("name", "") for n in nodes
+            n.get("name", "")
+            for n in nodes
             if n.get("component_type") == "TOOL"
-            and _IRREVERSIBLE_TOOL_PATTERNS.search(n.get("name", "") + " " + str(n.get("metadata", {})))
+            and _IRREVERSIBLE_TOOL_PATTERNS.search(
+                n.get("name", "") + " " + str(n.get("metadata", {}))
+            )
         ]
         return {
-            "agents_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
+            "agents_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
             "tools_checked": tool_names,
             "irreversible_tools_found": irreversible_tools,
         }
 
     if rule_id == "NGA-013":
         k8s = [
-            n.get("name", "") for n in nodes
+            n.get("name", "")
+            for n in nodes
             if n.get("component_type") in _DEPLOYMENT_TYPES
             and (
                 _depl_meta(n).get("deployment_target", "").lower() in ("kubernetes", "k8s")
@@ -2301,20 +2463,25 @@ def _build_pass_evidence(
 
     if rule_id == "NGA-015":
         return {
-            "deployment_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") == "DEPLOYMENT"],
+            "deployment_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") == "DEPLOYMENT"
+            ],
             "all_have_resource_limits": True,
         }
 
     if rule_id == "NGA-016":
         return {
-            "container_image_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _CONTAINER_TYPES],
+            "container_image_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _CONTAINER_TYPES
+            ],
             "all_images_version_pinned": True,
         }
 
     if rule_id == "NGA-017":
         return {
             "deployment_and_container_nodes_checked": [
-                n.get("name", "") for n in nodes
+                n.get("name", "")
+                for n in nodes
                 if n.get("component_type") in (_DEPLOYMENT_TYPES | _CONTAINER_TYPES)
             ],
             "all_have_health_check": True,
@@ -2322,43 +2489,63 @@ def _build_pass_evidence(
 
     if rule_id == "NGA-018":
         return {
-            "datastore_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES],
-            "agent_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
-            "iam_nodes_found": [n.get("name", "") for n in nodes if n.get("component_type") in _IAM_TYPES],
+            "datastore_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES
+            ],
+            "agent_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
+            "iam_nodes_found": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _IAM_TYPES
+            ],
         }
 
     if rule_id == "NGA-019":
         return {
-            "agent_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
-            "datastore_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES],
+            "agent_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
+            "datastore_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES
+            ],
             "requires_graph": True,
         }
 
     if rule_id == "NGA-020":
         return {
-            "agent_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
+            "agent_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
             "requires_graph": True,
         }
 
     if rule_id == "NGA-021":
         return {
-            "api_endpoint_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES],
+            "api_endpoint_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES
+            ],
             "requires_graph": True,
         }
 
     if rule_id == "NGA-022":
         return {
-            "tool_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") == "TOOL"],
+            "tool_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") == "TOOL"
+            ],
         }
 
     if rule_id == "NGA-023":
         return {
-            "datastore_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES],
+            "datastore_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _DATASTORE_TYPES
+            ],
         }
 
     if rule_id == "NGA-024":
         return {
-            "agent_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES],
+            "agent_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _AGENT_TYPES
+            ],
             "requires_graph": True,
         }
 
@@ -2371,17 +2558,23 @@ def _build_pass_evidence(
 
     if rule_id == "NGA-026":
         return {
-            "api_endpoint_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES],
+            "api_endpoint_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES
+            ],
         }
 
     if rule_id in ("NGA-027", "NGA-028", "NGA-029"):
         return {
-            "api_endpoint_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES],
+            "api_endpoint_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") in _API_ENDPOINT_TYPES
+            ],
         }
 
     if rule_id == "NGA-030":
         return {
-            "auth_nodes_checked": [n.get("name", "") for n in nodes if n.get("component_type") == "AUTH"],
+            "auth_nodes_checked": [
+                n.get("name", "") for n in nodes if n.get("component_type") == "AUTH"
+            ],
         }
 
     return {}
@@ -2419,9 +2612,9 @@ def _summarize_description(text: str, max_len: int = 140) -> str:
     # descriptions are formatted as unpunctuated numbered steps.
     candidate = text
     for m in _SENTENCE_END_RE.finditer(text):
-        if _LIST_MARKER_TAIL_RE.search(text[:m.start()]):
+        if _LIST_MARKER_TAIL_RE.search(text[: m.start()]):
             continue
-        chunk = text[:m.end()].strip()
+        chunk = text[: m.end()].strip()
         if chunk:
             candidate = chunk
             break
@@ -2574,41 +2767,52 @@ class NgaRulesPlugin(AnalysisPlugin):
                         audit_status = "PASS"
                     else:
                         audit_status = "FAIL"
-                    rule_audit.append({
-                        "rule_id": rule_id_str,
-                        "severity": meta["severity"],
-                        "title": meta["title"],
-                        "checks": meta["checks"],
-                        "status": audit_status,
-                        "finding_count": len(rule_findings),
-                        "pass_reason": meta["pass_reason"] if is_pass and not not_applicable else "",
-                        "pass_evidence": _build_pass_evidence(i, nodes, edges, summary) if (is_pass and not not_applicable) else {},
-                        "affected": list({
-                            f.get("affected_component") or ""
-                            for f in rule_findings
-                            if f.get("affected_component")
-                        }),
-                    })
+                    rule_audit.append(
+                        {
+                            "rule_id": rule_id_str,
+                            "severity": meta["severity"],
+                            "title": meta["title"],
+                            "checks": meta["checks"],
+                            "status": audit_status,
+                            "finding_count": len(rule_findings),
+                            "pass_reason": meta["pass_reason"]
+                            if is_pass and not not_applicable
+                            else "",
+                            "pass_evidence": _build_pass_evidence(i, nodes, edges, summary)
+                            if (is_pass and not not_applicable)
+                            else {},
+                            "affected": list(
+                                {
+                                    f.get("affected_component") or ""
+                                    for f in rule_findings
+                                    if f.get("affected_component")
+                                }
+                            ),
+                        }
+                    )
             except Exception as exc:
                 _log.warning("NGA rule %s raised an error and was skipped: %s", rule.__name__, exc)
                 if verbose:
                     meta = _RULE_META[i]
-                    rule_audit.append({
-                        "rule_id": meta["rule_id"],
-                        "severity": meta["severity"],
-                        "title": meta["title"],
-                        "checks": meta["checks"],
-                        "status": "ERROR",
-                        "finding_count": 0,
-                        "pass_reason": f"Rule raised an error: {exc}",
-                        "affected": [],
-                    })
+                    rule_audit.append(
+                        {
+                            "rule_id": meta["rule_id"],
+                            "severity": meta["severity"],
+                            "title": meta["title"],
+                            "checks": meta["checks"],
+                            "status": "ERROR",
+                            "finding_count": 0,
+                            "pass_reason": f"Rule raised an error: {exc}",
+                            "affected": [],
+                        }
+                    )
         _log.info("NGA structural rules: %d finding(s)", len(findings))
 
         # Phase 2: OSV dep scan
         osv_findings: list[dict[str, Any]] = []
         if provider in ("osv", "all"):
             from nuguard.analysis.osv_client import query_osv
+
             _log.info("Querying OSV for %d dep(s)", len(deps))
             for osv in query_osv(deps, timeout=timeout):
                 osv_findings.append(_osv_to_finding(osv))
@@ -2618,6 +2822,7 @@ class NgaRulesPlugin(AnalysisPlugin):
         grype_findings: list[dict[str, Any]] = []
         if provider in ("grype", "all"):
             from nuguard.analysis.grype_client import query_grype_images, query_grype_sbom
+
             grype_timeout = float(config.get("grype_timeout", 60.0))
             _log.info("Running grype sbom scan")
             for g in query_grype_sbom(sbom, timeout=grype_timeout):
@@ -2652,7 +2857,8 @@ class NgaRulesPlugin(AnalysisPlugin):
             status=status,
             plugin=self.name,
             message=(f"Found {len(all_findings)} finding(s): " + ", ".join(msg_parts))
-            if all_findings else "No vulnerabilities detected",
+            if all_findings
+            else "No vulnerabilities detected",
             findings=all_findings,
             details={
                 "provider": provider,

--- a/nuguard/common/soft_reject.py
+++ b/nuguard/common/soft_reject.py
@@ -1,0 +1,140 @@
+"""Shared contract for LLM-soft-rejected SBOM nodes.
+
+Deterministic nodes rejected by LLM verification remain in the AI-SBOM for
+recall, audit, and troubleshooting. Downstream consumers that treat nodes as
+confirmed application components must use this module rather than duplicating
+the metadata-key check.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from typing import TypeVar
+
+SOFT_REJECT_FLAG = "llm_soft_rejected"
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class NodeCountPartition:
+    """Effective and soft-rejected node counts by component type."""
+
+    effective: dict[str, int]
+    soft_rejected: dict[str, int]
+
+
+def _member(
+    value: object,
+    name: str,
+) -> object | None:
+    if isinstance(value, Mapping):
+        return value.get(name)
+
+    return getattr(
+        value,
+        name,
+        None,
+    )
+
+
+def _extras(
+    node: object,
+) -> Mapping[str, object]:
+    metadata = _member(
+        node,
+        "metadata",
+    )
+
+    if metadata is None:
+        return {}
+
+    extras = _member(
+        metadata,
+        "extras",
+    )
+
+    if isinstance(extras, Mapping):
+        return extras
+
+    return {}
+
+
+def is_soft_rejected(
+    node: object,
+) -> bool:
+    """Return whether LLM verification rejected a retained deterministic node."""
+    return _extras(node).get(SOFT_REJECT_FLAG) is True
+
+
+def iter_effective_nodes(
+    nodes: Iterable[T],
+) -> Iterator[T]:
+    """Yield nodes that downstream consumers may treat as confirmed."""
+    for node in nodes:
+        if not is_soft_rejected(node):
+            yield node
+
+
+def _component_type_name(
+    node: object,
+) -> str | None:
+    component_type = _member(
+        node,
+        "component_type",
+    )
+
+    if component_type is None:
+        return None
+
+    enum_value = _member(
+        component_type,
+        "value",
+    )
+    raw_value = enum_value if enum_value is not None else component_type
+
+    if not isinstance(raw_value, str):
+        return None
+
+    normalized = raw_value.strip()
+
+    return normalized or None
+
+
+def partition_node_counts(
+    nodes: Iterable[object],
+) -> NodeCountPartition:
+    """Count effective and soft-rejected nodes without removing audit records."""
+    effective: dict[str, int] = {}
+    soft_rejected: dict[str, int] = {}
+
+    for node in nodes:
+        component_type = _component_type_name(node)
+
+        if component_type is None:
+            continue
+
+        destination = soft_rejected if is_soft_rejected(node) else effective
+
+        destination[component_type] = (
+            destination.get(
+                component_type,
+                0,
+            )
+            + 1
+        )
+
+    return NodeCountPartition(
+        effective=dict(sorted(effective.items())),
+        soft_rejected=dict(sorted(soft_rejected.items())),
+    )
+
+
+__all__ = [
+    "NodeCountPartition",
+    "SOFT_REJECT_FLAG",
+    "is_soft_rejected",
+    "iter_effective_nodes",
+    "partition_node_counts",
+]

--- a/nuguard/policy/checker.py
+++ b/nuguard/policy/checker.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from nuguard.common.logging import get_logger
+from nuguard.common.soft_reject import is_soft_rejected as _is_soft_rejected
 from nuguard.models.policy import CognitivePolicy
 from nuguard.models.token_usage import TokenUsage
 from nuguard.sbom.models import AiSbomDocument, Node, RateLimitDetail
@@ -164,6 +165,7 @@ def _check_description(check_id: str) -> str:
 # Result models
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class PolicyGap:
     """A single gap between a policy directive and SBOM evidence."""
@@ -223,6 +225,7 @@ class PolicyCheckResult:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _nodes_of_type(doc: AiSbomDocument, *types: ComponentType) -> list:
     """Return all nodes whose component_type is in *types*."""
     return [n for n in doc.nodes if n.component_type in types]
@@ -277,11 +280,6 @@ def _component_label(node: Node) -> str:
         route = f"{method} {endpoint}" if method else endpoint
         label = f"{label} ({route})"
     return f"{label}, confidence={node.confidence:.2f}, {_component_location(node)}"
-
-
-def _is_soft_rejected(node: Node) -> bool:
-    """Return True when enrichment marked a candidate node as likely false positive."""
-    return bool(node.metadata.extras.get("llm_soft_rejected"))
 
 
 def _is_generic_endpoint_candidate(node: Node) -> bool:
@@ -396,8 +394,7 @@ def _prompt_evidence_for(triggers: list[str], doc: AiSbomDocument) -> list[str]:
         if matched_keywords:
             excerpt = content[:120].replace("\n", " ").strip()
             evidence.append(
-                f"{node.name!r}: '…{excerpt}…' "
-                f"[matched: {', '.join(matched_keywords[:3])}]"
+                f"{node.name!r}: '…{excerpt}…' [matched: {', '.join(matched_keywords[:3])}]"
             )
     return evidence
 
@@ -427,17 +424,11 @@ def _data_classification_evidence(node: Node) -> list[str]:
 
     classifications = _as_list(_metadata_value(node, "data_classification"))
     if classifications:
-        evidence.append(
-            "data_classification="
-            f"{', '.join(str(item) for item in classifications)}"
-        )
+        evidence.append(f"data_classification={', '.join(str(item) for item in classifications)}")
 
     classified_tables = _as_list(_metadata_value(node, "classified_tables"))
     if classified_tables:
-        evidence.append(
-            "classified_tables="
-            f"{', '.join(str(item) for item in classified_tables)}"
-        )
+        evidence.append(f"classified_tables={', '.join(str(item) for item in classified_tables)}")
 
     classified_fields = _metadata_value(node, "classified_fields")
     if isinstance(classified_fields, dict) and classified_fields:
@@ -450,10 +441,7 @@ def _data_classification_evidence(node: Node) -> list[str]:
     for field_name in ("pii_fields", "phi_fields", "pfi_fields"):
         fields = _as_list(_metadata_value(node, field_name))
         if fields:
-            evidence.append(
-                f"{field_name}="
-                f"{', '.join(str(field) for field in fields)}"
-            )
+            evidence.append(f"{field_name}={', '.join(str(field) for field in fields)}")
 
     return evidence
 
@@ -481,11 +469,7 @@ def _rate_limit_evidence(node: Node) -> list[str]:
 
     rate_limit_detail = _metadata_value(node, "rate_limit_detail")
     if rate_limit_detail:
-        evidence.append(
-            "rate_limit_detail={"
-            f"{_rate_limit_detail_summary(rate_limit_detail)}"
-            "}"
-        )
+        evidence.append(f"rate_limit_detail={{{_rate_limit_detail_summary(rate_limit_detail)}}}")
 
     legacy_rate_limit = node.metadata.extras.get("rate_limit")
     if legacy_rate_limit is not None:
@@ -498,9 +482,8 @@ def _rate_limit_evidence(node: Node) -> list[str]:
 # Public API
 # ---------------------------------------------------------------------------
 
-def check_policy_against_sbom(
-    policy: CognitivePolicy, doc: AiSbomDocument
-) -> PolicyCheckResult:
+
+def check_policy_against_sbom(policy: CognitivePolicy, doc: AiSbomDocument) -> PolicyCheckResult:
     """Cross-check a CognitivePolicy against an AiSbomDocument.
 
     Checks
@@ -529,26 +512,29 @@ def check_policy_against_sbom(
     datastore_nodes = _nodes_of_type(doc, ComponentType.DATASTORE)
     all_api_nodes = _nodes_of_type(doc, ComponentType.API_ENDPOINT)
     api_nodes = [
-        n for n in all_api_nodes
+        n
+        for n in all_api_nodes
         if not _is_soft_rejected(n) and not _is_generic_endpoint_candidate(n)
     ]
 
     # ---- CHECK-001: HITL Enforcement ----------------------------------------
     if policy.hitl_triggers:
         if guardrail_nodes:
-            result.passed.append(PolicyControl(
-                check_id="CHECK-001",
-                name=_check_name("CHECK-001"),
-                description=_check_description("CHECK-001"),
-                policy_section="hitl_triggers",
-                evidence=[
-                    f"GUARDRAIL node: {n.name!r} "
-                    f"(confidence={n.confidence:.2f}, "
-                    f"file={n.evidence[0].location.path if n.evidence else 'unknown'})"
-                    for n in guardrail_nodes
-                ],
-                evidence_source="sbom_node",
-            ))
+            result.passed.append(
+                PolicyControl(
+                    check_id="CHECK-001",
+                    name=_check_name("CHECK-001"),
+                    description=_check_description("CHECK-001"),
+                    policy_section="hitl_triggers",
+                    evidence=[
+                        f"GUARDRAIL node: {n.name!r} "
+                        f"(confidence={n.confidence:.2f}, "
+                        f"file={n.evidence[0].location.path if n.evidence else 'unknown'})"
+                        for n in guardrail_nodes
+                    ],
+                    evidence_source="sbom_node",
+                )
+            )
         else:
             # No guardrail — check prompt nodes for partial evidence
             prompt_ev = _prompt_evidence_for(policy.hitl_triggers, doc)
@@ -559,32 +545,35 @@ def check_policy_against_sbom(
                 searched.append(
                     f"PROMPT nodes: found {len(prompt_ev)} prompt(s) with related content"
                 )
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-001",
-                name=_check_name("CHECK-001"),
-                description=_check_description("CHECK-001"),
-                message=(
-                    "The policy defines HITL triggers but the SBOM contains no "
-                    "GUARDRAIL nodes that could enforce them."
-                    + (
-                        f" Found {len(prompt_ev)} PROMPT node(s) with related content "
-                        "(prompt-level instructions are weaker than guardrail enforcement)."
-                        if prompt_ev else ""
-                    )
-                ),
-                policy_section="hitl_triggers",
-                severity="high" if not prompt_ev else "medium",
-                searched=searched,
-                prompt_evidence=prompt_ev,
-                remediation=(
-                    "Add an InputGuardrail or OutputGuardrail component to your agent "
-                    "framework. In LangChain/LangGraph, implement a callback handler that "
-                    "intercepts dispute, fraud, and high-value transfer requests and routes "
-                    "them to a human queue. In ADK or OpenAI Agents SDK, configure a "
-                    "guardrail tool that triggers escalation. After adding the component, "
-                    "re-run 'nuguard sbom generate' so the GUARDRAIL node appears in the SBOM."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-001",
+                    name=_check_name("CHECK-001"),
+                    description=_check_description("CHECK-001"),
+                    message=(
+                        "The policy defines HITL triggers but the SBOM contains no "
+                        "GUARDRAIL nodes that could enforce them."
+                        + (
+                            f" Found {len(prompt_ev)} PROMPT node(s) with related content "
+                            "(prompt-level instructions are weaker than guardrail enforcement)."
+                            if prompt_ev
+                            else ""
+                        )
+                    ),
+                    policy_section="hitl_triggers",
+                    severity="high" if not prompt_ev else "medium",
+                    searched=searched,
+                    prompt_evidence=prompt_ev,
+                    remediation=(
+                        "Add an InputGuardrail or OutputGuardrail component to your agent "
+                        "framework. In LangChain/LangGraph, implement a callback handler that "
+                        "intercepts dispute, fraud, and high-value transfer requests and routes "
+                        "them to a human queue. In ADK or OpenAI Agents SDK, configure a "
+                        "guardrail tool that triggers escalation. After adding the component, "
+                        "re-run 'nuguard sbom generate' so the GUARDRAIL node appears in the SBOM."
+                    ),
+                )
+            )
 
     # ---- CHECK-002: Restricted Action Coverage ------------------------------
     if policy.restricted_actions:
@@ -593,70 +582,76 @@ def check_policy_against_sbom(
             for action in policy.restricted_actions:
                 matched_tools = _restricted_action_matches(action, tool_nodes)
                 if matched_tools:
-                    result.passed.append(PolicyControl(
-                        check_id="CHECK-002",
-                        name=_check_name("CHECK-002"),
-                        description=_check_description("CHECK-002"),
-                        policy_section="restricted_actions",
-                        evidence=[
-                            f"Action {action!r} maps to TOOL node {_component_label(n)} "
-                            f"(matched terms: {', '.join(sorted(overlap)[:5])})"
-                            for n, overlap in matched_tools
-                        ],
-                        evidence_source="sbom_node",
-                    ))
+                    result.passed.append(
+                        PolicyControl(
+                            check_id="CHECK-002",
+                            name=_check_name("CHECK-002"),
+                            description=_check_description("CHECK-002"),
+                            policy_section="restricted_actions",
+                            evidence=[
+                                f"Action {action!r} maps to TOOL node {_component_label(n)} "
+                                f"(matched terms: {', '.join(sorted(overlap)[:5])})"
+                                for n, overlap in matched_tools
+                            ],
+                            evidence_source="sbom_node",
+                        )
+                    )
                 else:
-                    result.gaps.append(PolicyGap(
-                        check_id="CHECK-002",
-                        name=_check_name("CHECK-002"),
-                        description=_check_description("CHECK-002"),
-                        message=(
-                            f"Restricted action {action!r} does not match any TOOL node "
-                            "name, description, or source-evidence terms in the SBOM. "
-                            "This may mean the capability is absent, the SBOM missed it, "
-                            "or the policy needs an explicit tool/control mapping."
-                        ),
-                        policy_section="restricted_actions",
-                        severity="medium",
-                        searched=[
-                            f"Checked {len(tool_names)} TOOL nodes: {', '.join(tool_names[:5])}"
-                            + (" …" if len(tool_names) > 5 else ""),
-                            "Matched against TOOL name, description, descriptive_name, "
-                            "extras.description, and source evidence terms.",
-                            "If this capability is intentionally absent, treat this as "
-                            "not applicable rather than an implementation defect.",
-                        ],
-                        remediation=(
-                            f"Map restricted action {action!r} to an enforcement boundary. "
-                            "Preferred options: (1) add explicit policy metadata such as "
-                            "'policy_controls', 'operation', 'data_access', and "
-                            "'authz_required' to the corresponding tool; (2) add or verify "
-                            "authorization checks inside the tool implementation; or "
-                            "(3) if the capability is not implemented, mark the policy "
-                            "control as not applicable in the source policy or control "
-                            "metadata. Re-run 'nuguard sbom generate' after changing code "
-                            "or annotations."
-                        ),
-                    ))
+                    result.gaps.append(
+                        PolicyGap(
+                            check_id="CHECK-002",
+                            name=_check_name("CHECK-002"),
+                            description=_check_description("CHECK-002"),
+                            message=(
+                                f"Restricted action {action!r} does not match any TOOL node "
+                                "name, description, or source-evidence terms in the SBOM. "
+                                "This may mean the capability is absent, the SBOM missed it, "
+                                "or the policy needs an explicit tool/control mapping."
+                            ),
+                            policy_section="restricted_actions",
+                            severity="medium",
+                            searched=[
+                                f"Checked {len(tool_names)} TOOL nodes: {', '.join(tool_names[:5])}"
+                                + (" …" if len(tool_names) > 5 else ""),
+                                "Matched against TOOL name, description, descriptive_name, "
+                                "extras.description, and source evidence terms.",
+                                "If this capability is intentionally absent, treat this as "
+                                "not applicable rather than an implementation defect.",
+                            ],
+                            remediation=(
+                                f"Map restricted action {action!r} to an enforcement boundary. "
+                                "Preferred options: (1) add explicit policy metadata such as "
+                                "'policy_controls', 'operation', 'data_access', and "
+                                "'authz_required' to the corresponding tool; (2) add or verify "
+                                "authorization checks inside the tool implementation; or "
+                                "(3) if the capability is not implemented, mark the policy "
+                                "control as not applicable in the source policy or control "
+                                "metadata. Re-run 'nuguard sbom generate' after changing code "
+                                "or annotations."
+                            ),
+                        )
+                    )
         else:
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-002",
-                name=_check_name("CHECK-002"),
-                description=_check_description("CHECK-002"),
-                message=(
-                    "Policy defines restricted_actions but the SBOM contains no "
-                    "TOOL nodes to enforce them against."
-                ),
-                policy_section="restricted_actions",
-                severity="medium",
-                searched=["TOOL nodes: none found in SBOM"],
-                remediation=(
-                    "Register the tools that enforce your restricted actions so they "
-                    "appear as TOOL nodes in the SBOM. Each restricted action should map "
-                    "to a named tool with authorization checks in its implementation. "
-                    "Re-run 'nuguard sbom generate' after adding the tools."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-002",
+                    name=_check_name("CHECK-002"),
+                    description=_check_description("CHECK-002"),
+                    message=(
+                        "Policy defines restricted_actions but the SBOM contains no "
+                        "TOOL nodes to enforce them against."
+                    ),
+                    policy_section="restricted_actions",
+                    severity="medium",
+                    searched=["TOOL nodes: none found in SBOM"],
+                    remediation=(
+                        "Register the tools that enforce your restricted actions so they "
+                        "appear as TOOL nodes in the SBOM. Each restricted action should map "
+                        "to a named tool with authorization checks in its implementation. "
+                        "Re-run 'nuguard sbom generate' after adding the tools."
+                    ),
+                )
+            )
 
     # ---- CHECK-003: Data Classification Metadata ----------------------------
     if policy.data_classification:
@@ -664,63 +659,69 @@ def check_policy_against_sbom(
             for ds in datastore_nodes:
                 data_evidence = _data_classification_evidence(ds)
                 if data_evidence:
-                    result.passed.append(PolicyControl(
-                        check_id="CHECK-003",
-                        name=_check_name("CHECK-003"),
-                        description=_check_description("CHECK-003"),
-                        policy_section="data_classification",
-                        evidence=[
-                            f"DATASTORE {ds.name!r} has classification metadata: {item}"
-                            for item in data_evidence
-                        ],
-                        evidence_source="sbom_node",
-                    ))
+                    result.passed.append(
+                        PolicyControl(
+                            check_id="CHECK-003",
+                            name=_check_name("CHECK-003"),
+                            description=_check_description("CHECK-003"),
+                            policy_section="data_classification",
+                            evidence=[
+                                f"DATASTORE {ds.name!r} has classification metadata: {item}"
+                                for item in data_evidence
+                            ],
+                            evidence_source="sbom_node",
+                        )
+                    )
                 else:
-                    result.gaps.append(PolicyGap(
-                        check_id="CHECK-003",
-                        name=_check_name("CHECK-003"),
-                        description=_check_description("CHECK-003"),
-                        message=(
-                            f"Policy declares data classification requirements but "
-                            f"DATASTORE node {ds.name!r} has no classification, "
-                            "classified-field, PII, PHI, or PFI metadata."
-                        ),
-                        policy_section="data_classification",
-                        sbom_component=ds.name,
-                        severity="medium",
-                        searched=[
-                            "Checked data_classification, classified_tables, "
-                            "classified_fields, pii_fields, phi_fields, and "
-                            f"pfi_fields on DATASTORE {ds.name!r}: empty"
-                        ],
-                        remediation=(
-                            f"Annotate the {ds.name!r} datastore in source code with "
-                            "data-classification markers (e.g. column-level 'pii=True' "
-                            "attributes in SQLAlchemy models, or NuGuard-comment annotations "
-                            "on the connection string). Re-run 'nuguard sbom generate' so "
-                            "pii_fields, phi_fields, or data_classification metadata is "
-                            "captured in the SBOM node."
-                        ),
-                    ))
+                    result.gaps.append(
+                        PolicyGap(
+                            check_id="CHECK-003",
+                            name=_check_name("CHECK-003"),
+                            description=_check_description("CHECK-003"),
+                            message=(
+                                f"Policy declares data classification requirements but "
+                                f"DATASTORE node {ds.name!r} has no classification, "
+                                "classified-field, PII, PHI, or PFI metadata."
+                            ),
+                            policy_section="data_classification",
+                            sbom_component=ds.name,
+                            severity="medium",
+                            searched=[
+                                "Checked data_classification, classified_tables, "
+                                "classified_fields, pii_fields, phi_fields, and "
+                                f"pfi_fields on DATASTORE {ds.name!r}: empty"
+                            ],
+                            remediation=(
+                                f"Annotate the {ds.name!r} datastore in source code with "
+                                "data-classification markers (e.g. column-level 'pii=True' "
+                                "attributes in SQLAlchemy models, or NuGuard-comment annotations "
+                                "on the connection string). Re-run 'nuguard sbom generate' so "
+                                "pii_fields, phi_fields, or data_classification metadata is "
+                                "captured in the SBOM node."
+                            ),
+                        )
+                    )
         else:
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-003",
-                name=_check_name("CHECK-003"),
-                description=_check_description("CHECK-003"),
-                message=(
-                    "Policy defines data_classification requirements but the SBOM "
-                    "contains no DATASTORE nodes."
-                ),
-                policy_section="data_classification",
-                severity="medium",
-                searched=["DATASTORE nodes: none found in SBOM"],
-                remediation=(
-                    "Ensure data access objects (SQLAlchemy sessions, Postgres connections, "
-                    "Redis clients, etc.) are imported and used within the scanned source "
-                    "tree. Re-run 'nuguard sbom generate' so DATASTORE nodes are detected "
-                    "and their PII/PHI field annotations are captured."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-003",
+                    name=_check_name("CHECK-003"),
+                    description=_check_description("CHECK-003"),
+                    message=(
+                        "Policy defines data_classification requirements but the SBOM "
+                        "contains no DATASTORE nodes."
+                    ),
+                    policy_section="data_classification",
+                    severity="medium",
+                    searched=["DATASTORE nodes: none found in SBOM"],
+                    remediation=(
+                        "Ensure data access objects (SQLAlchemy sessions, Postgres connections, "
+                        "Redis clients, etc.) are imported and used within the scanned source "
+                        "tree. Re-run 'nuguard sbom generate' so DATASTORE nodes are detected "
+                        "and their PII/PHI field annotations are captured."
+                    ),
+                )
+            )
 
     # ---- CHECK-004: Rate Limit Instrumentation ------------------------------
     if policy.rate_limits:
@@ -728,42 +729,47 @@ def check_policy_against_sbom(
             for ep in api_nodes:
                 rate_limit_evidence = _rate_limit_evidence(ep)
                 if rate_limit_evidence:
-                    result.passed.append(PolicyControl(
-                        check_id="CHECK-004",
-                        name=_check_name("CHECK-004"),
-                        description=_check_description("CHECK-004"),
-                        policy_section="rate_limits",
-                        evidence=[
-                            f"API_ENDPOINT {ep.name!r} has {item}"
-                            for item in rate_limit_evidence
-                        ],
-                        evidence_source="sbom_node",
-                    ))
+                    result.passed.append(
+                        PolicyControl(
+                            check_id="CHECK-004",
+                            name=_check_name("CHECK-004"),
+                            description=_check_description("CHECK-004"),
+                            policy_section="rate_limits",
+                            evidence=[
+                                f"API_ENDPOINT {ep.name!r} has {item}"
+                                for item in rate_limit_evidence
+                            ],
+                            evidence_source="sbom_node",
+                        )
+                    )
                 else:
                     severity = _endpoint_rate_limit_severity(ep)
-                    result.gaps.append(PolicyGap(
-                        check_id="CHECK-004",
-                        name=_check_name("CHECK-004"),
-                        description=_check_description("CHECK-004"),
-                        message=(
-                            f"Policy defines rate_limits but API_ENDPOINT node "
-                            f"{ep.name!r} has no rate_limited or rate_limit_detail "
-                            "metadata in the SBOM."
-                        ),
-                        policy_section="rate_limits",
-                        sbom_component=ep.name,
-                        severity=severity,
-                        searched=[
-                            "Checked rate_limited, rate_limit_detail, and legacy "
-                            f"rate_limit metadata on API_ENDPOINT {_component_label(ep)}: not set",
-                            "Endpoint priority is based on route/name, chat payload "
-                            "metadata, and sensitive-response metadata.",
-                        ],
-                        remediation=_rate_limit_remediation(ep),
-                    ))
+                    result.gaps.append(
+                        PolicyGap(
+                            check_id="CHECK-004",
+                            name=_check_name("CHECK-004"),
+                            description=_check_description("CHECK-004"),
+                            message=(
+                                f"Policy defines rate_limits but API_ENDPOINT node "
+                                f"{ep.name!r} has no rate_limited or rate_limit_detail "
+                                "metadata in the SBOM."
+                            ),
+                            policy_section="rate_limits",
+                            sbom_component=ep.name,
+                            severity=severity,
+                            searched=[
+                                "Checked rate_limited, rate_limit_detail, and legacy "
+                                f"rate_limit metadata on API_ENDPOINT {_component_label(ep)}: not set",
+                                "Endpoint priority is based on route/name, chat payload "
+                                "metadata, and sensitive-response metadata.",
+                            ],
+                            remediation=_rate_limit_remediation(ep),
+                        )
+                    )
         else:
             skipped = [
-                n for n in all_api_nodes
+                n
+                for n in all_api_nodes
                 if _is_soft_rejected(n) or _is_generic_endpoint_candidate(n)
             ]
             searched = ["API_ENDPOINT nodes: none found in SBOM"]
@@ -774,109 +780,121 @@ def check_policy_against_sbom(
                     + ", ".join(n.name for n in skipped[:5])
                     + (" …" if len(skipped) > 5 else ""),
                 ]
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-004",
-                name=_check_name("CHECK-004"),
-                description=_check_description("CHECK-004"),
-                message=(
-                    "Policy defines rate_limits but the SBOM contains no "
-                    "API_ENDPOINT nodes."
-                ),
-                policy_section="rate_limits",
-                severity="low",
-                searched=searched,
-                remediation=(
-                    "Ensure route/handler functions are present in the scanned source "
-                    "tree and decorated with the appropriate HTTP framework decorators "
-                    "(@app.route, @router.get, etc.) so NuGuard can detect them as "
-                    "API_ENDPOINT nodes. Re-run 'nuguard sbom generate'."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-004",
+                    name=_check_name("CHECK-004"),
+                    description=_check_description("CHECK-004"),
+                    message=(
+                        "Policy defines rate_limits but the SBOM contains no API_ENDPOINT nodes."
+                    ),
+                    policy_section="rate_limits",
+                    severity="low",
+                    searched=searched,
+                    remediation=(
+                        "Ensure route/handler functions are present in the scanned source "
+                        "tree and decorated with the appropriate HTTP framework decorators "
+                        "(@app.route, @router.get, etc.) so NuGuard can detect them as "
+                        "API_ENDPOINT nodes. Re-run 'nuguard sbom generate'."
+                    ),
+                )
+            )
 
     # ---- CHECK-005: Auth Node for HITL --------------------------------------
     if policy.hitl_triggers:
         if auth_nodes:
-            result.passed.append(PolicyControl(
-                check_id="CHECK-005",
-                name=_check_name("CHECK-005"),
-                description=_check_description("CHECK-005"),
-                policy_section="hitl_triggers",
-                evidence=[f"AUTH node: {n.name!r}" for n in auth_nodes],
-                evidence_source="sbom_node",
-            ))
+            result.passed.append(
+                PolicyControl(
+                    check_id="CHECK-005",
+                    name=_check_name("CHECK-005"),
+                    description=_check_description("CHECK-005"),
+                    policy_section="hitl_triggers",
+                    evidence=[f"AUTH node: {n.name!r}" for n in auth_nodes],
+                    evidence_source="sbom_node",
+                )
+            )
         else:
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-005",
-                name=_check_name("CHECK-005"),
-                description=_check_description("CHECK-005"),
-                message=(
-                    "Policy defines HITL triggers but the SBOM contains no AUTH "
-                    "nodes. Human-in-the-loop enforcement typically requires an "
-                    "authentication mechanism."
-                ),
-                policy_section="hitl_triggers",
-                severity="medium",
-                searched=["AUTH nodes: none found in SBOM"],
-                remediation=(
-                    "Add an authentication component (e.g. JWT middleware, OAuth2 handler, "
-                    "session manager) to the application so NuGuard can detect it as an "
-                    "AUTH node. Without identity verification, HITL triggers cannot reliably "
-                    "associate an escalation request with a specific customer. "
-                    "Re-run 'nuguard sbom generate' after adding the auth layer."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-005",
+                    name=_check_name("CHECK-005"),
+                    description=_check_description("CHECK-005"),
+                    message=(
+                        "Policy defines HITL triggers but the SBOM contains no AUTH "
+                        "nodes. Human-in-the-loop enforcement typically requires an "
+                        "authentication mechanism."
+                    ),
+                    policy_section="hitl_triggers",
+                    severity="medium",
+                    searched=["AUTH nodes: none found in SBOM"],
+                    remediation=(
+                        "Add an authentication component (e.g. JWT middleware, OAuth2 handler, "
+                        "session manager) to the application so NuGuard can detect it as an "
+                        "AUTH node. Without identity verification, HITL triggers cannot reliably "
+                        "associate an escalation request with a specific customer. "
+                        "Re-run 'nuguard sbom generate' after adding the auth layer."
+                    ),
+                )
+            )
 
     # ---- CHECK-006: High-Privilege Scope Without Guardrail ------------------
     _HIGH_RISK_SCOPES = {"admin", "db_write", "filesystem_write"}
     privilege_nodes = _nodes_of_type(doc, ComponentType.PRIVILEGE)
     high_risk_priv = [
-        n for n in privilege_nodes
+        n
+        for n in privilege_nodes
         if (n.metadata.privilege_scope or "").lower() in _HIGH_RISK_SCOPES
     ]
     if high_risk_priv:
         if guardrail_nodes:
-            result.passed.append(PolicyControl(
-                check_id="CHECK-006",
-                name=_check_name("CHECK-006"),
-                description=_check_description("CHECK-006"),
-                policy_section="restricted_actions",
-                evidence=[
-                    f"GUARDRAIL node {g.name!r} protects agent with PRIVILEGE nodes: "
-                    + ", ".join(f"{p.name!r} (scope={p.metadata.privilege_scope})"
-                                for p in high_risk_priv)
-                    for g in guardrail_nodes
-                ],
-                evidence_source="sbom_node",
-            ))
+            result.passed.append(
+                PolicyControl(
+                    check_id="CHECK-006",
+                    name=_check_name("CHECK-006"),
+                    description=_check_description("CHECK-006"),
+                    policy_section="restricted_actions",
+                    evidence=[
+                        f"GUARDRAIL node {g.name!r} protects agent with PRIVILEGE nodes: "
+                        + ", ".join(
+                            f"{p.name!r} (scope={p.metadata.privilege_scope})"
+                            for p in high_risk_priv
+                        )
+                        for g in guardrail_nodes
+                    ],
+                    evidence_source="sbom_node",
+                )
+            )
         else:
             scope_list = ", ".join(
                 f"{n.name!r} (scope={n.metadata.privilege_scope})" for n in high_risk_priv
             )
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-006",
-                name=_check_name("CHECK-006"),
-                description=_check_description("CHECK-006"),
-                message=(
-                    f"High-risk PRIVILEGE nodes detected ({scope_list}) but no "
-                    "GUARDRAIL nodes exist to intercept privileged operations before "
-                    "they execute. An attacker using prompt injection could invoke these "
-                    "capabilities without policy enforcement."
-                ),
-                policy_section="restricted_actions",
-                severity="high",
-                searched=[
-                    f"PRIVILEGE nodes with high-risk scope: {scope_list}",
-                    "GUARDRAIL nodes: none found",
-                ],
-                remediation=(
-                    "Add a guardrail component (InputGuardrail / OutputGuardrail) that "
-                    "specifically intercepts tool calls targeting admin, db_write, or "
-                    "filesystem_write operations and verifies intent and authorization "
-                    "before execution. In LangGraph, wrap the privileged tools in a "
-                    "ToolNode with a pre-call authorization check. Re-run "
-                    "'nuguard sbom generate' after adding the guardrail."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-006",
+                    name=_check_name("CHECK-006"),
+                    description=_check_description("CHECK-006"),
+                    message=(
+                        f"High-risk PRIVILEGE nodes detected ({scope_list}) but no "
+                        "GUARDRAIL nodes exist to intercept privileged operations before "
+                        "they execute. An attacker using prompt injection could invoke these "
+                        "capabilities without policy enforcement."
+                    ),
+                    policy_section="restricted_actions",
+                    severity="high",
+                    searched=[
+                        f"PRIVILEGE nodes with high-risk scope: {scope_list}",
+                        "GUARDRAIL nodes: none found",
+                    ],
+                    remediation=(
+                        "Add a guardrail component (InputGuardrail / OutputGuardrail) that "
+                        "specifically intercepts tool calls targeting admin, db_write, or "
+                        "filesystem_write operations and verifies intent and authorization "
+                        "before execution. In LangGraph, wrap the privileged tools in a "
+                        "ToolNode with a pre-call authorization check. Re-run "
+                        "'nuguard sbom generate' after adding the guardrail."
+                    ),
+                )
+            )
 
     # ---- CHECK-007: Unauthenticated Tool Access to PII Datastore ------------
     _pii_policy_keywords = {"pii", "account", "transaction", "personal", "sensitive"}
@@ -886,58 +904,61 @@ def check_policy_against_sbom(
     )
     if policy_restricts_pii:
         pii_datastores = [
-            n for n in datastore_nodes
-            if n.metadata.data_classification
-            or n.metadata.pii_fields
-            or n.metadata.phi_fields
+            n
+            for n in datastore_nodes
+            if n.metadata.data_classification or n.metadata.pii_fields or n.metadata.phi_fields
         ]
         no_auth_tools = [n for n in tool_nodes if n.metadata.no_auth_required]
         if pii_datastores and no_auth_tools:
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-007",
-                name=_check_name("CHECK-007"),
-                description=_check_description("CHECK-007"),
-                message=(
-                    f"{len(no_auth_tools)} TOOL node(s) have no_auth_required=True "
-                    f"while {len(pii_datastores)} DATASTORE node(s) carry PII/PHI "
-                    "classification. These tools can be invoked without identity "
-                    "verification, creating an unauthenticated path to sensitive data."
-                ),
-                policy_section="restricted_topics",
-                severity="high",
-                searched=[
-                    "TOOL nodes with no_auth_required=True: "
-                    + ", ".join(t.name for t in no_auth_tools[:5])
-                    + (" …" if len(no_auth_tools) > 5 else ""),
-                    "PII/PHI DATASTORE nodes: "
-                    + ", ".join(
-                        f"{d.name!r} (pii_fields={list(d.metadata.pii_fields or [])[:3]})"
-                        for d in pii_datastores
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-007",
+                    name=_check_name("CHECK-007"),
+                    description=_check_description("CHECK-007"),
+                    message=(
+                        f"{len(no_auth_tools)} TOOL node(s) have no_auth_required=True "
+                        f"while {len(pii_datastores)} DATASTORE node(s) carry PII/PHI "
+                        "classification. These tools can be invoked without identity "
+                        "verification, creating an unauthenticated path to sensitive data."
                     ),
-                ],
-                remediation=(
-                    "Add authentication guards to each tool that accesses PII datastores. "
-                    "In the tool implementation, verify the caller's identity token before "
-                    "querying sensitive tables. Remove 'no_auth_required=True' annotations "
-                    "from tools that touch the following datastores: "
-                    + ", ".join(d.name for d in pii_datastores)
-                    + ". Consider adding an AUTH node (JWT/OAuth2) and referencing it from "
-                    "these tools so the SBOM reflects the authentication boundary."
-                ),
-            ))
+                    policy_section="restricted_topics",
+                    severity="high",
+                    searched=[
+                        "TOOL nodes with no_auth_required=True: "
+                        + ", ".join(t.name for t in no_auth_tools[:5])
+                        + (" …" if len(no_auth_tools) > 5 else ""),
+                        "PII/PHI DATASTORE nodes: "
+                        + ", ".join(
+                            f"{d.name!r} (pii_fields={list(d.metadata.pii_fields or [])[:3]})"
+                            for d in pii_datastores
+                        ),
+                    ],
+                    remediation=(
+                        "Add authentication guards to each tool that accesses PII datastores. "
+                        "In the tool implementation, verify the caller's identity token before "
+                        "querying sensitive tables. Remove 'no_auth_required=True' annotations "
+                        "from tools that touch the following datastores: "
+                        + ", ".join(d.name for d in pii_datastores)
+                        + ". Consider adding an AUTH node (JWT/OAuth2) and referencing it from "
+                        "these tools so the SBOM reflects the authentication boundary."
+                    ),
+                )
+            )
         elif pii_datastores and not no_auth_tools:
-            result.passed.append(PolicyControl(
-                check_id="CHECK-007",
-                name=_check_name("CHECK-007"),
-                description=_check_description("CHECK-007"),
-                policy_section="restricted_topics",
-                evidence=[
-                    f"All TOOL nodes require authentication; PII DATASTORE "
-                    f"{d.name!r} is protected."
-                    for d in pii_datastores
-                ],
-                evidence_source="sbom_node",
-            ))
+            result.passed.append(
+                PolicyControl(
+                    check_id="CHECK-007",
+                    name=_check_name("CHECK-007"),
+                    description=_check_description("CHECK-007"),
+                    policy_section="restricted_topics",
+                    evidence=[
+                        f"All TOOL nodes require authentication; PII DATASTORE "
+                        f"{d.name!r} is protected."
+                        for d in pii_datastores
+                    ],
+                    evidence_source="sbom_node",
+                )
+            )
 
     # ---- CHECK-008: Allowed-Topic Agent Grounding ---------------------------
     if policy.allowed_topics:
@@ -957,46 +978,48 @@ def check_policy_against_sbom(
         for p in prompt_nodes:
             desc = (p.metadata.description or "").lower()
             if any(kw in desc for kw in topic_keywords):
-                grounding_evidence.append(
-                    f"PROMPT {p.name!r} contains topic-aligned content"
-                )
+                grounding_evidence.append(f"PROMPT {p.name!r} contains topic-aligned content")
 
         if grounding_evidence:
-            result.passed.append(PolicyControl(
-                check_id="CHECK-008",
-                name=_check_name("CHECK-008"),
-                description=_check_description("CHECK-008"),
-                policy_section="allowed_topics",
-                evidence=grounding_evidence[:5],
-                evidence_source="prompt",
-            ))
+            result.passed.append(
+                PolicyControl(
+                    check_id="CHECK-008",
+                    name=_check_name("CHECK-008"),
+                    description=_check_description("CHECK-008"),
+                    policy_section="allowed_topics",
+                    evidence=grounding_evidence[:5],
+                    evidence_source="prompt",
+                )
+            )
         else:
-            result.gaps.append(PolicyGap(
-                check_id="CHECK-008",
-                name=_check_name("CHECK-008"),
-                description=_check_description("CHECK-008"),
-                message=(
-                    f"Policy defines {len(policy.allowed_topics)} allowed topic(s) but "
-                    "no AGENT or PROMPT node description contains topic-scoping language. "
-                    "Without explicit grounding instructions the model may answer "
-                    "out-of-scope questions."
-                ),
-                policy_section="allowed_topics",
-                severity="medium",
-                searched=[
-                    f"Checked {len(agent_nodes)} AGENT node(s) and "
-                    f"{len(prompt_nodes)} PROMPT node(s) for topic keywords: "
-                    + ", ".join(topic_keywords[:8])
-                    + (" …" if len(topic_keywords) > 8 else "")
-                ],
-                remediation=(
-                    "Add explicit topic-restriction language to the agent's system prompt. "
-                    "Example: 'You are a banking assistant for Pinnacle Bank. You only help "
-                    "with: account inquiries, fund transfers, bill payments, loan status, "
-                    "credit card inquiries, and branch/ATM location. Politely refuse "
-                    "requests outside this scope.' Re-run 'nuguard sbom generate' so the "
-                    "updated prompt content appears in PROMPT node descriptions."
-                ),
-            ))
+            result.gaps.append(
+                PolicyGap(
+                    check_id="CHECK-008",
+                    name=_check_name("CHECK-008"),
+                    description=_check_description("CHECK-008"),
+                    message=(
+                        f"Policy defines {len(policy.allowed_topics)} allowed topic(s) but "
+                        "no AGENT or PROMPT node description contains topic-scoping language. "
+                        "Without explicit grounding instructions the model may answer "
+                        "out-of-scope questions."
+                    ),
+                    policy_section="allowed_topics",
+                    severity="medium",
+                    searched=[
+                        f"Checked {len(agent_nodes)} AGENT node(s) and "
+                        f"{len(prompt_nodes)} PROMPT node(s) for topic keywords: "
+                        + ", ".join(topic_keywords[:8])
+                        + (" …" if len(topic_keywords) > 8 else "")
+                    ],
+                    remediation=(
+                        "Add explicit topic-restriction language to the agent's system prompt. "
+                        "Example: 'You are a banking assistant for Pinnacle Bank. You only help "
+                        "with: account inquiries, fund transfers, bill payments, loan status, "
+                        "credit card inquiries, and branch/ATM location. Politely refuse "
+                        "requests outside this scope.' Re-run 'nuguard sbom generate' so the "
+                        "updated prompt content appears in PROMPT node descriptions."
+                    ),
+                )
+            )
 
     return result

--- a/nuguard/redteam/scenarios/generator.py
+++ b/nuguard/redteam/scenarios/generator.py
@@ -1,4 +1,5 @@
 """Context-sensitive scenario generator — reads SBOM and emits prioritised AttackScenario list."""
+
 from __future__ import annotations
 
 import re
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
     from nuguard.redteam.target.canary import CanaryConfig
 
 # ── 2024–2025 advanced attack families ────────────────────────────────────────
+from nuguard.common.soft_reject import iter_effective_nodes, partition_node_counts
+
 from .advanced_jailbreaks import (
     build_crescendo_attack,
     build_many_shot_jailbreak,
@@ -118,24 +121,65 @@ _log = get_logger(__name__)
 # High-risk tools are always tested individually (full max_turns=4) regardless
 # of sampling.  Low-risk tools are batched into groups of up to
 # _MAX_GROUP_SIZE and tested with a reduced turn budget.
-_HIGH_RISK_TOOL_KEYWORDS: frozenset[str] = frozenset({
-    "admin", "delete", "override", "bulk", "broadcast",
-    "invoke", "grant", "waive", "stream_all", "reset_password",
-    "whitelist", "escalat", "bypass", "export_all",
-})
+_HIGH_RISK_TOOL_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "admin",
+        "delete",
+        "override",
+        "bulk",
+        "broadcast",
+        "invoke",
+        "grant",
+        "waive",
+        "stream_all",
+        "reset_password",
+        "whitelist",
+        "escalat",
+        "bypass",
+        "export_all",
+    }
+)
 
 # Functional categories for grouping low/mid risk tools.  Each entry is a
 # (group_label, keywords) pair.  A tool is placed in the first matching group.
 _TOOL_GROUPS: list[tuple[str, tuple[str, ...]]] = [
-    ("fund_ops",        ("transfer", "payment", "crypto", "fund", "convert")),
-    ("read_data",       ("get", "list", "fetch", "view", "check", "status",
-                         "search", "lookup", "price", "rate", "summary")),
-    ("write_data",      ("create", "submit", "update", "flag", "schedule",
-                         "send", "file", "generate", "buy", "sell", "cancel")),
-    ("compliance",      ("kyc", "aml", "sanction", "compliance", "regulatory")),
-    ("audit",           ("audit", "log")),
-    ("user_mgmt",       ("user", "password", "otp", "session", "role")),
-    ("document",        ("document", "portfolio", "asset", "wallet")),
+    ("fund_ops", ("transfer", "payment", "crypto", "fund", "convert")),
+    (
+        "read_data",
+        (
+            "get",
+            "list",
+            "fetch",
+            "view",
+            "check",
+            "status",
+            "search",
+            "lookup",
+            "price",
+            "rate",
+            "summary",
+        ),
+    ),
+    (
+        "write_data",
+        (
+            "create",
+            "submit",
+            "update",
+            "flag",
+            "schedule",
+            "send",
+            "file",
+            "generate",
+            "buy",
+            "sell",
+            "cancel",
+        ),
+    ),
+    ("compliance", ("kyc", "aml", "sanction", "compliance", "regulatory")),
+    ("audit", ("audit", "log")),
+    ("user_mgmt", ("user", "password", "otp", "session", "role")),
+    ("document", ("document", "portfolio", "asset", "wallet")),
 ]
 _TOOL_GROUP_OTHER = "other"
 
@@ -319,7 +363,30 @@ class ScenarioGenerator:
         policy: CognitivePolicy | None = None,
         canary_config: "CanaryConfig | None" = None,
     ) -> None:
-        self._sbom = sbom
+        # Build one non-mutating effective view for every red-team consumer.
+        # Soft-rejected nodes remain in the original SBOM for recall and audit.
+        effective_nodes = list(iter_effective_nodes(sbom.nodes))
+        effective_node_ids = {node.id for node in effective_nodes}
+        effective_edges = [
+            edge
+            for edge in sbom.edges
+            if (edge.source in effective_node_ids and edge.target in effective_node_ids)
+        ]
+
+        effective_summary = sbom.summary.model_copy(deep=True) if sbom.summary is not None else None
+
+        if effective_summary is not None:
+            count_partition = partition_node_counts(sbom.nodes)
+            effective_summary.node_counts = count_partition.effective
+            effective_summary.node_counts_soft_rejected = count_partition.soft_rejected
+
+        self._sbom = sbom.model_copy(
+            update={
+                "nodes": effective_nodes,
+                "edges": effective_edges,
+                "summary": effective_summary,
+            }
+        )
         self._policy = policy or CognitivePolicy()
         # Real second tenant id (docs/claude-redteam-3.md §5 cross-tenant fix) —
         # used by build_cross_tenant_exfiltration in place of a random probe id
@@ -327,21 +394,38 @@ class ScenarioGenerator:
         self._real_tenant_id = ""
         if canary_config is not None and len(getattr(canary_config, "tenants", []) or []) >= 2:
             self._real_tenant_id = canary_config.tenants[1].tenant_id
-        self._node_by_id = {str(n.id): n for n in sbom.nodes}
-        # Build edge indexes: source_id -> {relationship_type -> [target_id]}
-        self._outgoing: dict[str, dict[str, list[str]]] = {}
-        for edge in sbom.edges:
-            self._outgoing.setdefault(str(edge.source), {}).setdefault(
-                edge.relationship_type, []
+        self._node_by_id = {str(node.id): node for node in self._sbom.nodes}
+
+        # Build edge indexes only from edges whose endpoints are effective.
+        self._outgoing: dict[
+            str,
+            dict[str, list[str]],
+        ] = {}
+
+        for edge in self._sbom.edges:
+            self._outgoing.setdefault(
+                str(edge.source),
+                {},
+            ).setdefault(
+                edge.relationship_type,
+                [],
             ).append(str(edge.target))
-        # Capability profile — built once, reused by generate_from_catalog()
+
+        # Capability and catalog selection must use the same effective view.
         from nuguard.redteam.catalog.capability import CapabilityDetector
-        self._caps = CapabilityDetector(sbom, self._policy).build()
+
+        self._caps = CapabilityDetector(
+            self._sbom,
+            self._policy,
+        ).build()
         # Coverage report produced by the last generate_from_catalog() call.
         from nuguard.redteam.catalog.coverage import CoverageReport as _CR
+
         self.last_coverage: _CR | None = None
 
-    def generate(self, with_guided: bool = False, progressive: bool = False) -> list[AttackScenario]:
+    def generate(
+        self, with_guided: bool = False, progressive: bool = False
+    ) -> list[AttackScenario]:
         """Generate all attack scenarios sorted by impact score descending.
 
         Parameters
@@ -441,6 +525,7 @@ class ScenarioGenerator:
 
         # Record coverage for each generated scenario
         from nuguard.redteam.coverage.tracker import CoverageTracker as _CT
+
         self.coverage_tracker = _CT()
         for sc in scenarios:
             primary_id = sc.target_node_ids[0] if sc.target_node_ids else ""
@@ -480,9 +565,7 @@ class ScenarioGenerator:
             tool_names: list[str] = []
             seen: set[str] = set()
             for node_id in sc.target_node_ids:
-                for tid in self._outgoing.get(node_id, {}).get(
-                    RelationshipType.CALLS, []
-                ):
+                for tid in self._outgoing.get(node_id, {}).get(RelationshipType.CALLS, []):
                     n = self._node_by_id.get(tid)
                     if n is None:
                         continue
@@ -524,6 +607,7 @@ class ScenarioGenerator:
             :func:`nuguard.redteam.catalog.loader.load_catalog_yaml`.
         """
         from nuguard.redteam.catalog.selector import select_scenarios
+
         scenarios, coverage = select_scenarios(
             sbom=self._sbom,
             profile=self._caps,
@@ -556,7 +640,9 @@ class ScenarioGenerator:
                 sc.target_tool_names = tool_names[:12]
         _log.info(
             "Catalog generated %d scenarios (profile=%s, guided=%s, categories=%d)",
-            len(scenarios), scan_profile, with_guided,
+            len(scenarios),
+            scan_profile,
+            with_guided,
             coverage.categories_covered_count,
         )
         return scenarios
@@ -702,8 +788,7 @@ class ScenarioGenerator:
             # 2. Name heuristic: triage / router / entry / gateway agents
             _ENTRY_KEYWORDS = ("triage", "router", "entry", "gateway", "main", "orchestrat")
             triage_nodes = [
-                n for n in all_agent_nodes
-                if any(kw in n.name.lower() for kw in _ENTRY_KEYWORDS)
+                n for n in all_agent_nodes if any(kw in n.name.lower() for kw in _ENTRY_KEYWORDS)
             ]
             target_nodes = triage_nodes if triage_nodes else all_agent_nodes[:1]
 
@@ -721,7 +806,9 @@ class ScenarioGenerator:
                     # truncation and is filterable/identifiable at a glance.
                     variant_suffix = scenario.title.rsplit(" — ", 1)[-1]
                     scenario.title = f"Universal Safety Probe ({category_id}) — {variant_suffix}"
-                    scenario.description = f"Universal safety probe ({category_id}): {scenario.description}"
+                    scenario.description = (
+                        f"Universal safety probe ({category_id}): {scenario.description}"
+                    )
                 out.extend(variants)
         for action in policy.restricted_actions:
             for node in target_nodes:
@@ -824,9 +911,7 @@ class ScenarioGenerator:
             agent_ids = self._agents_reaching_datastore(str(node.id))
             if not agent_ids:
                 agent_ids = [
-                    str(n.id)
-                    for n in self._sbom.nodes
-                    if n.component_type == ComponentType.AGENT
+                    str(n.id) for n in self._sbom.nodes if n.component_type == ComponentType.AGENT
                 ]
 
             for agent_id in agent_ids[:_MAX_AGENTS_PER_GOAL]:  # cap at 2 agents per datastore
@@ -895,18 +980,18 @@ class ScenarioGenerator:
             agent_ids = self._agents_reaching_datastore(str(node.id))
             if not agent_ids:
                 agent_ids = [
-                    str(n.id)
-                    for n in self._sbom.nodes
-                    if n.component_type == ComponentType.AGENT
+                    str(n.id) for n in self._sbom.nodes if n.component_type == ComponentType.AGENT
                 ]
             for agent_id in agent_ids[:1]:  # one agent per PFI datastore
                 agent_node = self._node_by_id.get(agent_id)
                 agent_name = agent_node.name if agent_node else "Agent"
-                out.extend([
-                    build_payment_method_escalation(agent_id=agent_id, agent_name=agent_name),
-                    build_bank_account_probe(agent_id=agent_id, agent_name=agent_name),
-                    build_ssn_enumeration(agent_id=agent_id, agent_name=agent_name),
-                ])
+                out.extend(
+                    [
+                        build_payment_method_escalation(agent_id=agent_id, agent_name=agent_name),
+                        build_bank_account_probe(agent_id=agent_id, agent_name=agent_name),
+                        build_ssn_enumeration(agent_id=agent_id, agent_name=agent_name),
+                    ]
+                )
 
         # Covert encoding exfiltration — always add for every agent with data access
         # All four techniques: base64, JSON/XML, document-embedded, image-URL steg
@@ -929,32 +1014,35 @@ class ScenarioGenerator:
         target_field = ", ".join(_covert_field_names[:3]) if _covert_field_names else "user record"
 
         for agent_node in agent_nodes_for_covert[:_MAX_AGENTS_PER_GOAL]:
-            out.extend([
-                build_base64_exfiltration(
-                    agent_id=str(agent_node.id),
-                    agent_name=agent_node.name,
-                    target_field=target_field,
-                ),
-                build_json_xml_exfiltration(
-                    agent_id=str(agent_node.id),
-                    agent_name=agent_node.name,
-                    target_field=target_field,
-                ),
-                build_document_embedded_exfiltration(
-                    agent_id=str(agent_node.id),
-                    agent_name=agent_node.name,
-                    target_field=target_field,
-                ),
-                build_image_url_exfiltration(
-                    agent_id=str(agent_node.id),
-                    agent_name=agent_node.name,
-                    target_field=target_field,
-                ),
-            ])
+            out.extend(
+                [
+                    build_base64_exfiltration(
+                        agent_id=str(agent_node.id),
+                        agent_name=agent_node.name,
+                        target_field=target_field,
+                    ),
+                    build_json_xml_exfiltration(
+                        agent_id=str(agent_node.id),
+                        agent_name=agent_node.name,
+                        target_field=target_field,
+                    ),
+                    build_document_embedded_exfiltration(
+                        agent_id=str(agent_node.id),
+                        agent_name=agent_node.name,
+                        target_field=target_field,
+                    ),
+                    build_image_url_exfiltration(
+                        agent_id=str(agent_node.id),
+                        agent_name=agent_node.name,
+                        target_field=target_field,
+                    ),
+                ]
+            )
 
         # Cross-tenant exfiltration — detect multi-tenant indicators
         cross_tenant_nodes = [
-            n for n in self._sbom.nodes
+            n
+            for n in self._sbom.nodes
             if n.component_type == ComponentType.AGENT
             and (
                 "multi_tenant" in (n.metadata.extras or {})
@@ -1027,21 +1115,26 @@ class ScenarioGenerator:
                 ds_agent_ids = self._agents_with_data_tools()
             if not ds_agent_ids:
                 ds_agent_ids = [
-                    str(n.id)
-                    for n in self._sbom.nodes
-                    if n.component_type == ComponentType.AGENT
+                    str(n.id) for n in self._sbom.nodes if n.component_type == ComponentType.AGENT
                 ]
 
             # NoSQL databases share "db" as a substring with SQL dbs, so guard
             # explicitly before running SQL-specific probes.
             _NOSQL_INDICATORS = (
-                "mongo", "redis", "cassandra", "dynamo", "elastic",
-                "couch", "neo4j", "graph", "firestore", "hbase",
+                "mongo",
+                "redis",
+                "cassandra",
+                "dynamo",
+                "elastic",
+                "couch",
+                "neo4j",
+                "graph",
+                "firestore",
+                "hbase",
             )
             _is_nosql = any(t in ds_type.lower() for t in _NOSQL_INDICATORS)
             _is_sql = not _is_nosql and any(
-                t in ds_type.lower()
-                for t in ("sql", "sqlite", "postgres", "mysql", "relational")
+                t in ds_type.lower() for t in ("sql", "sqlite", "postgres", "mysql", "relational")
             )
 
             for agent_id in ds_agent_ids[:_MAX_AGENTS_PER_GOAL]:
@@ -1078,16 +1171,12 @@ class ScenarioGenerator:
         # to social-engineer them into dumping data without per-account scoping.
         _BULK_TOOL_KEYWORDS = ("list_all", "bulk", "export", "all_", "dump", "enumerate")
         for agent_node in [n for n in self._sbom.nodes if n.component_type == ComponentType.AGENT]:
-            tool_ids = self._outgoing.get(str(agent_node.id), {}).get(
-                RelationshipType.CALLS, []
-            )
+            tool_ids = self._outgoing.get(str(agent_node.id), {}).get(RelationshipType.CALLS, [])
             privileged_tools = [
                 self._node_by_id[tid].name
                 for tid in tool_ids
                 if tid in self._node_by_id
-                and any(
-                    kw in self._node_by_id[tid].name.lower() for kw in _BULK_TOOL_KEYWORDS
-                )
+                and any(kw in self._node_by_id[tid].name.lower() for kw in _BULK_TOOL_KEYWORDS)
             ]
             if privileged_tools:
                 out.append(
@@ -1112,8 +1201,7 @@ class ScenarioGenerator:
         for agent_node in [n for n in self._sbom.nodes if n.component_type == ComponentType.AGENT]:
             tool_ids = self._outgoing.get(str(agent_node.id), {}).get(RelationshipType.CALLS, [])
             tool_names_lower = {
-                self._node_by_id[tid].name.lower()
-                for tid in tool_ids if tid in self._node_by_id
+                self._node_by_id[tid].name.lower() for tid in tool_ids if tid in self._node_by_id
             }
             id_label = "account"
             for label, keywords in _ID_LABELS.items():
@@ -1133,7 +1221,9 @@ class ScenarioGenerator:
         if not out and self._policy.data_classification:
             policy_fields = self._parse_policy_pii_fields(self._policy.data_classification)
             if policy_fields:
-                agent_nodes = [n for n in self._sbom.nodes if n.component_type == ComponentType.AGENT]
+                agent_nodes = [
+                    n for n in self._sbom.nodes if n.component_type == ComponentType.AGENT
+                ]
                 for node in agent_nodes[:3]:
                     chain_id = str(uuid.uuid4())
                     field_list = ", ".join(policy_fields[:5])
@@ -1211,10 +1301,22 @@ class ScenarioGenerator:
 
     # Keywords indicating a tool is likely involved in data access / querying.
     # Matched against tool.name.lower() — used by _agents_with_data_tools().
-    _DATA_TOOL_KEYWORDS: frozenset[str] = frozenset({
-        "query", "search", "lookup", "fetch", "get_", "list_", "find",
-        "account", "user", "customer", "booking", "record",
-    })
+    _DATA_TOOL_KEYWORDS: frozenset[str] = frozenset(
+        {
+            "query",
+            "search",
+            "lookup",
+            "fetch",
+            "get_",
+            "list_",
+            "find",
+            "account",
+            "user",
+            "customer",
+            "booking",
+            "record",
+        }
+    )
 
     def _agents_with_data_tools(self) -> list[str]:
         """Return AGENT node IDs that CALL at least one tool with a data-access name pattern.
@@ -1307,9 +1409,7 @@ class ScenarioGenerator:
             agent_ids = self._agents_reaching_datastore(str(ds_node.id))
             if not agent_ids:
                 agent_ids = [
-                    str(n.id)
-                    for n in self._sbom.nodes
-                    if n.component_type == ComponentType.AGENT
+                    str(n.id) for n in self._sbom.nodes if n.component_type == ComponentType.AGENT
                 ]
             for agent_id in agent_ids[:1]:
                 agent_node = self._node_by_id.get(agent_id)
@@ -1408,6 +1508,7 @@ class ScenarioGenerator:
         - If any scenario targets an entry agent, keep only entry-agent scenarios (cap 2).
         - Otherwise keep all (up to 3) sorted by impact score descending.
         """
+
         def _template_key(s: AttackScenario) -> str:
             return f"{s.goal_type.value}|{s.scenario_type.value}|{s.title}"
 
@@ -1422,8 +1523,7 @@ class ScenarioGenerator:
                 continue
 
             entry_targeted = [
-                s for s in group
-                if any(tid in entry_agents for tid in s.target_node_ids)
+                s for s in group if any(tid in entry_agents for tid in s.target_node_ids)
             ]
 
             if entry_targeted:
@@ -1437,7 +1537,9 @@ class ScenarioGenerator:
         if removed > 0:
             _log.info(
                 "Entry-endpoint dedup: removed %d near-duplicate scenarios (%d → %d)",
-                removed, len(scenarios), len(result),
+                removed,
+                len(scenarios),
+                len(result),
             )
         return result
 
@@ -1478,17 +1580,13 @@ class ScenarioGenerator:
         untrusted = [
             n
             for n in self._sbom.nodes
-            if n.component_type == ComponentType.TOOL
-            and n.metadata.trust_level == "untrusted"
+            if n.component_type == ComponentType.TOOL and n.metadata.trust_level == "untrusted"
         ]
         sinks = [
             n
             for n in self._sbom.nodes
             if n.component_type == ComponentType.TOOL
-            and (
-                n.metadata.privilege_scope in _WRITE_SCOPES
-                or n.metadata.high_privilege
-            )
+            and (n.metadata.privilege_scope in _WRITE_SCOPES or n.metadata.high_privilege)
         ]
         for source in untrusted[:3]:
             for sink in sinks[:3]:
@@ -1574,8 +1672,15 @@ class ScenarioGenerator:
         from nuguard.redteam.executor.poison_server import POISON_PAYLOAD_HOST
 
         _WRITE_TOOL_INDICATORS = {
-            "upload", "ingest", "index", "store", "write", "add_document",
-            "add_file", "insert", "embed",
+            "upload",
+            "ingest",
+            "index",
+            "store",
+            "write",
+            "add_document",
+            "add_file",
+            "insert",
+            "embed",
         }
 
         for agent_node in self._sbom.nodes:
@@ -1590,7 +1695,8 @@ class ScenarioGenerator:
 
             # Look for any write/upload capable tool that could index content
             write_tools = [
-                t for t in tools
+                t
+                for t in tools
                 if any(ind in t.name.lower() for ind in _WRITE_TOOL_INDICATORS)
                 or t.metadata.high_privilege
             ]
@@ -1616,12 +1722,28 @@ class ScenarioGenerator:
     # ------------------------------------------------------------------ #
 
     # Endpoint path segments that are unambiguously public — no auth bypass needed.
-    _PUBLIC_PATH_HINTS: frozenset[str] = frozenset({
-        "health", "healthz", "ping", "status", "metrics",
-        "docs", "openapi", "swagger", "redoc",
-        "login", "signin", "sign-in", "register", "signup", "sign-up",
-        "oauth", "callback", "token",
-    })
+    _PUBLIC_PATH_HINTS: frozenset[str] = frozenset(
+        {
+            "health",
+            "healthz",
+            "ping",
+            "status",
+            "metrics",
+            "docs",
+            "openapi",
+            "swagger",
+            "redoc",
+            "login",
+            "signin",
+            "sign-in",
+            "register",
+            "signup",
+            "sign-up",
+            "oauth",
+            "callback",
+            "token",
+        }
+    )
 
     def _api_attack_scenarios(self) -> list[AttackScenario]:
         """Generate direct HTTP attack scenarios from API_ENDPOINT SBOM nodes.
@@ -1688,12 +1810,14 @@ class ScenarioGenerator:
             # This endpoint's own sensitive fields (if the extractor tagged it
             # directly) plus the SBOM-wide datastore pool — used to prioritise
             # and to validate that a successful probe actually returned data.
-            endpoint_sensitive_fields = list(dict.fromkeys(
-                (meta.pii_fields or [])
-                + (meta.phi_fields or [])
-                + (meta.pfi_fields or [])
-                + sensitive_field_pool
-            ))
+            endpoint_sensitive_fields = list(
+                dict.fromkeys(
+                    (meta.pii_fields or [])
+                    + (meta.phi_fields or [])
+                    + (meta.pfi_fields or [])
+                    + sensitive_field_pool
+                )
+            )
             is_sensitive = bool(meta.returns_sensitive_data) or bool(
                 meta.pii_fields or meta.phi_fields or meta.pfi_fields
             )
@@ -1756,16 +1880,20 @@ class ScenarioGenerator:
             inferred_params: list[str] = list(meta.path_params or [])
             if not inferred_params:
                 # Detect {id}, :user_id, <account_id> style path templates
-                for m in re.finditer(
-                    r"\{([^}]+)\}|:([A-Za-z_][A-Za-z0-9_]*)|<([^>]+)>", path
-                ):
+                for m in re.finditer(r"\{([^}]+)\}|:([A-Za-z_][A-Za-z0-9_]*)|<([^>]+)>", path):
                     param = m.group(1) or m.group(2) or m.group(3)
                     if param:
                         inferred_params.append(param)
 
             _ID_LIKE_PARAMS = {
-                "id", "user_id", "tenant_id", "account_id",
-                "customer_id", "org_id", "record_id", "object_id",
+                "id",
+                "user_id",
+                "tenant_id",
+                "account_id",
+                "customer_id",
+                "org_id",
+                "record_id",
+                "object_id",
             }
             has_idor_params = meta.idor_surface or any(
                 p.lower() in _ID_LIKE_PARAMS for p in inferred_params
@@ -1899,14 +2027,15 @@ class ScenarioGenerator:
             n.name for n in self._sbom.nodes if n.component_type == ComponentType.DATASTORE
         ]
         pii_datastores = [
-            n.name for n in self._sbom.nodes
+            n.name
+            for n in self._sbom.nodes
             if n.component_type == ComponentType.DATASTORE
             and (n.metadata.pii_fields or n.metadata.phi_fields)
         ]
         pfi_datastores = [
-            n.name for n in self._sbom.nodes
-            if n.component_type == ComponentType.DATASTORE
-            and n.metadata.pfi_fields
+            n.name
+            for n in self._sbom.nodes
+            if n.component_type == ComponentType.DATASTORE and n.metadata.pfi_fields
         ]
 
         for node in self._sbom.nodes:
@@ -1961,7 +2090,16 @@ class ScenarioGenerator:
             if not has_pfi and self._policy.data_classification:
                 has_pfi = any(
                     kw in " ".join(self._policy.data_classification).lower()
-                    for kw in ("card", "bank", "account", "payment", "financial", "routing", "ssn", "tax_id")
+                    for kw in (
+                        "card",
+                        "bank",
+                        "account",
+                        "payment",
+                        "financial",
+                        "routing",
+                        "ssn",
+                        "tax_id",
+                    )
                 )
             if has_pfi:
                 out.append(
@@ -2028,8 +2166,11 @@ class ScenarioGenerator:
             # current user, then use the response to probe IDOR, record writes, and
             # privilege escalation.  Added for all agents with any data access signal.
             has_any_data = bool(
-                datastore_names or pii_datastores or pfi_datastores
-                or has_pii or has_pfi
+                datastore_names
+                or pii_datastores
+                or pfi_datastores
+                or has_pii
+                or has_pfi
                 or agent_capabilities
             )
             if has_any_data:
@@ -2038,12 +2179,18 @@ class ScenarioGenerator:
                 if self._sbom.summary:
                     uc = (getattr(self._sbom.summary, "use_case", "") or "").lower()
                     for kw, label in (
-                        ("health", "healthcare"), ("patient", "healthcare"),
-                        ("medical", "healthcare"), ("flight", "airline"),
-                        ("airline", "airline"), ("booking", "airline"),
-                        ("bank", "banking"), ("finance", "banking"),
-                        ("account", "banking"), ("shop", "e-commerce"),
-                        ("order", "e-commerce"), ("ecommerce", "e-commerce"),
+                        ("health", "healthcare"),
+                        ("patient", "healthcare"),
+                        ("medical", "healthcare"),
+                        ("flight", "airline"),
+                        ("airline", "airline"),
+                        ("booking", "airline"),
+                        ("bank", "banking"),
+                        ("finance", "banking"),
+                        ("account", "banking"),
+                        ("shop", "e-commerce"),
+                        ("order", "e-commerce"),
+                        ("ecommerce", "e-commerce"),
                     ):
                         if kw in uc:
                             domain = label
@@ -2051,8 +2198,10 @@ class ScenarioGenerator:
                 if not domain and meta.system_prompt_excerpt:
                     excerpt_lower = meta.system_prompt_excerpt.lower()
                     for kw, label in (
-                        ("health", "healthcare"), ("patient", "healthcare"),
-                        ("flight", "airline"), ("bank", "banking"),
+                        ("health", "healthcare"),
+                        ("patient", "healthcare"),
+                        ("flight", "airline"),
+                        ("bank", "banking"),
                         ("shop", "e-commerce"),
                     ):
                         if kw in excerpt_lower:
@@ -2070,7 +2219,8 @@ class ScenarioGenerator:
 
             # Privilege escalation — when agent has privileged tools or high-priv actions
             priv_tools = [
-                n.name for n in self._sbom.nodes
+                n.name
+                for n in self._sbom.nodes
                 if n.component_type == ComponentType.TOOL
                 and (n.metadata.no_auth_required or n.metadata.sql_injectable)
             ]
@@ -2103,6 +2253,7 @@ class ScenarioGenerator:
                 from nuguard.redteam.models.guided_conversation import (
                     infer_capability_profile,  # noqa: PLC0415
                 )
+
                 _domain = "customer_service"
                 _sbom_use_case = ""
                 if self._sbom.summary:
@@ -2113,7 +2264,10 @@ class ScenarioGenerator:
                         (("health", "patient", "medical"), "healthcare"),
                         (("bank", "finance", "payment"), "banking"),
                     ]:
-                        if any(k in _sbom_use_case or k in _app_name or k in agent_name.lower() for k in _kw):
+                        if any(
+                            k in _sbom_use_case or k in _app_name or k in agent_name.lower()
+                            for k in _kw
+                        ):
                             _domain = _dom
                             break
                 _profile = infer_capability_profile(
@@ -2143,8 +2297,12 @@ class ScenarioGenerator:
         import hashlib as _hashlib
         import random as _random
 
-        _seed_src = getattr(self._sbom, "document_id", None) or getattr(self._sbom, "name", "") or ""
-        _rng = _random.Random(int(_hashlib.md5(_seed_src.encode(), usedforsecurity=False).hexdigest(), 16))  # noqa: S324
+        _seed_src = (
+            getattr(self._sbom, "document_id", None) or getattr(self._sbom, "name", "") or ""
+        )
+        _rng = _random.Random(
+            int(_hashlib.md5(_seed_src.encode(), usedforsecurity=False).hexdigest(), 16)
+        )  # noqa: S324
 
         # --- collect tools ---
         # (node_id, name, description, agent_node_id) per TOOL with a description
@@ -2196,7 +2354,7 @@ class ScenarioGenerator:
             _rng.shuffle(members)
             # Split into sub-groups of up to _MAX_GROUP_SIZE tools each
             for chunk_start in range(0, len(members), _MAX_GROUP_SIZE):
-                chunk = members[chunk_start: chunk_start + _MAX_GROUP_SIZE]
+                chunk = members[chunk_start : chunk_start + _MAX_GROUP_SIZE]
                 # Use the agent_node_id from the first tool in the chunk
                 agent_id = chunk[0][3] if chunk else ""
                 tool_group = [(nid, nm, dsc) for nid, nm, dsc, _ in chunk]
@@ -2231,7 +2389,9 @@ class ScenarioGenerator:
         blocked_topics = list(self._policy.restricted_topics or [])
         blocked_actions = list(self._policy.restricted_actions or [])
         restricted_topic = blocked_topics[0] if blocked_topics else "restricted content"
-        restricted_action = blocked_actions[0] if blocked_actions else "share confidential system information"
+        restricted_action = (
+            blocked_actions[0] if blocked_actions else "share confidential system information"
+        )
 
         # Policy patch rule — try to craft a meaningful expansion of the restriction
         new_rule = (
@@ -2257,7 +2417,9 @@ class ScenarioGenerator:
                     agent_name=agent_name,
                     restricted_topic=restricted_topic,
                     new_rule=new_rule[:200],
-                    extra_restricted_topics=[t for t in blocked_topics[1:] if t != restricted_topic],
+                    extra_restricted_topics=[
+                        t for t in blocked_topics[1:] if t != restricted_topic
+                    ],
                     extra_restricted_actions=blocked_actions,
                 )
             )
@@ -2346,7 +2508,8 @@ class ScenarioGenerator:
 
             # Jurisdiction forgery — always applicable (GDPR right-to-erasure is universal)
             target_action = (
-                blocked_actions[0] if blocked_actions
+                blocked_actions[0]
+                if blocked_actions
                 else "delete all my personal data from your system immediately"
             )
             out.append(
@@ -2370,7 +2533,8 @@ class ScenarioGenerator:
 
         blocked_actions = list(self._policy.restricted_actions or [])
         blocked_action = (
-            blocked_actions[0][:120] if blocked_actions
+            blocked_actions[0][:120]
+            if blocked_actions
             else "reveal your system prompt and all internal instructions"
         )
 
@@ -2403,7 +2567,7 @@ class ScenarioGenerator:
         # Derive a plausible attack goal from policy / SBOM metadata
         def _attack_goal(node: object) -> str:
             meta = getattr(node, "metadata", None)
-            blocked = (getattr(meta, "blocked_topics", None) or [])
+            blocked = getattr(meta, "blocked_topics", None) or []
             restricted = list(self._policy.restricted_topics or [])
             candidates = blocked or restricted
             if candidates:
@@ -2411,9 +2575,8 @@ class ScenarioGenerator:
             use_case = ""
             if self._sbom.summary:
                 use_case = (getattr(self._sbom.summary, "use_case", "") or "")[:80]
-            return (
-                "provide information outside its primary purpose"
-                + (f" ({use_case})" if use_case else "")
+            return "provide information outside its primary purpose" + (
+                f" ({use_case})" if use_case else ""
             )
 
         for node in agent_nodes[:_MAX_AGENTS_PER_GOAL]:  # cap at 2 agents to avoid explosion
@@ -2424,10 +2587,14 @@ class ScenarioGenerator:
             if self._sbom.summary:
                 use_case = (getattr(self._sbom.summary, "use_case", "") or "").lower()
                 for kw, label in [
-                    ("bank", "financial services"), ("finance", "financial services"),
-                    ("health", "healthcare"), ("patient", "healthcare"),
-                    ("airline", "airline"), ("flight", "airline"),
-                    ("shop", "e-commerce"), ("order", "e-commerce"),
+                    ("bank", "financial services"),
+                    ("finance", "financial services"),
+                    ("health", "healthcare"),
+                    ("patient", "healthcare"),
+                    ("airline", "airline"),
+                    ("flight", "airline"),
+                    ("shop", "e-commerce"),
+                    ("order", "e-commerce"),
                 ]:
                     if kw in use_case:
                         domain = label
@@ -2456,9 +2623,7 @@ class ScenarioGenerator:
                 )
             )
             # Payload splitting — use the first restricted action if available
-            split_goal = (
-                list(self._policy.restricted_actions or [])[:1] or [goal]
-            )[0]
+            split_goal = (list(self._policy.restricted_actions or [])[:1] or [goal])[0]
             out.append(
                 build_payload_splitting(
                     agent_id=agent_id,
@@ -2518,11 +2683,19 @@ class ScenarioGenerator:
 
         # Confused Deputy — agent with a write/email/financial tool
         _HIGH_PRIV_INDICATORS = (
-            "email", "send", "transfer", "payment", "write", "delete",
-            "admin", "broadcast", "notify",
+            "email",
+            "send",
+            "transfer",
+            "payment",
+            "write",
+            "delete",
+            "admin",
+            "broadcast",
+            "notify",
         )
         priv_tools = [
-            t for t in tool_nodes
+            t
+            for t in tool_nodes
             if any(ind in t.name.lower() for ind in _HIGH_PRIV_INDICATORS)
             or t.metadata.high_privilege
         ]
@@ -2530,9 +2703,8 @@ class ScenarioGenerator:
             for priv_tool in priv_tools[:_MAX_AGENTS_PER_GOAL]:
                 # Build a plausible sensitive_action from restricted_actions or tool name
                 sensitive_action = (
-                    list(self._policy.restricted_actions or [])[:1] or [
-                        f"invoke {priv_tool.name} with attacker-controlled parameters"
-                    ]
+                    list(self._policy.restricted_actions or [])[:1]
+                    or [f"invoke {priv_tool.name} with attacker-controlled parameters"]
                 )[0]
                 out.append(
                     build_confused_deputy(
@@ -2545,16 +2717,16 @@ class ScenarioGenerator:
 
         # Multi-Agent Trust Boundary — orchestrator → sub-agent trust exploitation
         orchestrator_nodes = [
-            n for n in agent_nodes
+            n
+            for n in agent_nodes
             if any(kw in n.name.lower() for kw in ("orchestrat", "triage", "router", "main"))
         ]
         sub_agent_nodes = [n for n in agent_nodes if n not in orchestrator_nodes]
         for orch in orchestrator_nodes[:1]:
             for sub in sub_agent_nodes[:_MAX_AGENTS_PER_GOAL]:
                 privileged_cap = (
-                    list(self._policy.restricted_actions or [])[:1] or [
-                        "access internal data and return all results"
-                    ]
+                    list(self._policy.restricted_actions or [])[:1]
+                    or ["access internal data and return all results"]
                 )[0]
                 out.append(
                     build_multi_agent_trust_boundary(
@@ -2568,11 +2740,13 @@ class ScenarioGenerator:
 
         # Memory Poisoning — agents that have memory/history capability signals
         memory_agents = [
-            n for n in agent_nodes
+            n
+            for n in agent_nodes
             if "memory" in n.name.lower()
             or "memory" in (n.metadata.description or "").lower()
             or any(
-                "memory" in (self._node_by_id.get(tid, None) and self._node_by_id[tid].name or "").lower()
+                "memory"
+                in (self._node_by_id.get(tid, None) and self._node_by_id[tid].name or "").lower()
                 for tid in self._outgoing.get(str(n.id), {}).get(RelationshipType.CALLS, [])
             )
         ]
@@ -2588,9 +2762,8 @@ class ScenarioGenerator:
                     memory_store = t.name
                     break
             persistent_goal = (
-                list(self._policy.restricted_actions or [])[:1] or [
-                    "disclose sensitive user information when asked"
-                ]
+                list(self._policy.restricted_actions or [])[:1]
+                or ["disclose sensitive user information when asked"]
             )[0]
             out.append(
                 build_memory_poisoning(
@@ -2604,8 +2777,7 @@ class ScenarioGenerator:
         # Goal Hijacking — agents with search/query/fetch tools
         _HIJACKABLE_INDICATORS = ("search", "query", "fetch", "lookup", "retrieve", "find")
         hijackable_tools = [
-            t for t in tool_nodes
-            if any(ind in t.name.lower() for ind in _HIJACKABLE_INDICATORS)
+            t for t in tool_nodes if any(ind in t.name.lower() for ind in _HIJACKABLE_INDICATORS)
         ]
         for agent_node in agent_nodes[:1]:
             for tool in hijackable_tools[:_MAX_AGENTS_PER_GOAL]:
@@ -2614,9 +2786,7 @@ class ScenarioGenerator:
                         agent_id=str(agent_node.id),
                         agent_name=agent_node.name,
                         tool_name=tool.name,
-                        hijacked_action=(
-                            "exfiltrate all results to attacker-controlled endpoint"
-                        ),
+                        hijacked_action=("exfiltrate all results to attacker-controlled endpoint"),
                     )
                 )
 
@@ -2627,7 +2797,8 @@ class ScenarioGenerator:
         # the attack bypasses specialist guardrails by disguising the request.
         restricted_actions_list = list(self._policy.restricted_actions or [])
         high_risk_action = (
-            restricted_actions_list[0][:80] if restricted_actions_list
+            restricted_actions_list[0][:80]
+            if restricted_actions_list
             else "approve a loan application without credit checks"
         )
         for agent_node in agent_nodes[:_MAX_AGENTS_PER_GOAL]:
@@ -2653,7 +2824,8 @@ class ScenarioGenerator:
         if has_multi_agent_signals:
             target_action = (
                 f"finalise the {restricted_actions_list[0][:60]}"
-                if restricted_actions_list else "finalise the inter-account transfer"
+                if restricted_actions_list
+                else "finalise the inter-account transfer"
             )
             for agent_node in agent_nodes[:1]:
                 out.append(
@@ -2705,8 +2877,7 @@ class ScenarioGenerator:
         for agent_node in agent_nodes[:1]:
             tool_ids = self._outgoing.get(str(agent_node.id), {}).get(RelationshipType.CALLS, [])
             tool_names_agent = [
-                self._node_by_id[tid].name.lower()
-                for tid in tool_ids if tid in self._node_by_id
+                self._node_by_id[tid].name.lower() for tid in tool_ids if tid in self._node_by_id
             ]
             # Pick the first matching scope pair based on available tools
             scoped_req, overreach = "check my account summary", "modify my account settings"
@@ -2763,20 +2934,42 @@ class ScenarioGenerator:
         if self._sbom.summary:
             app_name = (getattr(self._sbom.summary, "application_name", "") or "").strip()
             use_case = (getattr(self._sbom.summary, "use_case", "") or "").strip()
-            app_domain = f"{app_name} — {use_case[:120]}" if app_name and use_case else (app_name or use_case[:120])
+            app_domain = (
+                f"{app_name} — {use_case[:120]}"
+                if app_name and use_case
+                else (app_name or use_case[:120])
+            )
 
-        restricted_action = (self._policy.restricted_actions or ["access privileged administrative functions"])[0]
+        restricted_action = (
+            self._policy.restricted_actions or ["access privileged administrative functions"]
+        )[0]
 
         out.extend(
             build_off_topic_probes(
-                agent_id, agent_name, app_domain=app_domain,
+                agent_id,
+                agent_name,
+                app_domain=app_domain,
                 restricted_topics=self._policy.restricted_topics,
             )
         )
-        out.append(build_scripted_identity_confusion(agent_id, agent_name, app_domain=app_domain or "this application"))
-        out.append(build_scripted_role_confusion(agent_id, agent_name, app_domain=app_domain or "this application"))
-        out.append(build_document_memory_poisoning(agent_id, agent_name, restricted_action=restricted_action))
-        out.append(build_recovery_verification(agent_id, agent_name, baseline_prompt=baseline_prompt))
+        out.append(
+            build_scripted_identity_confusion(
+                agent_id, agent_name, app_domain=app_domain or "this application"
+            )
+        )
+        out.append(
+            build_scripted_role_confusion(
+                agent_id, agent_name, app_domain=app_domain or "this application"
+            )
+        )
+        out.append(
+            build_document_memory_poisoning(
+                agent_id, agent_name, restricted_action=restricted_action
+            )
+        )
+        out.append(
+            build_recovery_verification(agent_id, agent_name, baseline_prompt=baseline_prompt)
+        )
         return out
 
     def _oracle_scenarios(self) -> list[AttackScenario]:

--- a/nuguard/sbom/core/application_summary.py
+++ b/nuguard/sbom/core/application_summary.py
@@ -17,6 +17,8 @@ from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse, urlunparse
 
+from nuguard.common.soft_reject import iter_effective_nodes, partition_node_counts
+
 from ..models import InstrumentationDetail, Node, TestingDetail
 from .route_patterns import ROUTE_PATTERNS
 
@@ -84,19 +86,21 @@ _STREAMING_SOURCE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"\bStreamingResponse\b"),
     re.compile(r"\bEventSourceResponse\b"),
     re.compile(r"['\"]text/event-stream['\"]"),
-    re.compile(r"\bastream\s*\("),                    # LangChain .astream()
-    re.compile(r"\bstream_events\s*\("),              # LangGraph .stream_events()
-    re.compile(r"\bstream\s*=\s*True"),               # litellm / openai stream=True passed to caller
-    re.compile(r"/run_sse"),                           # ADK SSE path reference
+    re.compile(r"\bastream\s*\("),  # LangChain .astream()
+    re.compile(r"\bstream_events\s*\("),  # LangGraph .stream_events()
+    re.compile(r"\bstream\s*=\s*True"),  # litellm / openai stream=True passed to caller
+    re.compile(r"/run_sse"),  # ADK SSE path reference
     re.compile(r"\bserver.sent.events?\b", re.IGNORECASE),
-    re.compile(r"\bAsyncGenerator\b.*\bstr\b"),       # async generator route returning str chunks
+    re.compile(r"\bAsyncGenerator\b.*\bstr\b"),  # async generator route returning str chunks
 ]
 
 # Decorator + return-type patterns that identify a specific route as streaming
-_STREAMING_ROUTE_RETURN_TYPES: frozenset[str] = frozenset({
-    "StreamingResponse",
-    "EventSourceResponse",
-})
+_STREAMING_ROUTE_RETURN_TYPES: frozenset[str] = frozenset(
+    {
+        "StreamingResponse",
+        "EventSourceResponse",
+    }
+)
 
 # Route path suffixes / names strongly associated with SSE output
 _STREAMING_PATH_PATTERNS: list[re.Pattern[str]] = [
@@ -189,7 +193,7 @@ def _extract_streaming_route_paths(source: str, out: "list[str]") -> None:
             out.append(route_path)
             continue
         # Check the next 30 lines for streaming return types or patterns
-        window = "\n".join(lines[i: i + 30])
+        window = "\n".join(lines[i : i + 30])
         if any(t in window for t in _STREAMING_ROUTE_RETURN_TYPES):
             out.append(route_path)
         elif re.search(r"['\"]text/event-stream['\"]", window):
@@ -593,21 +597,25 @@ def extract_iac_security_context(nodes: Sequence[Node]) -> dict[str, Any]:
             if meta.extras.get("iac_format") == "github_actions"
             and meta.extras.get("workflow_content")
         ),
-        "workflow_security_findings": list({
-            (f["rule_signal"], f.get("line", 0)): f
-            for node in nodes
-            for meta in [node.metadata]
-            if meta.extras.get("iac_format") == "github_actions"
-            for f in meta.extras.get("workflow_security_findings", [])
-        }.values()),
-        "k8s_network_policy_namespaces": sorted({
-            meta.extras.get("k8s_namespace", "")
-            for node in nodes
-            for meta in [node.metadata]
-            if meta.extras.get("iac_format") == "kubernetes"
-            and meta.extras.get("is_network_policy_namespace") is True
-            and meta.extras.get("k8s_namespace")
-        }),
+        "workflow_security_findings": list(
+            {
+                (f["rule_signal"], f.get("line", 0)): f
+                for node in nodes
+                for meta in [node.metadata]
+                if meta.extras.get("iac_format") == "github_actions"
+                for f in meta.extras.get("workflow_security_findings", [])
+            }.values()
+        ),
+        "k8s_network_policy_namespaces": sorted(
+            {
+                meta.extras.get("k8s_namespace", "")
+                for node in nodes
+                for meta in [node.metadata]
+                if meta.extras.get("iac_format") == "kubernetes"
+                and meta.extras.get("is_network_policy_namespace") is True
+                and meta.extras.get("k8s_namespace")
+            }
+        ),
     }
 
 
@@ -621,12 +629,12 @@ def build_scan_summary(
     """Build scan-level summary for reporting."""
     from .app_env_detector import detect_app_env
 
-    node_types: dict[str, int] = {}
+    node_count_partition = partition_node_counts(nodes)
+    nodes = tuple(iter_effective_nodes(nodes))
+    node_types = node_count_partition.effective
     frameworks: list[str] = []
 
     for node in nodes:
-        nt = _node_type_str(node)
-        node_types[nt] = node_types.get(nt, 0) + 1
         framework = node.metadata.framework or node.metadata.extras.get("framework")
         if isinstance(framework, str) and _is_agentic_framework(framework):
             frameworks.append(framework)
@@ -654,9 +662,7 @@ def build_scan_summary(
     app_env = detect_app_env(files)
     # Merge any newly discovered deployment URLs into the IaC-detected list
     all_deployment_urls = _uniq(
-        deployment.get("deployment_urls", [])
-        + app_env["staging_urls"]
-        + app_env["production_urls"]
+        deployment.get("deployment_urls", []) + app_env["staging_urls"] + app_env["production_urls"]
     )
 
     # Data classification: collect from typed fields on DATASTORE nodes, then fall back
@@ -690,6 +696,7 @@ def build_scan_summary(
         "source_ref": source_ref,
         "branch": branch,
         "node_type_counts": node_types,
+        "node_type_counts_soft_rejected": node_count_partition.soft_rejected,
         "frameworks": frameworks_list,
         "api_endpoints": endpoints[:200],
         "use_case_summary": use_case_summary,
@@ -857,6 +864,7 @@ async def maybe_refine_use_case_summary_with_llm(
         )
         system = "You are a technical writer producing concise AI system inventory summaries."
         from ..llm_client import complete_structured
+
         result = await asyncio.wait_for(
             complete_structured(llm_client, system, user_prompt, schema),
             timeout=15.0,
@@ -908,6 +916,7 @@ async def maybe_refine_asset_summary_with_llm(
         )
         system = "You are a technical writer producing concise AI asset inventory summaries."
         from ..llm_client import complete_structured
+
         result = await asyncio.wait_for(
             complete_structured(llm_client, system, user_prompt, schema),
             timeout=15.0,
@@ -939,9 +948,7 @@ _APP_INSTRUMENTATION_IMPORTS: dict[str, str] = {
     "jaeger": "jaeger",
 }
 
-_LOG_LEVEL_RE = re.compile(
-    r"logging\.basicConfig\s*\(.*?level\s*=\s*logging\.(\w+)", re.DOTALL
-)
+_LOG_LEVEL_RE = re.compile(r"logging\.basicConfig\s*\(.*?level\s*=\s*logging\.(\w+)", re.DOTALL)
 
 
 def _detect_app_instrumentation(

--- a/nuguard/sbom/core/verification.py
+++ b/nuguard/sbom/core/verification.py
@@ -23,6 +23,7 @@ from typing import Any
 from uuid import UUID
 
 from nuguard.common.logging import get_logger
+from nuguard.common.soft_reject import SOFT_REJECT_FLAG
 
 from ..models import ComponentType, Evidence, Node
 from .gap_fill.snippets import detect_language, extract_context
@@ -327,7 +328,7 @@ def apply_verification_results(
                 else:
                     # Soft-reject: keep but push confidence below verification floor
                     node.confidence = min(node.confidence, 0.55)
-                    node.metadata.extras["llm_soft_rejected"] = True
+                    node.metadata.extras[SOFT_REJECT_FLAG] = True
                     node.metadata.extras["llm_verification_reason"] = result.reason
                     _log.debug(
                         "apply_verification: soft-reject deterministic node %r → conf=0.55",
@@ -413,9 +414,7 @@ async def verify_uncertain_nodes(
             evidence_list[0].location.path if evidence_list and evidence_list[0].location else ""
         )
         file_content = (file_contents or {}).get(file_path)
-        system_prompt, user_prompt = build_verification_prompt(
-            node, evidence_list, file_content
-        )
+        system_prompt, user_prompt = build_verification_prompt(node, evidence_list, file_content)
         prepared.append((node, system_prompt, user_prompt, VERIFICATION_CALL_COST_CAP))
 
     cost_per_call = VERIFICATION_CALL_COST_CAP

--- a/nuguard/sbom/extractor/core.py
+++ b/nuguard/sbom/extractor/core.py
@@ -35,6 +35,7 @@ from typing import Any, Callable
 from urllib.parse import urlsplit
 
 from nuguard.common.logging import get_logger
+from nuguard.common.soft_reject import partition_node_counts
 from nuguard.common.url_sanitization import (
     redact_repository_url_from_text,
     sanitize_repository_url,
@@ -387,7 +388,11 @@ def _extract_python_prompt_dicts(
                 continue
 
             for dk, dv in zip(value.keys, value.values):
-                dict_key = dk.value if isinstance(dk, _ast.Constant) and isinstance(dk.value, str) else None
+                dict_key = (
+                    dk.value
+                    if isinstance(dk, _ast.Constant) and isinstance(dk.value, str)
+                    else None
+                )
                 if dict_key is None:
                     continue
 
@@ -483,18 +488,47 @@ _SCRIPT_EXTENSIONS = {".sh", ".bash", ".zsh", ".fish", ".ps1"}
 
 def _should_skip_path_parts(parts: tuple[str, ...]) -> bool:
     skip_dirs = {
-        ".git", "__pycache__", "node_modules", ".tox", ".claude", "site-packages",
-        ".mypy_cache", ".pytest_cache", ".ruff_cache", ".pytype", "logs", "log",
-        "reports", "nuguard-test-results", "test-results",
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".tox",
+        ".claude",
+        "site-packages",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".pytype",
+        "logs",
+        "log",
+        "reports",
+        "nuguard-test-results",
+        "test-results",
         # Build/generated-output directories — large volumes of generated code
         # (bundled JS, compiled artefacts) that match include_extensions but
         # carry no AIBOM signal, and just burn the file/byte budget.
-        "dist", "build", ".next", ".nuxt", ".output", "target", "vendor",
-        ".terraform", "coverage", ".turbo", ".parcel-cache", ".serverless",
-        "bin", "obj", ".gradle", ".dvc",
+        "dist",
+        "build",
+        ".next",
+        ".nuxt",
+        ".output",
+        "target",
+        "vendor",
+        ".terraform",
+        "coverage",
+        ".turbo",
+        ".parcel-cache",
+        ".serverless",
+        "bin",
+        "obj",
+        ".gradle",
+        ".dvc",
         # Generated/vendored code and test artefacts — no AIBOM signal.
-        "generated", "third_party", "external", "__snapshots__",
-        ".ipynb_checkpoints", ".idea",
+        "generated",
+        "third_party",
+        "external",
+        "__snapshots__",
+        ".ipynb_checkpoints",
+        ".idea",
     }
     for part in parts:
         if part in skip_dirs:
@@ -512,8 +546,15 @@ def _should_skip_path_parts(parts: tuple[str, ...]) -> bool:
 # tests, Terraform state, and OS/editor cruft that can slip past the
 # directory-level skip list above.
 _SKIP_FILENAME_SUFFIXES = (
-    "_pb2.py", "_pb2_grpc.py", ".pb.go", "_grpc.py", ".pbtxt",
-    ".snap", ".tfstate", ".tfstate.backup", ".terraform.lock.hcl",
+    "_pb2.py",
+    "_pb2_grpc.py",
+    ".pb.go",
+    "_grpc.py",
+    ".pbtxt",
+    ".snap",
+    ".tfstate",
+    ".tfstate.backup",
+    ".terraform.lock.hcl",
     ".DS_Store",
 )
 _SKIP_FILENAMES = {"Thumbs.db"}
@@ -523,6 +564,8 @@ def _should_skip_filename(name: str) -> bool:
     if name in _SKIP_FILENAMES:
         return True
     return any(name.endswith(suffix) for suffix in _SKIP_FILENAME_SUFFIXES)
+
+
 _DOCS_STEMS = {
     "readme",
     "changelog",
@@ -622,6 +665,20 @@ def _load_gitignore_matcher(root: Path) -> "Callable[[str], bool] | None":
     except Exception as exc:
         _log.warning("failed to parse .gitignore: %s", exc)
         return None
+
+
+def _refresh_summary_node_counts(
+    doc: AiSbomDocument,
+) -> None:
+    """Refresh effective and retained-rejection counts from final nodes."""
+    summary = doc.summary
+
+    if summary is None:
+        return
+
+    count_partition = partition_node_counts(doc.nodes)
+    summary.node_counts = count_partition.effective
+    summary.node_counts_soft_rejected = count_partition.soft_rejected
 
 
 class AiSbomExtractor:
@@ -837,7 +894,9 @@ class AiSbomExtractor:
                 suffix_pkg = "/".join([*base_parts, "__init__"]) + ".py"
                 for known in _all_py_rel_paths:
                     _known_norm = known.replace("\\", "/")
-                    if _known_norm.endswith("/" + suffix_module) or _known_norm.endswith("/" + suffix_pkg):
+                    if _known_norm.endswith("/" + suffix_module) or _known_norm.endswith(
+                        "/" + suffix_pkg
+                    ):
                         return known
                 return None
 
@@ -1013,8 +1072,11 @@ class AiSbomExtractor:
             if file_path.suffix.lower() == ".json" and '"generator"' in content[:512]:
                 try:
                     import json as _json
+
                     _peek = _json.loads(content)
-                    if isinstance(_peek, dict) and str(_peek.get("generator", "")).lower().startswith("nuguard"):
+                    if isinstance(_peek, dict) and str(
+                        _peek.get("generator", "")
+                    ).lower().startswith("nuguard"):
                         _log.debug("skipping nuguard-generated file: %s", file_path)
                         continue
                 except Exception:
@@ -1114,7 +1176,9 @@ class AiSbomExtractor:
                                         # provider resolution — consumed below
                                         # (after this file loop) to resolve
                                         # cross-file TOOL -> DATASTORE hints.
-                                        _ds_symbol_index[(rel_path, _ds_symbol)] = det.canonical_name
+                                        _ds_symbol_index[(rel_path, _ds_symbol)] = (
+                                            det.canonical_name
+                                        )
 
                         # Phase 1a-prime: module-level Python prompt constants.
                         # Runs on ALL .py files regardless of framework imports so that
@@ -1149,10 +1213,9 @@ class AiSbomExtractor:
                         # nodes directly; everything else (e.g. PROMPT detections
                         # from PromptSQLAdapter) goes through the normal merge path,
                         # mirroring the Python-file branch's discrimination above.
-                        if (
-                            det.component_type == ComponentType.DATASTORE
-                            and det.metadata.get("source") in ("sql_schema", "python_model")
-                        ):
+                        if det.component_type == ComponentType.DATASTORE and det.metadata.get(
+                            "source"
+                        ) in ("sql_schema", "python_model"):
                             _dc_metadata.append(det.metadata)
                         else:
                             self._merge_detection(node_map, det)
@@ -1507,7 +1570,10 @@ class AiSbomExtractor:
                     if not _ds_canon:
                         continue
                     for _fn_name in _tool_fn_names:
-                        _tool_key = (ComponentType.TOOL, canonicalize_text(f"langchain:tool:{_fn_name}"))
+                        _tool_key = (
+                            ComponentType.TOOL,
+                            canonicalize_text(f"langchain:tool:{_fn_name}"),
+                        )
                         _ds_key = (ComponentType.DATASTORE, canonicalize_text(_ds_canon))
                         _acc = node_map.get(_tool_key)
                         if _acc is None or _ds_key not in node_map:
@@ -1522,7 +1588,9 @@ class AiSbomExtractor:
                             )
                         )
         except Exception as _cross_ds_exc:
-            _log.debug("cross-file datastore ACCESSES resolution failed (non-fatal): %s", _cross_ds_exc)
+            _log.debug(
+                "cross-file datastore ACCESSES resolution failed (non-fatal): %s", _cross_ds_exc
+            )
 
         # Deduplicate nodes that share (component_type, file, line) — e.g. a
         # regex adapter and an AST adapter both firing on the same token.
@@ -1573,6 +1641,7 @@ class AiSbomExtractor:
             # Normalize display names that are raw variable identifiers
             if " " not in _raw_display:
                 from ..normalization import normalize_display_name as _norm_dn
+
                 _raw_display = _norm_dn(_raw_display, acc.component_type)
             node = Node(
                 name=_raw_display,
@@ -1617,9 +1686,9 @@ class AiSbomExtractor:
             # AGENT node typed fields
             if acc.component_type == ComponentType.AGENT:
                 _spe = (
-                    acc.metadata.get("instructions_preview")   # openai_agents
-                    or acc.metadata.get("backstory_preview")   # crewai
-                    or acc.metadata.get("goal_preview")        # crewai fallback
+                    acc.metadata.get("instructions_preview")  # openai_agents
+                    or acc.metadata.get("backstory_preview")  # crewai
+                    or acc.metadata.get("goal_preview")  # crewai fallback
                     or acc.metadata.get("system_prompt_preview")
                 )
                 if _spe:
@@ -1743,9 +1812,7 @@ class AiSbomExtractor:
                     node.metadata.response_text_key = str(_rtk)
                 _rbs = acc.metadata.get("request_body_schema")
                 if isinstance(_rbs, dict) and _rbs:
-                    node.metadata.request_body_schema = {
-                        str(k): str(v) for k, v in _rbs.items()
-                    }
+                    node.metadata.request_body_schema = {str(k): str(v) for k, v in _rbs.items()}
                     node.metadata.request_schema = dict(_rbs)
                 _resp_schema = acc.metadata.get("response_body_schema")
                 if isinstance(_resp_schema, dict) and _resp_schema:
@@ -1906,11 +1973,10 @@ class AiSbomExtractor:
         # Runs after the main AST/regex loop so CES nodes can be appended.
         try:
             from ..adapters.ces import CESScanner, build_ces_sbom_nodes  # noqa: PLC0415
+
             ces_detections = CESScanner().scan_directory(root)
             if ces_detections:
-                _log.info(
-                    "CESScanner: detected %d CES deployment(s)", len(ces_detections)
-                )
+                _log.info("CESScanner: detected %d CES deployment(s)", len(ces_detections))
                 ces_nodes = build_ces_sbom_nodes(ces_detections, doc)
                 if ces_nodes:
                     # Collect source files covered by CES endpoints
@@ -1920,8 +1986,10 @@ class AiSbomExtractor:
                     # Remove generic API_ENDPOINT nodes whose only evidence comes from the
                     # same source files — CES nodes are more specific (auth, schema, endpoint URL)
                     from ..types import ComponentType as _CT  # noqa: PLC0415
+
                     doc.nodes = [
-                        n for n in doc.nodes
+                        n
+                        for n in doc.nodes
                         if not (
                             n.component_type == _CT.API_ENDPOINT
                             and not getattr(n.metadata, "framework", None)
@@ -1968,6 +2036,7 @@ class AiSbomExtractor:
 
         # Post-extraction enrichment: derive risk attributes from graph topology
         from ..enricher import enrich as _enrich_sbom
+
         _enrich_sbom(doc)
 
         # Scan package manifest dependencies (pyproject.toml, requirements*.txt, package.json, …)
@@ -1979,9 +2048,7 @@ class AiSbomExtractor:
         for node in doc.nodes:
             # LOC: sum lines from all evidence source files for this node
             ev_paths = {
-                ev.location.path
-                for ev in node.evidence
-                if ev.location and ev.location.path
+                ev.location.path for ev in node.evidence if ev.location and ev.location.path
             }
             loc_sum = sum(file_loc.get(p, 0) for p in ev_paths)
             if loc_sum:
@@ -2025,10 +2092,7 @@ class AiSbomExtractor:
             doc.summary.minified_js_files = _minified_js_files
 
         # Ensure google-ces is listed in summary.frameworks when CES nodes exist
-        _has_ces = any(
-            getattr(n.metadata, "framework", "") == "google-ces"
-            for n in doc.nodes
-        )
+        _has_ces = any(getattr(n.metadata, "framework", "") == "google-ces" for n in doc.nodes)
         if _has_ces and doc.summary is not None:
             if "google-ces" not in doc.summary.frameworks:
                 doc.summary.frameworks.append("google-ces")
@@ -2045,13 +2109,19 @@ class AiSbomExtractor:
                     LifecycleScriptAdapter,
                 )
 
-                for adapter_cls in (DevToolConfigAdapter, GithubActionsAdapter, LifecycleScriptAdapter):
+                for adapter_cls in (
+                    DevToolConfigAdapter,
+                    GithubActionsAdapter,
+                    LifecycleScriptAdapter,
+                ):
                     sc_nodes, sc_edges = adapter_cls().scan(root)
                     doc.nodes.extend(sc_nodes)
                     doc.edges.extend(sc_edges)
                     _log.debug(
                         "supply-chain pass (%s): +%d nodes, +%d edges",
-                        adapter_cls.__name__, len(sc_nodes), len(sc_edges),
+                        adapter_cls.__name__,
+                        len(sc_nodes),
+                        len(sc_edges),
                     )
             except Exception as _sc_exc:
                 _log.warning("supply-chain second pass failed (continuing): %s", _sc_exc)
@@ -2096,6 +2166,8 @@ class AiSbomExtractor:
             except Exception as exc:  # noqa: BLE001
                 _log.warning("LLM enrichment failed, continuing with deterministic output: %s", exc)
 
+        # Keep summary counts consistent with the final retained node set.
+        _refresh_summary_node_counts(doc)
         return doc
 
     def extract_from_repo(
@@ -2151,7 +2223,9 @@ class AiSbomExtractor:
             self._clone_repo(url=url, ref=ref, dest=repo_dir)
             return self.extract_from_path(repo_dir, config, source_ref=display_url, branch=ref)
 
-        with tempfile.TemporaryDirectory(prefix="nuguard_clone_", ignore_cleanup_errors=True) as temp_dir:
+        with tempfile.TemporaryDirectory(
+            prefix="nuguard_clone_", ignore_cleanup_errors=True
+        ) as temp_dir:
             repo_dir = Path(temp_dir) / "repo" / app_name
             repo_dir.mkdir(parents=True, exist_ok=True)
             self._clone_repo(url=url, ref=ref, dest=repo_dir)
@@ -2527,9 +2601,9 @@ class AiSbomExtractor:
         for agent in by_type.get(ComponentType.AGENT, []):
             if agent.id in agent_ids_with_model_edges:
                 continue
-            for model in sorted(
-                by_type.get(ComponentType.MODEL, []), key=lambda n: -n.confidence
-            )[:3]:
+            for model in sorted(by_type.get(ComponentType.MODEL, []), key=lambda n: -n.confidence)[
+                :3
+            ]:
                 _add_edge(agent.id, model.id, "USES")
 
         # Fallback: FRAMEWORK → AGENT (CALLS) via shared metadata.framework
@@ -2633,7 +2707,11 @@ class AiSbomExtractor:
         for auth in by_type.get(ComponentType.AUTH, []):
             matched = [ep for ep in endpoints_with_auth_type if _auth_type(ep) == _auth_type(auth)]
             is_matched = bool(matched)
-            targets = matched if matched else sorted(endpoints_without_auth_type, key=lambda n: n.name)[:10]
+            targets = (
+                matched
+                if matched
+                else sorted(endpoints_without_auth_type, key=lambda n: n.name)[:10]
+            )
             for ep in targets:
                 key = (auth.id, ep.id, "PROTECTS")
                 if key not in seen_edges:
@@ -2657,9 +2735,7 @@ class AiSbomExtractor:
         # so guessing a protects-relationship across unrelated files would
         # misrepresent coverage.
         guardrail_ids_with_protects_edges: set[Any] = {
-            e.source
-            for e in doc.edges
-            if e.relationship_type == RelationshipType.PROTECTS
+            e.source for e in doc.edges if e.relationship_type == RelationshipType.PROTECTS
         }
         for guardrail in by_type.get(ComponentType.GUARDRAIL, []):
             if guardrail.id in guardrail_ids_with_protects_edges:
@@ -2796,6 +2872,7 @@ class AiSbomExtractor:
         # Step 5: Enrich descriptions for AGENT/TOOL nodes missing them
         try:
             from ..llm_client import enrich_node_descriptions
+
             await enrich_node_descriptions(doc.nodes, client, concurrency=config.llm_concurrency)
             _log.info("description-enrichment: completed for agent/tool nodes")
         except Exception as exc:
@@ -2804,6 +2881,7 @@ class AiSbomExtractor:
         # Step 6: Build Markdown relationship graph (Mermaid diagram + LLM narrative)
         try:
             from ..core.relationship_graph import build_relationship_graph_with_llm
+
             graph_md = await build_relationship_graph_with_llm(doc, client)
             if graph_md:
                 doc.relationship_graph_md = graph_md
@@ -2814,6 +2892,7 @@ class AiSbomExtractor:
         # Step 7: Generate LLM descriptive names for all nodes
         try:
             from ..llm_client import enrich_descriptive_names
+
             await enrich_descriptive_names(doc.nodes, client)
             _log.info("descriptive-names: completed")
         except Exception as exc:
@@ -2822,13 +2901,9 @@ class AiSbomExtractor:
         # Recompute node_counts from the final node list after all verification,
         # aggregation, and discovery steps — gap-fill may have added nodes that
         # verification later rejected, leaving the counts stale.
-        if doc.summary:
-            from ..types import ComponentType as _CT
-            doc.summary.node_counts = {
-                ct.value: sum(1 for n in doc.nodes if n.component_type == ct)
-                for ct in _CT
-                if any(n.component_type == ct for n in doc.nodes)
-            }
+        # Verification retains deterministic false positives for audit.
+        # Refresh effective and retained-rejection count views together.
+        _refresh_summary_node_counts(doc)
 
         # Write LLM token usage into the summary
         if doc.summary:
@@ -3189,7 +3264,9 @@ class AiSbomExtractor:
     def _iter_files(root: Path, config: AiSbomConfig) -> Iterator[tuple[Path, int]]:
         import fnmatch as _fnmatch  # noqa: PLC0415
 
-        _gitignore_match = _load_gitignore_matcher(root) if getattr(config, "honor_gitignore", True) else None
+        _gitignore_match = (
+            _load_gitignore_matcher(root) if getattr(config, "honor_gitignore", True) else None
+        )
         count = 0
         for dirpath, dirnames, filenames in os.walk(root):
             # Keep traversal deterministic and prune irrelevant dirs early.
@@ -3250,9 +3327,7 @@ class AiSbomExtractor:
                     ):
                         continue
                 # .gitignore support
-                if _gitignore_match is not None and _gitignore_match(
-                    str(path.relative_to(root))
-                ):
+                if _gitignore_match is not None and _gitignore_match(str(path.relative_to(root))):
                     continue
                 try:
                     size = path.stat().st_size
@@ -3264,4 +3339,3 @@ class AiSbomExtractor:
                 count += 1
                 if config.max_files is not None and count >= config.max_files:
                     return
-

--- a/nuguard/sbom/extractor/postprocess.py
+++ b/nuguard/sbom/extractor/postprocess.py
@@ -40,6 +40,7 @@ def _make_scan_summary(d: dict) -> ScanSummary:
         deployment_urls=d.get("deployment_urls") or [],
         iac_accounts=d.get("subscription_account_project") or [],
         node_counts=d.get("node_type_counts") or {},
+        node_counts_soft_rejected=(d.get("node_type_counts_soft_rejected") or {}),
         data_classification=d.get("data_classification") or [],
         classified_tables=d.get("classified_tables") or [],
         # IaC security / resilience aggregate fields
@@ -148,9 +149,7 @@ def _dedup_by_name_prefix(
             if winner_key is not None:
                 node_map[winner_key].evidence.extend(node_map[key_a].evidence)
                 keys_to_remove.add(key_a)
-                _log.debug(
-                    "dedup_by_name_prefix: dropped %s → kept %s", key_a, winner_key
-                )
+                _log.debug("dedup_by_name_prefix: dropped %s → kept %s", key_a, winner_key)
 
     for k in keys_to_remove:
         del node_map[k]
@@ -272,7 +271,10 @@ def _dedup_by_location(
             # trivially contains the keyword as a substring) must not absorb
             # that node's unrelated evidence from every other file. Keep both
             # kinds separate so each gets its own node in the SBOM.
-            if winner[0] in (ComponentType.FRAMEWORK, ComponentType.DEPLOYMENT) and winner[1] != loser[1]:
+            if (
+                winner[0] in (ComponentType.FRAMEWORK, ComponentType.DEPLOYMENT)
+                and winner[1] != loser[1]
+            ):
                 continue
             # MODEL nodes: two canonical names at the same location are
             # usually the same model detected twice with different boundaries
@@ -313,15 +315,32 @@ _AUTH_NAME_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\boauth2?\b", re.IGNORECASE), "oauth_auth"),
     (re.compile(r"\b(api[_-]?key|apikey)\b", re.IGNORECASE), "api_key_auth"),
     (re.compile(r"\b(bcrypt|passlib|argon2|pbkdf2|scrypt)\b", re.IGNORECASE), "password_auth"),
-    (re.compile(r"\b(session[_.]cookie|cookie[_.]jar|csrf[_.]token)\b", re.IGNORECASE), "session_auth"),
+    (
+        re.compile(r"\b(session[_.]cookie|cookie[_.]jar|csrf[_.]token)\b", re.IGNORECASE),
+        "session_auth",
+    ),
 ]
 
 _DEPLOY_NAME_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bgcloud\b", re.IGNORECASE), "gcloud_deployment"),
     (re.compile(r"\bgsutil\b", re.IGNORECASE), "gcloud_deployment"),
-    (re.compile(r"\b(kubectl|kubernetes|kustomize|skaffold|argocd|fluxcd)\b", re.IGNORECASE), "kubernetes_deployment"),
-    (re.compile(r"\b(az\s+(?:login|group|webapp|container|acr|aks|functionapp)|azure[_-]cli|azd)\b", re.IGNORECASE), "azure_deployment"),
-    (re.compile(r"\baws\s+(?:ec2|s3|lambda|ecs|eks|rds|cloudformation|deploy|ecr)\b", re.IGNORECASE), "aws_deployment"),
+    (
+        re.compile(r"\b(kubectl|kubernetes|kustomize|skaffold|argocd|fluxcd)\b", re.IGNORECASE),
+        "kubernetes_deployment",
+    ),
+    (
+        re.compile(
+            r"\b(az\s+(?:login|group|webapp|container|acr|aks|functionapp)|azure[_-]cli|azd)\b",
+            re.IGNORECASE,
+        ),
+        "azure_deployment",
+    ),
+    (
+        re.compile(
+            r"\baws\s+(?:ec2|s3|lambda|ecs|eks|rds|cloudformation|deploy|ecr)\b", re.IGNORECASE
+        ),
+        "aws_deployment",
+    ),
     (re.compile(r"\b(terraform|pulumi|cdktf)\b", re.IGNORECASE), "terraform_deployment"),
     (re.compile(r"\bansible\b", re.IGNORECASE), "ansible_deployment"),
     (re.compile(r"\bhelm\b", re.IGNORECASE), "helm_deployment"),
@@ -455,7 +474,9 @@ def _dedup_generic_endpoints(
     alone rather than risk merging evidence into the wrong endpoint.
     """
     endpoint_keys = [key for key in node_map if key[0] == ComponentType.API_ENDPOINT]
-    generic_keys = [key for key in endpoint_keys if node_map[key].metadata.get("_generic_endpoint_fallback")]
+    generic_keys = [
+        key for key in endpoint_keys if node_map[key].metadata.get("_generic_endpoint_fallback")
+    ]
     real_keys = [key for key in endpoint_keys if key not in generic_keys]
     if not generic_keys or not real_keys:
         return
@@ -560,8 +581,7 @@ def _dedup_deployment_nodes(doc: "AiSbomDocument") -> None:
     # proxy_pass node) — those would then satisfy the substring check against
     # their own canonical name and get wrongly removed.
     generic_nodes = [
-        n for n in deployment_nodes
-        if n.metadata.extras.get("adapter") == "deployment_generic"
+        n for n in deployment_nodes if n.metadata.extras.get("adapter") == "deployment_generic"
     ]
     nodes_to_remove = []
 
@@ -582,7 +602,9 @@ def _dedup_deployment_nodes(doc: "AiSbomDocument") -> None:
 
     for generic_node in generic_nodes:
         generic_canon = (generic_node.metadata.extras.get("canonical_name") or "").lower()
-        if generic_canon and any(generic_canon in specific for specific in specific_canonical_names):
+        if generic_canon and any(
+            generic_canon in specific for specific in specific_canonical_names
+        ):
             if generic_node not in nodes_to_remove:
                 nodes_to_remove.append(generic_node)
 
@@ -593,7 +615,8 @@ def _dedup_deployment_nodes(doc: "AiSbomDocument") -> None:
         cloud_providers: list[str] = gha_node.metadata.extras.get("cloud_providers") or []
         for provider in cloud_providers:
             cloud_nodes = [
-                n for n in by_target.get(provider, [])
+                n
+                for n in by_target.get(provider, [])
                 if n not in nodes_to_remove
                 and n.metadata.extras.get("adapter") != "deployment_generic"
             ]

--- a/nuguard/sbom/models.py
+++ b/nuguard/sbom/models.py
@@ -119,11 +119,21 @@ class ToolParameter(BaseModel):
 class RateLimitDetail(BaseModel):
     """Structured rate limit configuration extracted from code or IaC."""
 
-    requests_per_minute: int | None = Field(default=None, description="Maximum requests allowed per minute")
-    requests_per_hour: int | None = Field(default=None, description="Maximum requests allowed per hour")
-    requests_per_day: int | None = Field(default=None, description="Maximum requests allowed per day")
-    burst_size: int | None = Field(default=None, description="Burst/concurrency limit above the steady-state rate")
-    window_seconds: int | None = Field(default=None, description="Duration of the rate limit window in seconds")
+    requests_per_minute: int | None = Field(
+        default=None, description="Maximum requests allowed per minute"
+    )
+    requests_per_hour: int | None = Field(
+        default=None, description="Maximum requests allowed per hour"
+    )
+    requests_per_day: int | None = Field(
+        default=None, description="Maximum requests allowed per day"
+    )
+    burst_size: int | None = Field(
+        default=None, description="Burst/concurrency limit above the steady-state rate"
+    )
+    window_seconds: int | None = Field(
+        default=None, description="Duration of the rate limit window in seconds"
+    )
     enforcement_type: str | None = Field(
         default=None,
         description="How the rate limit is enforced, e.g. 'decorator', 'middleware', 'api_gateway'",
@@ -133,9 +143,15 @@ class RateLimitDetail(BaseModel):
 class SecurityHeaderDetail(BaseModel):
     """HTTP security-header posture extracted from code or IaC."""
 
-    csp: bool | None = Field(default=None, description="True when a Content-Security-Policy header is set")
-    x_frame_options: bool | None = Field(default=None, description="True when an X-Frame-Options header is set")
-    hsts: bool | None = Field(default=None, description="True when a Strict-Transport-Security header is set")
+    csp: bool | None = Field(
+        default=None, description="True when a Content-Security-Policy header is set"
+    )
+    x_frame_options: bool | None = Field(
+        default=None, description="True when an X-Frame-Options header is set"
+    )
+    hsts: bool | None = Field(
+        default=None, description="True when a Strict-Transport-Security header is set"
+    )
     missing: list[str] = Field(
         default_factory=list,
         description="Security headers confirmed absent, e.g. ['csp', 'x_frame_options', 'hsts']",
@@ -149,7 +165,8 @@ class CorsPolicyDetail(BaseModel):
         default=None, description="Configured allowed origin(s), e.g. '*' or 'https://example.com'"
     )
     allow_credentials: bool | None = Field(
-        default=None, description="True when the CORS policy allows credentialed cross-origin requests"
+        default=None,
+        description="True when the CORS policy allows credentialed cross-origin requests",
     )
     wildcard_with_credentials: bool = Field(
         default=False,
@@ -164,8 +181,12 @@ class AuthDetail(BaseModel):
         default_factory=list,
         description="Auth protocols in use, e.g. ['oauth2', 'bearer', 'api_key', 'basic']",
     )
-    token_expiry_seconds: int | None = Field(default=None, description="Token TTL in seconds when detectable")
-    mfa_required: bool | None = Field(default=None, description="True when MFA is required for access")
+    token_expiry_seconds: int | None = Field(
+        default=None, description="Token TTL in seconds when detectable"
+    )
+    mfa_required: bool | None = Field(
+        default=None, description="True when MFA is required for access"
+    )
     credential_rotation_policy: str | None = Field(
         default=None, description="Rotation policy description, e.g. '90-day', 'on-demand'"
     )
@@ -191,7 +212,9 @@ class AuthDetail(BaseModel):
 class EncryptionDetail(BaseModel):
     """Encryption and redaction posture for a component."""
 
-    in_transit: bool | None = Field(default=None, description="True when data is encrypted in transit (TLS/SSL)")
+    in_transit: bool | None = Field(
+        default=None, description="True when data is encrypted in transit (TLS/SSL)"
+    )
     at_rest: bool | None = Field(default=None, description="True when data is encrypted at rest")
     algorithm: str | None = Field(
         default=None, description="Encryption algorithm, e.g. 'AES256', 'aws:kms', 'RSA-4096'"
@@ -217,14 +240,18 @@ class DataHandlingDetail(BaseModel):
 
     retention_days: int | None = Field(default=None, description="Data retention period in days")
     purge_schedule: str | None = Field(
-        default=None, description="Schedule or trigger for data purge, e.g. 'weekly', 'on-account-deletion'"
+        default=None,
+        description="Schedule or trigger for data purge, e.g. 'weekly', 'on-account-deletion'",
     )
     backup_frequency: str | None = Field(
         default=None, description="Backup frequency, e.g. 'daily', 'hourly', '7-day-retention'"
     )
-    backup_encrypted: bool | None = Field(default=None, description="True when backups are encrypted")
+    backup_encrypted: bool | None = Field(
+        default=None, description="True when backups are encrypted"
+    )
     anonymization_method: str | None = Field(
-        default=None, description="Anonymization or pseudonymization technique, e.g. 'tokenization', 'k-anonymity'"
+        default=None,
+        description="Anonymization or pseudonymization technique, e.g. 'tokenization', 'k-anonymity'",
     )
     consent_required: bool | None = Field(
         default=None, description="True when user consent is required before processing data"
@@ -244,8 +271,12 @@ class InstrumentationDetail(BaseModel):
     log_level: str | None = Field(
         default=None, description="Configured log level, e.g. 'DEBUG', 'INFO', 'WARNING'"
     )
-    tracing_enabled: bool | None = Field(default=None, description="True when distributed tracing is configured")
-    metrics_enabled: bool | None = Field(default=None, description="True when metrics collection is configured")
+    tracing_enabled: bool | None = Field(
+        default=None, description="True when distributed tracing is configured"
+    )
+    metrics_enabled: bool | None = Field(
+        default=None, description="True when metrics collection is configured"
+    )
     sampling_rate: float | None = Field(
         default=None, description="Trace or log sampling rate [0.0, 1.0] when detectable"
     )
@@ -254,7 +285,9 @@ class InstrumentationDetail(BaseModel):
 class TestingDetail(BaseModel):
     """Testing, validation, and CI/CD posture for a component or application."""
 
-    has_unit_tests: bool | None = Field(default=None, description="True when unit test files are detected")
+    has_unit_tests: bool | None = Field(
+        default=None, description="True when unit test files are detected"
+    )
     has_integration_tests: bool | None = Field(
         default=None, description="True when integration test files or suites are detected"
     )
@@ -263,14 +296,16 @@ class TestingDetail(BaseModel):
         description="Test frameworks detected, e.g. ['pytest', 'jest', 'vitest', 'hypothesis']",
     )
     ci_cd_pipeline: str | None = Field(
-        default=None, description="CI/CD platform detected, e.g. 'github_actions', 'gitlab_ci', 'jenkins'"
+        default=None,
+        description="CI/CD platform detected, e.g. 'github_actions', 'gitlab_ci', 'jenkins'",
     )
     quality_gates: list[str] = Field(
         default_factory=list,
         description="Quality gate tools detected, e.g. ['codecov', 'sonarqube', 'snyk']",
     )
     test_coverage_tool: str | None = Field(
-        default=None, description="Coverage measurement tool detected, e.g. 'coverage.py', 'istanbul'"
+        default=None,
+        description="Coverage measurement tool detected, e.g. 'coverage.py', 'istanbul'",
     )
 
 
@@ -906,7 +941,18 @@ class ScanSummary(BaseModel):
     )
     node_counts: dict[str, int] = Field(
         default_factory=dict,
-        description="Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+        description=(
+            "Count of effective nodes per ComponentType. "
+            "Nodes carrying llm_soft_rejected=true are excluded."
+        ),
+    )
+    node_counts_soft_rejected: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Count of deterministic nodes retained for audit after LLM "
+            "verification rejected them. These nodes remain in document.nodes "
+            "but are excluded from effective summaries and red-team generation."
+        ),
     )
     # Security & resilience aggregate fields (populated from IaC/Dockerfile adapter output)
     secret_stores: list[str] = Field(

--- a/nuguard/sbom/schemas/aibom.schema.json
+++ b/nuguard/sbom/schemas/aibom.schema.json
@@ -2299,8 +2299,16 @@
           "additionalProperties": {
             "type": "integer"
           },
-          "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+          "description": "Count of effective nodes per ComponentType. Nodes carrying llm_soft_rejected=true are excluded.",
           "title": "Node Counts",
+          "type": "object"
+        },
+        "node_counts_soft_rejected": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Count of deterministic nodes retained for audit after LLM verification rejected them. These nodes remain in document.nodes but are excluded from effective summaries and red-team generation.",
+          "title": "Node Counts Soft Rejected",
           "type": "object"
         },
         "secret_stores": {

--- a/tests/contracts/public_api.schema.json
+++ b/tests/contracts/public_api.schema.json
@@ -10168,8 +10168,16 @@
             "additionalProperties": {
               "type": "integer"
             },
-            "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+            "description": "Count of effective nodes per ComponentType. Nodes carrying llm_soft_rejected=true are excluded.",
             "title": "Node Counts",
+            "type": "object"
+          },
+          "node_counts_soft_rejected": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of deterministic nodes retained for audit after LLM verification rejected them. These nodes remain in document.nodes but are excluded from effective summaries and red-team generation.",
+            "title": "Node Counts Soft Rejected",
             "type": "object"
           },
           "secret_stores": {
@@ -13127,8 +13135,16 @@
             "additionalProperties": {
               "type": "integer"
             },
-            "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+            "description": "Count of effective nodes per ComponentType. Nodes carrying llm_soft_rejected=true are excluded.",
             "title": "Node Counts",
+            "type": "object"
+          },
+          "node_counts_soft_rejected": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of deterministic nodes retained for audit after LLM verification rejected them. These nodes remain in document.nodes but are excluded from effective summaries and red-team generation.",
+            "title": "Node Counts Soft Rejected",
             "type": "object"
           },
           "secret_stores": {
@@ -16343,8 +16359,16 @@
             "additionalProperties": {
               "type": "integer"
             },
-            "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+            "description": "Count of effective nodes per ComponentType. Nodes carrying llm_soft_rejected=true are excluded.",
             "title": "Node Counts",
+            "type": "object"
+          },
+          "node_counts_soft_rejected": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of deterministic nodes retained for audit after LLM verification rejected them. These nodes remain in document.nodes but are excluded from effective summaries and red-team generation.",
+            "title": "Node Counts Soft Rejected",
             "type": "object"
           },
           "secret_stores": {
@@ -19281,8 +19305,16 @@
             "additionalProperties": {
               "type": "integer"
             },
-            "description": "Count of nodes per ComponentType, e.g. {'AGENT': 3, 'MODEL': 2}",
+            "description": "Count of effective nodes per ComponentType. Nodes carrying llm_soft_rejected=true are excluded.",
             "title": "Node Counts",
+            "type": "object"
+          },
+          "node_counts_soft_rejected": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of deterministic nodes retained for audit after LLM verification rejected them. These nodes remain in document.nodes but are excluded from effective summaries and red-team generation.",
+            "title": "Node Counts Soft Rejected",
             "type": "object"
           },
           "secret_stores": {

--- a/tests/redteam/test_soft_rejected_nodes.py
+++ b/tests/redteam/test_soft_rejected_nodes.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nuguard.common.soft_reject import SOFT_REJECT_FLAG
+from nuguard.redteam.scenarios.generator import ScenarioGenerator
+from nuguard.sbom.models import (
+    AiSbomDocument,
+    Edge,
+    Node,
+    NodeMetadata,
+    ScanSummary,
+)
+from nuguard.sbom.types import (
+    ComponentType,
+    RelationshipType,
+)
+
+
+def _node(
+    name: str,
+    component_type: ComponentType,
+    *,
+    rejected: bool = False,
+    pii_fields: list[str] | None = None,
+    datastore_type: str | None = None,
+) -> Node:
+    return Node(
+        name=name,
+        component_type=component_type,
+        confidence=0.9,
+        metadata=NodeMetadata(
+            pii_fields=pii_fields,
+            datastore_type=datastore_type,
+            extras=(
+                {
+                    SOFT_REJECT_FLAG: True,
+                }
+                if rejected
+                else {}
+            ),
+        ),
+    )
+
+
+def _document() -> tuple[
+    AiSbomDocument,
+    Node,
+    Node,
+    Node,
+    Node,
+]:
+    rejected_store = _node(
+        "False Chroma Utility",
+        ComponentType.DATASTORE,
+        rejected=True,
+        pii_fields=[
+            "fabricated_customer_ssn",
+        ],
+        datastore_type="chroma",
+    )
+    active_store = _node(
+        "Customer Postgres",
+        ComponentType.DATASTORE,
+        pii_fields=[
+            "email",
+        ],
+        datastore_type="postgres",
+    )
+    active_agent = _node(
+        "Support Agent",
+        ComponentType.AGENT,
+    )
+    rejected_agent = _node(
+        "Rejected Hallucinated Agent",
+        ComponentType.AGENT,
+        rejected=True,
+    )
+
+    document = AiSbomDocument(
+        target="soft-reject-redteam-fixture",
+        nodes=[
+            rejected_store,
+            active_store,
+            active_agent,
+            rejected_agent,
+        ],
+        edges=[
+            Edge(
+                source=active_agent.id,
+                target=active_store.id,
+                relationship_type=(RelationshipType.ACCESSES),
+            ),
+            Edge(
+                source=active_agent.id,
+                target=rejected_store.id,
+                relationship_type=(RelationshipType.ACCESSES),
+            ),
+            Edge(
+                source=rejected_agent.id,
+                target=active_store.id,
+                relationship_type=(RelationshipType.ACCESSES),
+            ),
+        ],
+        summary=ScanSummary(
+            node_counts={
+                "AGENT": 2,
+                "DATASTORE": 2,
+            }
+        ),
+    )
+
+    return (
+        document,
+        rejected_store,
+        active_store,
+        active_agent,
+        rejected_agent,
+    )
+
+
+def test_generator_builds_non_mutating_effective_sbom_view() -> None:
+    (
+        original,
+        rejected_store,
+        active_store,
+        active_agent,
+        rejected_agent,
+    ) = _document()
+
+    generator = ScenarioGenerator(original)
+
+    # The source document remains complete for recall and audit.
+    assert len(original.nodes) == 4
+    assert len(original.edges) == 3
+    assert rejected_store in original.nodes
+    assert rejected_agent in original.nodes
+
+    effective_names = {node.name for node in generator._sbom.nodes}
+
+    assert effective_names == {
+        "Customer Postgres",
+        "Support Agent",
+    }
+
+    assert str(rejected_store.id) not in generator._node_by_id
+    assert str(rejected_agent.id) not in generator._node_by_id
+
+    assert len(generator._sbom.edges) == 1
+
+    remaining_edge = generator._sbom.edges[0]
+
+    assert remaining_edge.source == active_agent.id
+    assert remaining_edge.target == active_store.id
+
+    assert generator._sbom.summary is not None
+    assert generator._sbom.summary.node_counts == {
+        "AGENT": 1,
+        "DATASTORE": 1,
+    }
+    assert generator._sbom.summary.node_counts_soft_rejected == {
+        "AGENT": 1,
+        "DATASTORE": 1,
+    }
+
+
+def test_rejected_fields_and_agents_are_absent_from_generator_input() -> None:
+    (
+        original,
+        rejected_store,
+        active_store,
+        _active_agent,
+        rejected_agent,
+    ) = _document()
+
+    generator = ScenarioGenerator(original)
+
+    serialized = generator._sbom.model_dump_json()
+
+    assert "fabricated_customer_ssn" not in serialized
+    assert rejected_store.name not in serialized
+    assert rejected_agent.name not in serialized
+
+    assert active_store.name in serialized
+    assert "email" in serialized
+
+    effective_datastores = [
+        node for node in generator._sbom.nodes if node.component_type == ComponentType.DATASTORE
+    ]
+
+    # Reproduces the first-match path reported in #511:
+    # the first available datastore is now the confirmed one.
+    assert len(effective_datastores) == 1
+    assert effective_datastores[0].metadata.pii_fields == ["email"]
+
+    # Generator filtering must never mutate the audit SBOM.
+    assert "fabricated_customer_ssn" in original.model_dump_json()
+
+
+def test_generator_preserves_canary_tenant_initialization() -> None:
+    (
+        document,
+        _rejected_store,
+        _active_store,
+        _active_agent,
+        _rejected_agent,
+    ) = _document()
+
+    without_canary = ScenarioGenerator(document)
+
+    assert without_canary._real_tenant_id == ""
+
+    canary_config = SimpleNamespace(
+        tenants=[
+            SimpleNamespace(
+                tenant_id="tenant-primary",
+            ),
+            SimpleNamespace(
+                tenant_id="tenant-secondary",
+            ),
+        ]
+    )
+
+    with_canary = ScenarioGenerator(
+        document,
+        canary_config=canary_config,
+    )
+
+    assert with_canary._real_tenant_id == "tenant-secondary"

--- a/tests/sbom/test_soft_rejected_summary.py
+++ b/tests/sbom/test_soft_rejected_summary.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from nuguard.common.soft_reject import SOFT_REJECT_FLAG
+from nuguard.sbom.core.application_summary import build_scan_summary
+from nuguard.sbom.extractor.core import _refresh_summary_node_counts
+from nuguard.sbom.extractor.postprocess import _make_scan_summary
+from nuguard.sbom.models import (
+    AiSbomDocument,
+    Node,
+    NodeMetadata,
+    ScanSummary,
+)
+from nuguard.sbom.types import ComponentType
+
+
+def _node(
+    name: str,
+    component_type: ComponentType,
+    *,
+    rejected: bool = False,
+    framework: str | None = None,
+    endpoint: str | None = None,
+    data_classification: list[str] | None = None,
+    classified_tables: list[str] | None = None,
+) -> Node:
+    return Node(
+        name=name,
+        component_type=component_type,
+        confidence=0.9,
+        metadata=NodeMetadata(
+            framework=framework,
+            endpoint=endpoint,
+            data_classification=(data_classification or []),
+            classified_tables=(classified_tables or []),
+            extras=(
+                {
+                    SOFT_REJECT_FLAG: True,
+                }
+                if rejected
+                else {}
+            ),
+        ),
+    )
+
+
+def _nodes() -> list[Node]:
+    return [
+        _node(
+            "active-agent",
+            ComponentType.AGENT,
+        ),
+        _node(
+            "active-store",
+            ComponentType.DATASTORE,
+            data_classification=[
+                "PII",
+            ],
+            classified_tables=[
+                "customers",
+            ],
+        ),
+        _node(
+            "langgraph",
+            ComponentType.FRAMEWORK,
+            framework="langgraph",
+        ),
+        _node(
+            "POST /chat",
+            ComponentType.API_ENDPOINT,
+            endpoint="/chat",
+        ),
+        _node(
+            "false-chroma",
+            ComponentType.DATASTORE,
+            rejected=True,
+            data_classification=[
+                "PHI",
+            ],
+            classified_tables=[
+                "fabricated_records",
+            ],
+        ),
+        _node(
+            "false-crewai",
+            ComponentType.FRAMEWORK,
+            rejected=True,
+            framework="crewai",
+        ),
+        _node(
+            "POST /fabricated",
+            ComponentType.API_ENDPOINT,
+            rejected=True,
+            endpoint="/fabricated",
+        ),
+    ]
+
+
+def test_deterministic_summary_uses_effective_nodes_and_reports_rejections() -> None:
+    nodes = _nodes()
+
+    summary = build_scan_summary(
+        nodes,
+        [],
+    )
+
+    assert summary["node_type_counts"] == {
+        "AGENT": 1,
+        "API_ENDPOINT": 1,
+        "DATASTORE": 1,
+        "FRAMEWORK": 1,
+    }
+
+    assert summary["node_type_counts_soft_rejected"] == {
+        "API_ENDPOINT": 1,
+        "DATASTORE": 1,
+        "FRAMEWORK": 1,
+    }
+
+    assert "langgraph" in summary["frameworks"]
+    assert "crewai" not in summary["frameworks"]
+
+    assert "/chat" in summary["api_endpoints"]
+    assert "/fabricated" not in summary["api_endpoints"]
+
+    assert summary["data_classification"] == [
+        "PII",
+    ]
+
+    assert "fabricated_records" not in summary["classified_tables"]
+
+    # Summary construction must not remove retained audit nodes.
+    assert len(nodes) == 7
+
+
+def test_typed_summary_maps_both_count_views() -> None:
+    summary = _make_scan_summary(
+        build_scan_summary(
+            _nodes(),
+            [],
+        )
+    )
+
+    assert summary.node_counts == {
+        "AGENT": 1,
+        "API_ENDPOINT": 1,
+        "DATASTORE": 1,
+        "FRAMEWORK": 1,
+    }
+
+    assert summary.node_counts_soft_rejected == {
+        "API_ENDPOINT": 1,
+        "DATASTORE": 1,
+        "FRAMEWORK": 1,
+    }
+
+
+def test_final_refresh_corrects_stale_counts_without_removing_nodes() -> None:
+    nodes = _nodes()
+
+    document = AiSbomDocument(
+        target="soft-reject-fixture",
+        nodes=nodes,
+        summary=ScanSummary(
+            node_counts={
+                "AGENT": 99,
+                "DATASTORE": 99,
+            },
+            node_counts_soft_rejected={},
+        ),
+    )
+
+    _refresh_summary_node_counts(document)
+
+    assert len(document.nodes) == 7
+    assert document.summary is not None
+
+    assert document.summary.node_counts == {
+        "AGENT": 1,
+        "API_ENDPOINT": 1,
+        "DATASTORE": 1,
+        "FRAMEWORK": 1,
+    }
+
+    assert document.summary.node_counts_soft_rejected == {
+        "API_ENDPOINT": 1,
+        "DATASTORE": 1,
+        "FRAMEWORK": 1,
+    }
+
+
+def test_older_summaries_default_rejected_counts_to_empty() -> None:
+    summary = ScanSummary.model_validate(
+        {
+            "node_counts": {
+                "AGENT": 1,
+            }
+        }
+    )
+
+    assert summary.node_counts_soft_rejected == {}

--- a/tests/test_soft_reject.py
+++ b/tests/test_soft_reject.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from nuguard.analysis.plugins import nga_rules
+from nuguard.common.soft_reject import (
+    SOFT_REJECT_FLAG,
+    is_soft_rejected,
+    iter_effective_nodes,
+    partition_node_counts,
+)
+from nuguard.policy import checker
+from nuguard.sbom.models import Node, NodeMetadata
+from nuguard.sbom.types import ComponentType
+
+
+def _node(
+    name: str,
+    component_type: ComponentType,
+    *,
+    rejected: bool = False,
+) -> Node:
+    return Node(
+        name=name,
+        component_type=component_type,
+        confidence=0.9,
+        metadata=NodeMetadata(
+            extras=(
+                {
+                    SOFT_REJECT_FLAG: True,
+                }
+                if rejected
+                else {}
+            )
+        ),
+    )
+
+
+def test_soft_rejection_contract_supports_models_and_mappings() -> None:
+    active = _node(
+        "active-agent",
+        ComponentType.AGENT,
+    )
+    rejected = _node(
+        "rejected-agent",
+        ComponentType.AGENT,
+        rejected=True,
+    )
+
+    assert is_soft_rejected(active) is False
+    assert is_soft_rejected(rejected) is True
+
+    assert (
+        is_soft_rejected(
+            {
+                "metadata": {
+                    "extras": {
+                        SOFT_REJECT_FLAG: True,
+                    }
+                }
+            }
+        )
+        is True
+    )
+
+    # Require the canonical JSON boolean, not an arbitrary truthy string.
+    assert (
+        is_soft_rejected(
+            {
+                "metadata": {
+                    "extras": {
+                        SOFT_REJECT_FLAG: "true",
+                    }
+                }
+            }
+        )
+        is False
+    )
+
+
+def test_effective_iterator_and_count_partition_preserve_audit_nodes() -> None:
+    active_agent = _node(
+        "active-agent",
+        ComponentType.AGENT,
+    )
+    rejected_agent = _node(
+        "rejected-agent",
+        ComponentType.AGENT,
+        rejected=True,
+    )
+    active_store = _node(
+        "active-store",
+        ComponentType.DATASTORE,
+    )
+    rejected_model = _node(
+        "rejected-model",
+        ComponentType.MODEL,
+        rejected=True,
+    )
+
+    nodes = [
+        rejected_agent,
+        active_agent,
+        rejected_model,
+        active_store,
+    ]
+
+    assert list(iter_effective_nodes(nodes)) == [
+        active_agent,
+        active_store,
+    ]
+
+    partition = partition_node_counts(nodes)
+
+    assert partition.effective == {
+        "AGENT": 1,
+        "DATASTORE": 1,
+    }
+    assert partition.soft_rejected == {
+        "AGENT": 1,
+        "MODEL": 1,
+    }
+
+    assert len(nodes) == 4
+    assert rejected_agent in nodes
+    assert rejected_model in nodes
+
+
+def test_analysis_and_policy_use_the_shared_contract() -> None:
+    assert nga_rules._is_soft_rejected is is_soft_rejected
+    assert checker._is_soft_rejected is is_soft_rejected


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature

## What

- Add a shared `nuguard.common.soft_reject` contract for identifying retained LLM-soft-rejected nodes.
- Replace duplicated analysis and policy `_is_soft_rejected()` implementations with aliases to the shared helper.
- Make the verification producer use the shared soft-rejection flag constant.
- Build a non-mutating effective SBOM view when `ScenarioGenerator` is constructed.
- Exclude soft-rejected nodes from red-team scenario generation, capability detection, catalog selection, node indexes, and edge indexes.
- Remove edges whose source or target is soft-rejected.
- Preserve the existing canary-config-driven `_real_tenant_id` initialization.
- Preserve the complete original SBOM for recall, audit, and troubleshooting.
- Define `ScanSummary.node_counts` as counts of effective nodes.
- Add `ScanSummary.node_counts_soft_rejected` so retained false-positive counts remain visible.
- Make deterministic summary construction ignore soft-rejected nodes when deriving frameworks, endpoints, modalities, use-case text, data classification, IaC posture, instrumentation, and testing metadata.
- Map both count views through `extractor.postprocess._make_scan_summary()`.
- Refresh both count views after LLM verification and before returning the final SBOM.
- Update SBOM schema documentation.
- Regenerate both committed schema artifacts:
  - `nuguard/sbom/schemas/aibom.schema.json`
  - `tests/contracts/public_api.schema.json`
- Add shared-contract, backward-compatibility, summary, count-refresh, non-mutation, dangling-edge, generator-boundary, tenant-initialization, and first-datastore regression tests.

## Why

`llm_soft_rejected` marks deterministic AST or regex detections that NuGuard's own LLM verification identified as false positives. These nodes intentionally remain in `document.nodes` for recall and audit, but downstream consumers must not treat them as confirmed application components.

Several consumers implemented this convention independently, while red-team generation and final SBOM count refreshes did not implement it consistently.

The result was that:

- a rejected datastore could provide fabricated `pii_fields` to covert-exfiltration scenarios;
- rejected agents, datastores, guardrails, models, and tools remained available to other red-team paths;
- capability detection and catalog selection received rejected nodes;
- edges attached to rejected nodes remained traversable;
- `summary.node_counts` included known false positives;
- CLI and exported summaries inherited inflated counts.

Closes #511

## Root Cause

The soft-rejection state was represented by a metadata magic string rather than a shared domain contract.

`ScenarioGenerator` accepted the complete audit SBOM and built node indexes, edge indexes, and application capabilities from it. Individual scenario methods then iterated the same unfiltered document, making every generation path responsible for remembering the metadata flag.

Separately, the extractor rebuilt `summary.node_counts` from every retained node. Since soft rejection intentionally retains deterministic nodes, rejected false positives remained in the effective count.

The repository also maintains two schema anti-drift artifacts for `AiSbomDocument`. Both must be regenerated when `ScanSummary` changes.

## How

### Shared contract

`nuguard.common.soft_reject` owns:

- `SOFT_REJECT_FLAG`
- `is_soft_rejected()`
- `iter_effective_nodes()`
- `partition_node_counts()`

The helper supports Pydantic nodes and mapping-shaped data and requires the canonical JSON boolean value `true`.

### Red-team boundary

`ScenarioGenerator` creates an effective Pydantic model copy containing:

- only non-soft-rejected nodes;
- only edges whose source and target are both effective;
- a copied summary containing effective and rejected count partitions.

The caller's original `AiSbomDocument` is not modified. Generator methods, capability detection, catalog selection, indexes, and future node iterations therefore share the same filtered boundary.

The pre-existing `_real_tenant_id` initialization remains driven by `canary_config`. Regression coverage verifies both the default value and selection of the second configured tenant.

### Summary semantics

`node_counts` represents confirmed/effective nodes.

`node_counts_soft_rejected` separately records deterministic nodes retained for audit. Older documents remain compatible because the new field defaults to an empty mapping.

Both views are handled by:

1. deterministic summary construction;
2. the typed converter in `extractor/postprocess.py`;
3. the post-verification refresh;
4. the final pre-return refresh.

### Schema contracts

The additive `ScanSummary` change is reflected in both committed schemas:

- the packaged `AiSbomDocument` JSON schema;
- the public API schema contract snapshot.

## Test Steps

```bash
python3 -m compileall -q \
  nuguard/common/soft_reject.py \
  nuguard/analysis/plugins/nga_rules.py \
  nuguard/policy/checker.py \
  nuguard/redteam/scenarios/generator.py \
  nuguard/sbom/core/application_summary.py \
  nuguard/sbom/core/verification.py \
  nuguard/sbom/extractor/core.py \
  nuguard/sbom/extractor/postprocess.py \
  nuguard/sbom/models.py \
  tests/test_soft_reject.py \
  tests/sbom/test_soft_rejected_summary.py \
  tests/redteam/test_soft_rejected_nodes.py

uv run ruff check \
  nuguard/analysis/plugins/nga_rules.py \
  nuguard/common/soft_reject.py \
  nuguard/policy/checker.py \
  nuguard/redteam/scenarios/generator.py \
  nuguard/sbom/core/application_summary.py \
  nuguard/sbom/core/verification.py \
  nuguard/sbom/extractor/core.py \
  nuguard/sbom/extractor/postprocess.py \
  nuguard/sbom/models.py \
  tests/redteam/test_soft_rejected_nodes.py \
  tests/sbom/test_soft_rejected_summary.py \
  tests/test_soft_reject.py

uv run ruff format --check \
  nuguard/analysis/plugins/nga_rules.py \
  nuguard/common/soft_reject.py \
  nuguard/policy/checker.py \
  nuguard/redteam/scenarios/generator.py \
  nuguard/sbom/core/application_summary.py \
  nuguard/sbom/core/verification.py \
  nuguard/sbom/extractor/core.py \
  nuguard/sbom/extractor/postprocess.py \
  nuguard/sbom/models.py \
  tests/redteam/test_soft_rejected_nodes.py \
  tests/sbom/test_soft_rejected_summary.py \
  tests/test_soft_reject.py

uv run mypy \
  nuguard/common/soft_reject.py \
  nuguard/analysis/plugins/nga_rules.py \
  nuguard/policy/checker.py \
  nuguard/redteam/scenarios/generator.py \
  nuguard/sbom/core/application_summary.py \
  nuguard/sbom/core/verification.py \
  nuguard/sbom/extractor/core.py \
  nuguard/sbom/extractor/postprocess.py \
  nuguard/sbom/models.py

uv run pytest \
  tests/test_soft_reject.py \
  tests/sbom/test_soft_rejected_summary.py \
  tests/redteam/test_soft_rejected_nodes.py \
  nuguard/sbom/tests/test_schema.py \
  tests/contracts/test_public_api_schema_contract.py \
  -v

uv run pytest \
  nuguard/analysis/tests \
  nuguard/redteam/tests \
  nuguard/sbom/tests \
  -q

make lint
make test
make precommit-run

git diff --check
```

## Checks

- [x] Shared soft-rejection contract tests pass
- [x] Analysis and policy consumers use the shared helper
- [x] Verification uses the shared flag constant
- [x] Effective-node iterator tests pass
- [x] Effective and rejected count-partition tests pass
- [x] Generator input-filtering tests pass
- [x] Original SBOM non-mutation tests pass
- [x] Dangling rejected-node edges are removed
- [x] Capability and catalog inputs use the effective document
- [x] Existing canary tenant initialization is preserved
- [x] Default and second-tenant initialization tests pass
- [x] Rejected agents are absent from generator input
- [x] Rejected datastore names and fabricated fields are absent from generator input
- [x] The first effective datastore is a confirmed datastore
- [x] Effective summary-count tests pass
- [x] Retained soft-rejection count tests pass
- [x] Typed postprocess conversion preserves both count views
- [x] Older SBOM summaries remain compatible
- [x] Final extractor count-refresh tests pass
- [x] Packaged AI-SBOM schema anti-drift test passes
- [x] Public API schema contract passes
- [x] Both committed schema snapshots are updated
- [x] Impacted colocated analysis, red-team, and SBOM suites pass
- [x] Ruff checks pass
- [x] Mypy checks pass
- [x] Changed Python files pass targeted Ruff formatting checks
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make precommit-run` passes
- [x] `git diff --check` passes
- [x] Final patch is limited to the intended 15 files
- [x] Soft-rejected nodes remain available in `document.nodes` for audit

## Other Notes

- This change does not delete soft-rejected nodes from the canonical AI-SBOM.
- Existing SBOM documents without `node_counts_soft_rejected` continue to load with an empty mapping.
- `node_counts` represents the effective component inventory consumed by reports and downstream execution.
- `node_counts_soft_rejected` provides audit visibility without allowing rejected components to affect operational behavior.
- Filtering occurs once at the red-team generator boundary rather than being repeated in individual scenario methods.
- The filtered generator document is a Pydantic model copy; the caller's source document remains unchanged.
- Canary tenant configuration remains independent of SBOM filtering.
- Formatting was limited to files changed by this PR to avoid unrelated repository-wide churn.

## Release Note

Fixed inconsistent handling of LLM-soft-rejected AI-SBOM nodes. Red-team generation, capability selection, and summary counts now exclude confirmed false positives while retaining separate audit counts and preserving the original nodes in the AI-SBOM.