### PR TITLE
Feat: Support Custom Payload with tokens for behavioral and red-teaming validation tests

### DIFF
--- a/nuguard.yaml.example
+++ b/nuguard.yaml.example
@@ -74,6 +74,16 @@ target:
   # chat_payload_extras:
   #  user_id: alice
 
+  # Fully custom payload shape: if any value contains the {{message}} token,
+  # the whole dict is sent as-is with tokens substituted (message/history/
+  # session_id/conversation_id) instead of being merged with the
+  # auto-detected shape above.
+  # chat_payload_extras:
+  #   input:
+  #     text: "{{message}}"
+  #     history: "{{history}}"
+  #   session_id: "{{session_id}}"
+
   # Authentication — uncomment ONE option:
   auth:
     # Option A: Login flow (preferred when the app exposes a /login endpoint)

--- a/nuguard/config.py
+++ b/nuguard/config.py
@@ -722,7 +722,13 @@ class BehaviorConfig(BaseModel):
         default_factory=dict,
         description=(
             "Extra static JSON fields merged into every chat POST body "
-            "(e.g. vehicleState, language). The message key always takes precedence."
+            "(e.g. vehicleState, language). The message key always takes precedence. "
+            "If any string value contains the literal token '{{message}}', the entire "
+            "dict is instead treated as a payload template: it is sent as-is with "
+            "'{{message}}' substituted for the current turn's message text, and, if "
+            "present, '{{history}}' (prior turns as a JSON [{role, content}, ...] "
+            "string), '{{session_id}}', and '{{conversation_id}}' substituted as well. "
+            "Without '{{message}}', behavior is unchanged."
         ),
     )
     adk: GoogleADKConfig = Field(

--- a/nuguard/redteam/target/client.py
+++ b/nuguard/redteam/target/client.py
@@ -82,6 +82,62 @@ def _is_message_history_key(key: str) -> bool:
     return key.strip().lower() in _MESSAGE_HISTORY_KEYS
 
 
+# Recognized tokens inside a chat_payload_extras template — see
+# TargetAppClient._build_templated_chat_payload. Deliberately only these four;
+# an unrecognized {{foo}} sequence is left untouched rather than guessed at.
+_PAYLOAD_TOKEN_PATTERN = re.compile(r"\{\{(message|history|session_id|conversation_id)\}\}")
+
+
+def _contains_message_token(obj: Any) -> bool:
+    """Recursively check whether any string value in *obj* contains ``{{message}}``.
+
+    This gate decides whether chat_payload_extras is treated as a literal
+    template (this feature) or merged with the auto-detected body shape
+    (existing behaviour, unchanged when the token is absent).
+    """
+    if isinstance(obj, str):
+        return "{{message}}" in obj
+    if isinstance(obj, dict):
+        return any(_contains_message_token(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_contains_message_token(v) for v in obj)
+    return False
+
+
+def _render_payload_template(
+    template: Any,
+    *,
+    message: str,
+    history: str,
+    session_id: str,
+    conversation_id: str,
+) -> Any:
+    """Deep-copy *template*, substituting ``{{message}}``/``{{history}}``/
+    ``{{session_id}}``/``{{conversation_id}}`` tokens in every string value.
+
+    Substitution happens on Python objects before ``json.dumps``, so message
+    content containing quotes or braces is safe — there is no JSON-injection
+    risk from user-controlled text landing in ``message``/``history``.
+    """
+    substitutions = {
+        "message": message,
+        "history": history,
+        "session_id": session_id,
+        "conversation_id": conversation_id,
+    }
+
+    def _walk(node: Any) -> Any:
+        if isinstance(node, str):
+            return _PAYLOAD_TOKEN_PATTERN.sub(lambda m: substitutions[m.group(1)], node)
+        if isinstance(node, dict):
+            return {k: _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(v) for v in node]
+        return node
+
+    return _walk(template)
+
+
 # Path-parameter placeholder styles seen across frameworks: FastAPI/ASP.NET
 # Core use `{id}`, NestJS/Express use `:id`. Substituted against
 # TargetAppClient._path_param_values before every request — see
@@ -798,6 +854,34 @@ class TargetAppClient:
                 )
                 raise
 
+    def _build_templated_chat_payload(self, payload: str, session: AttackSession) -> Any:
+        """Render ``self._chat_payload_extras`` as a literal token template.
+
+        Only called once :func:`_contains_message_token` confirms the extras
+        contain ``{{message}}`` — this is the "custom payload shape with
+        tokens" path, distinct from the auto-detected/merged shape built by
+        :meth:`_build_chat_payload_value`.
+
+        ``history`` replays prior turns using the same ``[{role, content},
+        ...]`` shape as the OpenAI-style branch of ``_build_chat_payload_value``,
+        serialized to a JSON string. The *current* turn is intentionally
+        excluded from history — it is already placed via the ``{{message}}``
+        token, so including it here would duplicate it when a template uses
+        both tokens.
+        """
+        history: list[dict[str, str]] = []
+        for turn in session.turns:
+            history.append({"role": "user", "content": turn.prompt})
+            if turn.response:
+                history.append({"role": "assistant", "content": turn.response})
+        return _render_payload_template(
+            self._chat_payload_extras,
+            message=payload,
+            history=json.dumps(history),
+            session_id=str(session.session_id or self._session_context.get("session_id", "")),
+            conversation_id=str(self._session_context.get("conversation_id", "")),
+        )
+
     def _build_chat_payload_value(self, payload: str, session: AttackSession) -> Any:
         """Shape the outgoing value for ``chat_payload_key`` in the generic (non-adapter) path.
 
@@ -900,17 +984,27 @@ class TargetAppClient:
                     body = self._framework_adapter.build_body(payload, session_id)
                     chat_path = self._framework_adapter.run_path
                 else:
-                    # Generic path: flat key/value body
-                    value: Any = self._build_chat_payload_value(payload, session)
-                    body = {self._chat_payload_key: value}
-                    # Merge any previously extracted session/conversation context so the
-                    # server can correlate subsequent turns within the same conversation.
-                    if self._session_context:
-                        body.update(self._session_context)
-                    # Merge static extra fields (e.g. vehicleState, language) declared in
-                    # chat_payload_extras — the message key always takes precedence.
-                    if self._chat_payload_extras:
-                        body = {**self._chat_payload_extras, **body}
+                    value: Any
+                    if self._chat_payload_extras and _contains_message_token(
+                        self._chat_payload_extras
+                    ):
+                        # Custom payload shape with {{message}} (and optionally
+                        # {{history}}/{{session_id}}/{{conversation_id}}) tokens:
+                        # the extras dict IS the body, tokens substituted in place.
+                        value = payload
+                        body = self._build_templated_chat_payload(payload, session)
+                    else:
+                        # Generic path: flat key/value body
+                        value = self._build_chat_payload_value(payload, session)
+                        body = {self._chat_payload_key: value}
+                        # Merge any previously extracted session/conversation context so the
+                        # server can correlate subsequent turns within the same conversation.
+                        if self._session_context:
+                            body.update(self._session_context)
+                        # Merge static extra fields (e.g. vehicleState, language) declared in
+                        # chat_payload_extras — the message key always takes precedence.
+                        if self._chat_payload_extras:
+                            body = {**self._chat_payload_extras, **body}
                     chat_path, _missing_params = _substitute_path_params(
                         self._chat_path, self._path_param_values
                     )
@@ -921,10 +1015,18 @@ class TargetAppClient:
                         )
                         return f"[CONFIG_ERROR: unresolved path param {_missing_params[0]!r}]", []
 
+                _log.debug(
+                    "Target HTTP POST url=%s body=%s",
+                    chat_path, json.dumps(body, default=str),
+                )
                 if self._chat_payload_format == "form":
                     resp = await self._client.post(chat_path, data=body, headers=extra_headers)
                 else:
                     resp = await self._client.post(chat_path, json=body, headers=extra_headers)
+                _log.debug(
+                    "Target HTTP Response status=%s body=%s",
+                    resp.status_code, resp.text,
+                )
                 resp.raise_for_status()
                 _content_type = resp.headers.get("content-type", "")
                 if "text/event-stream" in _content_type and self._framework_adapter is None:
@@ -1217,12 +1319,19 @@ class TargetAppClient:
                 body = self._framework_adapter.build_body(payload, session_id)
                 chat_path = self._framework_adapter.run_path
             else:
-                value: Any = self._build_chat_payload_value(payload, session)
-                body = {self._chat_payload_key: value}
-                if self._session_context:
-                    body.update(self._session_context)
-                if self._chat_payload_extras:
-                    body = {**self._chat_payload_extras, **body}
+                value: Any
+                if self._chat_payload_extras and _contains_message_token(
+                    self._chat_payload_extras
+                ):
+                    value = payload
+                    body = self._build_templated_chat_payload(payload, session)
+                else:
+                    value = self._build_chat_payload_value(payload, session)
+                    body = {self._chat_payload_key: value}
+                    if self._session_context:
+                        body.update(self._session_context)
+                    if self._chat_payload_extras:
+                        body = {**self._chat_payload_extras, **body}
                 chat_path, _missing_params = _substitute_path_params(
                     self._chat_path, self._path_param_values
                 )
@@ -1239,6 +1348,10 @@ class TargetAppClient:
                 {"data": body}
                 if self._chat_payload_format == "form"
                 else {"json": body}
+            )
+            _log.debug(
+                "Target HTTP POST (stream) url=%s body=%s",
+                chat_path, json.dumps(body, default=str),
             )
             async with self._client.stream("POST", chat_path, **_stream_kwargs) as resp:
                 resp.raise_for_status()
@@ -1266,12 +1379,21 @@ class TargetAppClient:
                     # If nothing yielded yet, yield what we have (empty)
                     if not accumulated_text_parts:
                         yield "", tool_calls
+                    _log.debug(
+                        "Target HTTP Response (stream/SSE) status=%s body=%s",
+                        resp.status_code, "".join(accumulated_text_parts),
+                    )
                     self._record_chat_success()
                 else:
                     # JSON path: buffer and yield once
                     raw = await resp.aread()
                     elapsed_ms = int((time.monotonic() - t_start) * 1000)
                     _ = elapsed_ms  # available to callers via latency if needed
+                    _log.debug(
+                        "Target HTTP Response (stream) status=%s body=%s",
+                        resp.status_code,
+                        raw.decode(errors="replace") if isinstance(raw, bytes) else str(raw),
+                    )
                     try:
                         data = json.loads(raw)
                     except Exception:

--- a/tests/contracts/public_api.schema.json
+++ b/tests/contracts/public_api.schema.json
@@ -985,7 +985,7 @@
           },
           "chat_payload_extras": {
             "additionalProperties": true,
-            "description": "Extra static JSON fields merged into every chat POST body (e.g. vehicleState, language). The message key always takes precedence.",
+            "description": "Extra static JSON fields merged into every chat POST body (e.g. vehicleState, language). The message key always takes precedence. If any string value contains the literal token '{{message}}', the entire dict is instead treated as a payload template: it is sent as-is with '{{message}}' substituted for the current turn's message text, and, if present, '{{history}}' (prior turns as a JSON [{role, content}, ...] string), '{{session_id}}', and '{{conversation_id}}' substituted as well. Without '{{message}}', behavior is unchanged.",
             "title": "Chat Payload Extras",
             "type": "object"
           },
@@ -2322,7 +2322,7 @@
           },
           "chat_payload_extras": {
             "additionalProperties": true,
-            "description": "Extra static JSON fields merged into every chat POST body (e.g. vehicleState, language). The message key always takes precedence.",
+            "description": "Extra static JSON fields merged into every chat POST body (e.g. vehicleState, language). The message key always takes precedence. If any string value contains the literal token '{{message}}', the entire dict is instead treated as a payload template: it is sent as-is with '{{message}}' substituted for the current turn's message text, and, if present, '{{history}}' (prior turns as a JSON [{role, content}, ...] string), '{{session_id}}', and '{{conversation_id}}' substituted as well. Without '{{message}}', behavior is unchanged.",
             "title": "Chat Payload Extras",
             "type": "object"
           },

--- a/tests/redteam/test_chat_payload_template.py
+++ b/tests/redteam/test_chat_payload_template.py
@@ -1,0 +1,203 @@
+"""Tests for {{message}}-token payload templating in TargetAppClient.
+
+Covers: token detection, template rendering, the new templated body path in
+send()/send_impl() when chat_payload_extras defines {{message}}, and the two
+regression guarantees — extras without {{message}} keep the existing merge
+behaviour, and no extras at all keeps auto-detection untouched.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nuguard.redteam.target.client import (
+    TargetAppClient,
+    _contains_message_token,
+    _render_payload_template,
+)
+from nuguard.redteam.target.session import AttackSession
+
+
+def _mock_response(json_body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=json_body)
+    resp.status_code = status_code
+    resp.text = json.dumps(json_body)
+    resp.headers = {"content-type": "application/json"}
+    return resp
+
+
+class TestContainsMessageToken:
+    def test_true_for_flat_string(self) -> None:
+        assert _contains_message_token({"input": "{{message}}"})
+
+    def test_true_nested_dict_and_list(self) -> None:
+        assert _contains_message_token({"a": {"b": ["x", "{{message}} please"]}})
+
+    def test_false_when_absent(self) -> None:
+        assert not _contains_message_token({"user_id": "alice", "lang": "en"})
+
+    def test_false_for_empty_or_non_string_values(self) -> None:
+        assert not _contains_message_token({"count": 3, "flag": True, "nested": {}})
+
+
+class TestRenderPayloadTemplate:
+    def test_substitutes_all_known_tokens(self) -> None:
+        template = {
+            "input": {"text": "{{message}}", "history": "{{history}}"},
+            "session_id": "{{session_id}}",
+            "conversation_id": "{{conversation_id}}",
+        }
+        rendered = _render_payload_template(
+            template,
+            message="hello",
+            history="[]",
+            session_id="s-1",
+            conversation_id="c-1",
+        )
+        assert rendered == {
+            "input": {"text": "hello", "history": "[]"},
+            "session_id": "s-1",
+            "conversation_id": "c-1",
+        }
+
+    def test_leaves_unknown_tokens_untouched(self) -> None:
+        rendered = _render_payload_template(
+            {"a": "{{message}} {{unknown_token}}"},
+            message="hi",
+            history="",
+            session_id="",
+            conversation_id="",
+        )
+        assert rendered == {"a": "hi {{unknown_token}}"}
+
+    def test_does_not_mutate_original_template(self) -> None:
+        template = {"a": "{{message}}"}
+        _render_payload_template(template, message="hi", history="", session_id="", conversation_id="")
+        assert template == {"a": "{{message}}"}
+
+    def test_multiple_tokens_in_one_string(self) -> None:
+        rendered = _render_payload_template(
+            {"a": "msg={{message}} sid={{session_id}}"},
+            message="hi",
+            history="",
+            session_id="s1",
+            conversation_id="",
+        )
+        assert rendered == {"a": "msg=hi sid=s1"}
+
+
+@pytest.mark.asyncio
+async def test_send_uses_templated_body_when_message_token_present() -> None:
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_extras={"input": {"text": "{{message}}"}, "lang": "en"},
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    resp = _mock_response({"response": "ok"})
+    with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp) as post_mock:
+        text, _ = await client.send("hello there", session)
+
+    assert text == "ok"
+    sent_body = post_mock.await_args.kwargs["json"]
+    assert sent_body == {"input": {"text": "hello there"}, "lang": "en"}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_templated_body_threads_history_session_and_conversation() -> None:
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_extras={
+            "input": {"text": "{{message}}", "history": "{{history}}"},
+            "session_id": "{{session_id}}",
+            "conversation_id": "{{conversation_id}}",
+        },
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+    session.add_turn("first prompt", "first response")
+
+    # Simulate a conversation_id previously echoed back by the target.
+    client._session_context["conversation_id"] = "conv-42"
+
+    resp = _mock_response({"response": "second reply"})
+    with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp) as post_mock:
+        text, _ = await client.send("second prompt", session)
+
+    assert text == "second reply"
+    sent_body = post_mock.await_args.kwargs["json"]
+    assert sent_body["input"]["text"] == "second prompt"
+    history = json.loads(sent_body["input"]["history"])
+    assert history == [{"role": "user", "content": "first prompt"}, {"role": "assistant", "content": "first response"}]
+    assert sent_body["session_id"] == "s1"
+    assert sent_body["conversation_id"] == "conv-42"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_extras_without_message_token_keeps_existing_merge_behavior() -> None:
+    """Regression: chat_payload_extras without {{message}} merges exactly as before."""
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_key="text",
+        chat_payload_extras={"vehicleState": "parked", "language": "en"},
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    resp = _mock_response({"response": "ok"})
+    with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp) as post_mock:
+        text, _ = await client.send("hello", session)
+
+    assert text == "ok"
+    sent_body = post_mock.await_args.kwargs["json"]
+    assert sent_body == {"vehicleState": "parked", "language": "en", "text": "hello"}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_without_extras_keeps_auto_detection_untouched() -> None:
+    """Regression: no chat_payload_extras at all — auto-detected flat body, unchanged."""
+    client = TargetAppClient(base_url="http://localhost:9999", chat_payload_key="message")
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    resp = _mock_response({"response": "ok"})
+    with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp) as post_mock:
+        text, _ = await client.send("hello", session)
+
+    assert text == "ok"
+    sent_body = post_mock.await_args.kwargs["json"]
+    assert sent_body == {"message": "hello"}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_debug_logs_request_and_response_bodies() -> None:
+    """Debug logging fires with the exact outgoing/incoming JSON bodies.
+
+    Patches the module logger directly rather than relying on caplog, since
+    get_logger() configures a non-propagating logger (propagate=False) whose
+    effective level is fixed by NUGUARD_LOG_LEVEL at first use.
+    """
+    client = TargetAppClient(
+        base_url="http://localhost:9999",
+        chat_payload_extras={"input": {"text": "{{message}}"}},
+    )
+    session = AttackSession(session_id="s1", target_url="http://localhost:9999", chain_id="c1")
+
+    resp = _mock_response({"response": "debug-ok"})
+    with patch("nuguard.redteam.target.client._log") as log_mock:
+        with patch.object(client._client, "post", new_callable=AsyncMock, return_value=resp):
+            await client.send("hello debug", session)
+
+    debug_calls = [call.args for call in log_mock.debug.call_args_list]
+    assert any(
+        "Target HTTP POST" in args[0] and "hello debug" in args[2] for args in debug_calls
+    )
+    assert any(
+        "Target HTTP Response" in args[0] and "debug-ok" in args[2] for args in debug_calls
+    )
+    await client.aclose()


