### PR TITLE
fix(behavior): reconcile gap findings with final coverage

### DIFF
--- a/nuguard/behavior/report.py
+++ b/nuguard/behavior/report.py
@@ -695,8 +695,9 @@ def to_markdown(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = No
 
     # Behavioral Gap Summary — findings promoted from LLM-generated gap strings
     gap_findings = [f for f in result.dynamic_findings if f.get("finding_type") in _GAP_FINDING_TYPES]
-    if gap_findings:
-        stats = result.gap_aggregation_stats or {}
+    stats = result.gap_aggregation_stats or {}
+    suppressed_gap_buckets = int(stats.get("buckets_suppressed_by_coverage", 0))
+    if gap_findings or suppressed_gap_buckets:
         threshold = int(stats.get("min_occurrences_threshold", 0))
         lines.append("## Behavioral Gap Summary")
         lines.append("")
@@ -711,6 +712,10 @@ def to_markdown(result: "BehaviorAnalysisResult", meta: "ReportMeta | None" = No
         lines.append(f"| Deduplicated unique gaps | {int(stats.get('unique_gap_observations', 0))} |")
         lines.append(f"| Buckets formed | {int(stats.get('buckets_formed', 0))} |")
         lines.append(f"| Buckets emitted as findings (>= {threshold}) | {int(stats.get('buckets_emitted', len(gap_findings)))} |")
+        lines.append(
+            "| Buckets suppressed by successful final coverage | "
+            f"{int(stats.get('buckets_suppressed_by_coverage', 0))} |"
+        )
         lines.append(f"| Buckets dropped (below threshold) | {int(stats.get('buckets_dropped', 0))} |")
         lines.append("")
         for ftype in ("CAPABILITY_GAP", "INTENT_MISALIGNMENT", "TOOL_CHAIN_BROKEN", "POLICY_VIOLATION"):

--- a/nuguard/behavior/runner.py
+++ b/nuguard/behavior/runner.py
@@ -105,14 +105,49 @@ def _classify_gap(gap_text: str) -> tuple[str, str]:
     reserved for the policy evaluator's hard signals.
     """
     t = gap_text.lower()
-    if any(k in t for k in ("tool", "not called", "not invoked", "chain broken", "function not")):
+    if _is_explicit_chain_failure(t):
         return "TOOL_CHAIN_BROKEN", "high"
-    if any(k in t for k in ("wrong", "incorrect", "invalid", "unrelated", "off-topic", "irrelevant", "inconsistent",
-                            "restricted", "not allowed", "violat", "should not")):
+    if any(k in t for k in ("not mentioned", "no mention", "not called", "not invoked")):
+        return "CAPABILITY_GAP", "medium"
+    if any(k in t for k in (
+        "wrong",
+        "incorrect",
+        "invalid",
+        "unrelated",
+        "off-topic",
+        "irrelevant",
+        "inconsistent",
+        "restricted",
+        "not allowed",
+        "violat",
+        "should not",
+    )):
         return "INTENT_MISALIGNMENT", "medium"
     if any(k in t for k in ("missing", "not provided", "did not include", "failed to provide", "no mention", "omitted", "absent")):
         return "CAPABILITY_GAP", "medium"
     return "CAPABILITY_GAP", "low"
+
+
+def _is_explicit_chain_failure(gap_text: str) -> bool:
+    """Return whether a gap explicitly describes an operational chain failure."""
+    text = gap_text.lower()
+    return any(k in text for k in (
+        "tool invocation failed",
+        "tool call failed",
+        "function call failed",
+        "delegation failed",
+        "invalid tool result",
+        "chain broken",
+    ))
+
+
+def _is_nonmention_gap(gap_text: str) -> bool:
+    """Return whether a gap reports absent mention rather than execution failure."""
+    text = gap_text.lower()
+    return not _is_explicit_chain_failure(text) and any(
+        phrase in text
+        for phrase in ("not mentioned", "no mention", "not called", "not invoked")
+    )
 
 
 def _make_short_title(violation_type: str, policy_clause: str) -> str:
@@ -2470,7 +2505,7 @@ class BehaviorRunner:
 
         raw_results = await asyncio.gather(*(_run_and_emit(i, s) for i, s in enumerate(scenarios)))
 
-        seen_findings: set[tuple[str, str, str]] = set()
+        seen_findings: set[tuple[str, ...]] = set()
         raw_gap_observations = 0
         unique_gap_observations = 0
         for run_result in raw_results:
@@ -2512,12 +2547,57 @@ class BehaviorRunner:
                         **_dynamic_finding_control_refs(_dev_finding_type),
                     })
 
+        # Build final run-wide coverage before promoting transient gap observations.
+        # Coverage owns component/alias resolution, so reconciliation consumes its
+        # canonical names rather than introducing a second fuzzy matcher.
+        coverage = self._build_coverage_map(scenario_results)
+        coverage_by_type: dict[str, list[BehaviorCoverage]] = {}
+        for coverage_item in coverage:
+            coverage_by_type.setdefault(coverage_item.node_type, []).append(coverage_item)
+
+        def _canonical_coverage_component(
+            name: str,
+            node_type: str | None = None,
+        ) -> str | None:
+            normalized = normalise_name(name)
+            if not normalized:
+                return None
+            candidates = coverage_by_type.get(node_type, []) if node_type else coverage
+            matches = [
+                item.component_name
+                for item in candidates
+                if normalized
+                in {
+                    normalise_name(candidate)
+                    for candidate in (
+                        item.component_name,
+                        *item.aliases_seen,
+                        *item.evidence_mentions,
+                    )
+                }
+            ]
+            return matches[0] if len(set(matches)) == 1 else None
+
+        successfully_exercised: set[str] = set()
+        for run_result in scenario_results:
+            for verdict_dict in run_result.verdicts:
+                if str(verdict_dict.get("verdict", "")).upper() != "PASS":
+                    continue
+                for mention in verdict_dict.get("agents_mentioned") or []:
+                    canonical = _canonical_coverage_component(str(mention), "AGENT")
+                    if canonical:
+                        successfully_exercised.add(canonical)
+                for mention in verdict_dict.get("tools_mentioned") or []:
+                    canonical = _canonical_coverage_component(str(mention), "TOOL")
+                    if canonical:
+                        successfully_exercised.add(canonical)
+
         # Aggregate gap strings from all scenario verdicts into bucketed findings.
         # Buckets are keyed by (finding_type, affected_component); each bucket that
         # accumulates >= _GAP_FINDING_MIN_OCCURRENCES gap instances becomes one finding.
         #
-        # Scoped non-goal: this block intentionally avoids changing verdict/scoring
-        # behavior. It only refactors evidence aggregation and deduplication.
+        # Verdict scoring remains unchanged; only final finding promotion is
+        # reconciled against run-wide successful coverage.
         _gap_buckets: dict[tuple[str, str], list[str]] = {}
         _gap_bucket_evidence: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
         _gap_bucket_raw_evidence_rows: dict[tuple[str, str], int] = {}
@@ -2533,6 +2613,8 @@ class BehaviorRunner:
             ):
                 continue
             component = _resolve_affected_component(orig)
+            component_type = str(getattr(orig, "target_component_type", "") or "").upper() or None
+            component = _canonical_coverage_component(component, component_type) or component
             for v_dict in run_result.verdicts:
                 turn_hash = _canonical_turn_hash(v_dict, scenario_id=run_result.scenario_id)
                 evidence_entry = dict(v_dict)
@@ -2549,26 +2631,50 @@ class BehaviorRunner:
                     _gap_bucket_raw_evidence_rows[bucket_key] = _gap_bucket_raw_evidence_rows.get(bucket_key, 0) + 1
                     _gap_bucket_evidence.setdefault(bucket_key, {}).setdefault(turn_hash, evidence_entry)
 
+        buckets_emitted = 0
+        buckets_suppressed_by_coverage = 0
         for (ftype, component), gap_list in _gap_buckets.items():
             if len(gap_list) < _GAP_FINDING_MIN_OCCURRENCES:
                 continue
+            raw_unique_gaps = {gap.lower() for gap in gap_list}
+            unique_gap_observations += len(raw_unique_gaps)
+            reconciled_gaps = [
+                gap
+                for gap in gap_list
+                if not (_is_nonmention_gap(gap) and component in successfully_exercised)
+            ]
+            if not reconciled_gaps:
+                buckets_suppressed_by_coverage += 1
+                continue
+            if len(reconciled_gaps) < _GAP_FINDING_MIN_OCCURRENCES:
+                continue
             # Deduplicate while preserving first-seen order
             seen_texts: dict[str, str] = {}
-            for g in gap_list:
+            for g in reconciled_gaps:
                 seen_texts.setdefault(g.lower(), g)
             unique_gaps = list(seen_texts.values())
-            unique_gap_observations += len(unique_gaps)
             _, severity = _classify_gap(unique_gaps[0])
             description = "; ".join(unique_gaps[:5])
-            dedup_key = (ftype, severity, description[:80])
-            if dedup_key in seen_findings:
+            gap_dedup_key = (ftype, severity, component, description[:80])
+            if gap_dedup_key in seen_findings:
                 continue
-            seen_findings.add(dedup_key)
-            bucket_verdicts = list(_gap_bucket_evidence.get((ftype, component), {}).values())
+            seen_findings.add(gap_dedup_key)
+            retained_gap_text = {gap.lower() for gap in reconciled_gaps}
+            bucket_verdicts = []
+            for verdict_dict in _gap_bucket_evidence.get((ftype, component), {}).values():
+                retained_verdict_gaps = [
+                    gap
+                    for gap in verdict_dict.get("gaps") or []
+                    if isinstance(gap, str) and gap.lower() in retained_gap_text
+                ]
+                if retained_verdict_gaps:
+                    retained_verdict = dict(verdict_dict)
+                    retained_verdict["gaps"] = retained_verdict_gaps
+                    bucket_verdicts.append(retained_verdict)
             bucket_verdicts.sort(key=lambda v: int(v.get("turn", 0)))
             unique_evidence_turn_count = len(bucket_verdicts)
             bucket_verdicts = bucket_verdicts[:5]
-            raw_evidence_rows = _gap_bucket_raw_evidence_rows.get((ftype, component), 0)
+            raw_evidence_rows = len(reconciled_gaps)
             duplicate_turns_removed = max(0, raw_evidence_rows - unique_evidence_turn_count)
             gap_attack_steps = [
                 {
@@ -2598,15 +2704,16 @@ class BehaviorRunner:
                 "description": description,
                 "affected_component": component,
                 "finding_type": ftype,
-                "occurrence_count": len(gap_list),
+                "occurrence_count": len(reconciled_gaps),
                 "gap_texts": unique_gaps,
-                "raw_gap_count": len(gap_list),
+                "raw_gap_count": len(reconciled_gaps),
                 "unique_gap_count": len(unique_gaps),
                 "evidence_turn_count": unique_evidence_turn_count,
                 "duplicate_turns_removed": duplicate_turns_removed,
                 "attack_steps": gap_attack_steps,
                 **_dynamic_finding_control_refs(ftype),
             })
+            buckets_emitted += 1
 
         # Flush judge cache to disk once all scenarios are done (v3).
         if self._judge_cache is not None:
@@ -2614,9 +2721,6 @@ class BehaviorRunner:
                 self._judge_cache.flush()
             except Exception as exc:
                 _log.warning("BehaviorRunner.run: judge cache flush failed: %s", exc)
-
-        # Build coverage map from all scenarios
-        coverage = self._build_coverage_map(scenario_results)
 
         # Determine scan outcome — severity-tiered first, then target health
         has_critical = any(str(f.get("severity", "")).lower() == "critical" for f in all_findings)
@@ -2652,13 +2756,16 @@ class BehaviorRunner:
 
         _in_tok, _out_tok = self._llm.token_counts if self._llm is not None else (0, 0)
         buckets_formed = len(_gap_buckets)
-        buckets_emitted = sum(1 for _k, gap_list in _gap_buckets.items() if len(gap_list) >= _GAP_FINDING_MIN_OCCURRENCES)
         gap_aggregation_stats = {
             "raw_gap_observations": raw_gap_observations,
             "unique_gap_observations": unique_gap_observations,
             "buckets_formed": buckets_formed,
             "buckets_emitted": buckets_emitted,
-            "buckets_dropped": max(0, buckets_formed - buckets_emitted),
+            "buckets_dropped": max(
+                0,
+                buckets_formed - buckets_emitted - buckets_suppressed_by_coverage,
+            ),
+            "buckets_suppressed_by_coverage": buckets_suppressed_by_coverage,
             "min_occurrences_threshold": _GAP_FINDING_MIN_OCCURRENCES,
             "raw_evidence_rows": sum(_gap_bucket_raw_evidence_rows.values()),
             "unique_evidence_turns": sum(len(v) for v in _gap_bucket_evidence.values()),

--- a/nuguard/behavior/tests/test_report.py
+++ b/nuguard/behavior/tests/test_report.py
@@ -453,16 +453,39 @@ def test_to_markdown_gap_summary_renders_remediation_and_fallback():
         gap_aggregation_stats={
             "raw_gap_observations": 5,
             "unique_gap_observations": 4,
+            "buckets_suppressed_by_coverage": 2,
             "min_occurrences_threshold": 1,
         },
     )
     md = to_markdown(result)
     assert "## Behavioral Gap Summary" in md
     assert "| Component | Occurrences | Sample Gaps | Remediation |" in md
+    assert "| Buckets suppressed by successful final coverage | 2 |" in md
     # Explicit remediation is rendered verbatim.
     assert "Add a wheelchair-assistance entry to the FAQ knowledge base." in md
     # Missing remediation falls back to the per-type guidance template.
     assert "Align doc_agent system prompt with application's stated purpose" in md
+
+
+def test_to_markdown_gap_summary_renders_when_all_buckets_reconciled() -> None:
+    result = _make_result(
+        dynamic_findings=[],
+        gap_aggregation_stats={
+            "raw_gap_observations": 2,
+            "unique_gap_observations": 1,
+            "buckets_formed": 1,
+            "buckets_emitted": 0,
+            "buckets_dropped": 0,
+            "buckets_suppressed_by_coverage": 1,
+            "min_occurrences_threshold": 2,
+        },
+    )
+
+    md = to_markdown(result)
+
+    assert "## Behavioral Gap Summary" in md
+    assert "| Buckets emitted as findings (>= 2) | 0 |" in md
+    assert "| Buckets suppressed by successful final coverage | 1 |" in md
 
 
 def test_to_markdown_gap_summary_empty_remediation_falls_back():

--- a/nuguard/behavior/tests/test_runner.py
+++ b/nuguard/behavior/tests/test_runner.py
@@ -217,6 +217,254 @@ async def test_run_single_scenario_pass():
 
 
 @pytest.mark.asyncio
+async def test_run_reconciles_nonmention_gap_with_final_successful_coverage() -> None:
+    """A later successful exercise must clear an earlier non-mention gap."""
+    tool_name = "Search Tool"
+    runner = BehaviorRunner(
+        config=_make_config(),
+        sbom=AiSbomDocument(
+            target="test",
+            nodes=[
+                Node(
+                    name=tool_name,
+                    component_type=ComponentType.TOOL,
+                    confidence=1.0,
+                    metadata=NodeMetadata(),
+                )
+            ],
+        ),
+        policy=_make_mock_policy(),
+        intent=_make_intent(),
+        llm_client=None,
+    )
+    scenarios = [
+        BehaviorScenario(
+            scenario_type=BehaviorScenarioType.COMPONENT_COVERAGE,
+            name="search_missing",
+            messages=["Try search without naming it."],
+            target_component=tool_name,
+            target_component_type="TOOL",
+            scoped_tools=[tool_name],
+        ),
+        BehaviorScenario(
+            scenario_type=BehaviorScenarioType.COMPONENT_COVERAGE,
+            name="search_succeeds",
+            messages=["Use search explicitly."],
+            target_component=tool_name,
+            target_component_type="TOOL",
+            scoped_tools=[tool_name],
+        ),
+    ]
+
+    async def _canned_result(scenario, _client, _evaluator):
+        if scenario.name == "search_missing":
+            verdicts = [
+                {
+                    "turn": turn,
+                    "verdict": "FAIL",
+                    "overall_score": 1.0,
+                    "gaps": [f"Tools not mentioned: {tool_name}"],
+                    "agents_mentioned": [],
+                    "tools_mentioned": [],
+                    "deviations": [],
+                }
+                for turn in (1, 2)
+            ]
+        else:
+            verdicts = [
+                {
+                    "turn": 1,
+                    "verdict": "PASS",
+                    "overall_score": 5.0,
+                    "gaps": [],
+                    "agents_mentioned": [],
+                    "tools_mentioned": [tool_name],
+                    "deviations": [],
+                }
+            ]
+        return ScenarioResult(
+            scenario_id=scenario.scenario_id,
+            scenario_name=scenario.name,
+            scenario_type=scenario.scenario_type.value,
+            verdicts=verdicts,
+            overall_score=max(v["overall_score"] for v in verdicts),
+            total_turns=len(verdicts),
+        )
+
+    mock_client = AsyncMock()
+    with (
+        patch.object(runner, "_build_client", new=AsyncMock(return_value=mock_client)),
+        patch.object(runner, "_build_policy_evaluator", return_value=None),
+        patch.object(runner, "_run_scenario", side_effect=_canned_result),
+    ):
+        result = await runner.run(scenarios=scenarios, pre_scan_profile=DiscoveredProfile())
+
+    tool_coverage = next(c for c in result.coverage if c.component_name == tool_name)
+    assert tool_coverage.exercised is True
+    assert tool_coverage.exercised_within_policy is True
+    assert not any(
+        finding.get("affected_component") == tool_name
+        and finding.get("finding_type") in {"CAPABILITY_GAP", "TOOL_CHAIN_BROKEN"}
+        for finding in result.findings
+    )
+    assert result.scan_outcome == "no_findings"
+    assert result.gap_aggregation_stats["buckets_suppressed_by_coverage"] == 1
+
+
+async def _run_component_gap_scenarios(
+    *,
+    gap_text: str,
+    mention_verdict: str,
+    mentioned_tool: str,
+    target_tool: str = "Search Tool",
+    additional_tools: list[str] | None = None,
+) -> BehaviorRunResult:
+    tool_names = [target_tool, *(additional_tools or [])]
+    runner = BehaviorRunner(
+        config=_make_config(),
+        sbom=AiSbomDocument(
+            target="test",
+            nodes=[
+                Node(
+                    name=name,
+                    component_type=ComponentType.TOOL,
+                    confidence=1.0,
+                    metadata=NodeMetadata(),
+                )
+                for name in tool_names
+            ],
+        ),
+        policy=_make_mock_policy(),
+        intent=_make_intent(),
+        llm_client=None,
+    )
+    gap_scenario = BehaviorScenario(
+        scenario_type=BehaviorScenarioType.COMPONENT_COVERAGE,
+        name="target_gap",
+        messages=["Exercise the target tool."],
+        target_component=target_tool,
+        target_component_type="TOOL",
+        scoped_tools=[target_tool],
+    )
+    mention_scenario = BehaviorScenario(
+        scenario_type=BehaviorScenarioType.COMPONENT_COVERAGE,
+        name="mention_evidence",
+        messages=["Exercise the mentioned tool."],
+        target_component=mentioned_tool,
+        target_component_type="TOOL",
+        scoped_tools=[mentioned_tool],
+    )
+
+    async def _canned_result(scenario, _client, _evaluator):
+        if scenario.name == "target_gap":
+            verdicts = [
+                {
+                    "turn": turn,
+                    "verdict": "FAIL",
+                    "overall_score": 1.0,
+                    "gaps": [gap_text],
+                    "agents_mentioned": [],
+                    "tools_mentioned": [],
+                    "deviations": [],
+                }
+                for turn in (1, 2)
+            ]
+        else:
+            verdicts = [
+                {
+                    "turn": 1,
+                    "verdict": mention_verdict,
+                    "overall_score": 5.0 if mention_verdict == "PASS" else 1.0,
+                    "gaps": [],
+                    "agents_mentioned": [],
+                    "tools_mentioned": [mentioned_tool],
+                    "deviations": [],
+                }
+            ]
+        return ScenarioResult(
+            scenario_id=scenario.scenario_id,
+            scenario_name=scenario.name,
+            scenario_type=scenario.scenario_type.value,
+            verdicts=verdicts,
+            overall_score=max(v["overall_score"] for v in verdicts),
+            total_turns=len(verdicts),
+        )
+
+    with (
+        patch.object(runner, "_build_client", new=AsyncMock(return_value=AsyncMock())),
+        patch.object(runner, "_build_policy_evaluator", return_value=None),
+        patch.object(runner, "_run_scenario", side_effect=_canned_result),
+    ):
+        return await runner.run(
+            scenarios=[gap_scenario, mention_scenario],
+            pre_scan_profile=DiscoveredProfile(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_fail_mention_does_not_suppress_nonmention_gap() -> None:
+    """A mention on a failed verdict cannot prove successful tool coverage."""
+    result = await _run_component_gap_scenarios(
+        gap_text="Tool not mentioned: Search Tool",
+        mention_verdict="FAIL",
+        mentioned_tool="Search Tool",
+    )
+
+    finding = next(f for f in result.findings if f.get("affected_component") == "Search Tool")
+    assert finding["finding_type"] == "CAPABILITY_GAP"
+    assert finding["severity"] == "medium"
+    assert result.gap_aggregation_stats["buckets_suppressed_by_coverage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_pass_mention_does_not_suppress_explicit_tool_failure() -> None:
+    """Successful mention evidence must not erase explicit invocation failures."""
+    result = await _run_component_gap_scenarios(
+        gap_text="Tool invocation failed: Search Tool timed out",
+        mention_verdict="PASS",
+        mentioned_tool="Search Tool",
+    )
+
+    finding = next(f for f in result.findings if f.get("affected_component") == "Search Tool")
+    assert finding["finding_type"] == "TOOL_CHAIN_BROKEN"
+    assert finding["severity"] == "high"
+    assert result.gap_aggregation_stats["buckets_suppressed_by_coverage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_unrelated_tool_pass_does_not_suppress_target_gap() -> None:
+    """Coverage reconciliation must remain scoped to the canonical target tool."""
+    result = await _run_component_gap_scenarios(
+        gap_text="Tool not mentioned: Search Tool",
+        mention_verdict="PASS",
+        mentioned_tool="Billing Tool",
+        additional_tools=["Billing Tool"],
+    )
+
+    finding = next(f for f in result.findings if f.get("affected_component") == "Search Tool")
+    assert finding["finding_type"] == "CAPABILITY_GAP"
+    assert finding["severity"] == "medium"
+    assert result.gap_aggregation_stats["buckets_suppressed_by_coverage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_normalized_pass_mention_suppresses_canonical_tool_gap() -> None:
+    """Normalized mention spelling must reconcile to the canonical SBOM tool name."""
+    result = await _run_component_gap_scenarios(
+        gap_text="Tool not mentioned: Search Tool",
+        mention_verdict="PASS",
+        mentioned_tool="search_tool",
+    )
+
+    assert not any(
+        finding.get("affected_component") == "Search Tool"
+        and finding.get("finding_type") == "CAPABILITY_GAP"
+        for finding in result.findings
+    )
+    assert result.gap_aggregation_stats["buckets_suppressed_by_coverage"] == 1
+
+
+@pytest.mark.asyncio
 async def test_run_policy_violation_creates_finding():
     """If _run_scenario returns deviations with policy_violation, findings are emitted."""
     runner = BehaviorRunner(


### PR DESCRIPTION
## Summary
- reconcile aggregated behavior gaps against final run-wide component coverage before emitting findings
- classify simple component non-mention as `CAPABILITY_GAP`/medium and reserve `TOOL_CHAIN_BROKEN`/high for explicit operational failures
- keep gap evidence, deduplication, suppression statistics, reports, and final scan outcome internally consistent
- add regression coverage for successful later mentions, failed mentions, explicit failures, unrelated components, normalized aliases, and suppression-only reports

Closes #485

## Validation
- focused reconciliation tests: 5 passed
- behavior report tests: 38 passed
- attack-step evidence tests: 10 passed
- public API schema contract: 1 passed
- scoped Ruff: passed
- mypy: 617 files passed
- live OpenAI CS agent behavior E2E: 26/26 scenarios, 151 turns, 91.67% coverage, zero stale non-mention findings on successfully covered components, zero false `TOOL_CHAIN_BROKEN` findings

## Repository-wide checks
- behavior suites: 495 passed; one unrelated timing-threshold failure in `test_build_scenarios_parallelises_llm_calls`
- top-level suite: 2,296 passed, 39 skipped, 5 unrelated pre-existing/platform failures