### PR DESCRIPTION
In certain situations, Auto-detection or simple Payload may not be adequate to find
the correct Payload shape. This feature mitigates this problem by allowing users to
define Custom Payload  in the `chat_payload_extras` field in `nuguard.yaml`. When
value contains the {{message}} token any where in the Custom Payload, this token
would be replaced by actual message dynamically as a part of the HTTP POST.

Supported tokens are: 
```
{{message}}
{{history}} (prior turns as a JSON [{role, content}, ...] string), 
{{session_id}}
and {{conversation_id}}.
```
**Note: Existing auto-detection and merge behavior is unchanged when the `{{message}}`
token is absent from the Custom Payload**

Also adds debug logging of outgoing request/response bodies for the target
HTTP client to aid troubleshooting of custom payload shapes.

This PR Closes #422 

---
## PR Type

<!--
Check exactly ONE box below. This is the single source of truth automation
reads to classify the PR (e.g. a GitHub Action looking for "[x] Bug fix" vs
"[x] Feature") — do not remove or rephrase these two lines.
-->
- [ ] Bug fix
- [X] Feature

## What

What changed at a high level?
- Added Custom Payload feature with arbitrary location of the Messages in a complex JSON paylodd
- Also added DEBUG statements for HTTP POST and HTTP Response for troubleshooting purposes.

#422 
## Why

Why are these changes helpful or necessary?
- Some AI Apps may have complex payload where we cannot auto-detect the exact message key and message location in the Payload. This allows you to define the Custom Payload in nuguard.yaml file.


## Root Cause

<!-- Bug fixes only — delete this section for feature PRs. -->

What was actually causing the bug?
N/A

## How

How did you go about making these changes?
- Provided requirements and reviewed the Implementation plan created by Claude 

## Test Steps

What are all the steps to testing your code changes?
- [x] Redteam'd against NuGuard-app chat interface running on Demo env

## Checks

- [x] `make test` passes (`uv run pytest tests/ -v`)
- [x] `make lint` passes (`ruff check` + `mypy`)
- [x] Added/updated tests covering this change (regression test for bugs, new coverage for features)

## Other Notes

What, if anything, hasn't been addressed in these code changes but should be in future changes?