### PR TITLE
fix: reconcile release version automation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.7.5",
+    "version": "0.9.7",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.7.5",
+      "version": "0.9.7",
       "category": "security",
       "tags": [
         "ai-security",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -95,3 +95,12 @@ Include in the PR description:
 ## Release Notes
 
 If your change affects users, include a short note maintainers can reuse in release notes.
+
+## Releases
+
+Contributors do not need to publish packages or create release tags. Repository maintainers
+own version selection, release approval, tagging, and publication as described in
+[Governance](../documentation/GOVERNANCE.md).
+
+Maintainers should follow the canonical [NuGuard release runbook](../documentation/releasing.md)
+for version synchronization, validation, prerelease testing, and production publishing.

--- a/.github/README.md
+++ b/.github/README.md
@@ -108,6 +108,10 @@ Dev setup, running tests and lint, and the pull request process are covered in t
 
 [![Read the Contributing guide](https://img.shields.io/badge/→_Read_the_Contributing_Guide-111111?style=for-the-badge)](CONTRIBUTING.md)
 
+Release publication is managed by repository maintainers. See
+[Governance](../documentation/GOVERNANCE.md) for ownership and the
+[release runbook](../documentation/releasing.md) for the maintained procedure.
+
 ## Repo Notes
 
 - The repository currently contains example applications under `tests/apps/`
@@ -146,5 +150,6 @@ Filter by category or profile, or set `enabled: false` per scenario in a catalog
 <a href="../documentation/docs/plugin-guide.md">Claude plugin</a> ·
 <a href="../documentation/docs/troubleshooting.md">Troubleshooting</a> ·
 <a href="SECURITY.md">Security</a> ·
-<a href="CONTRIBUTING.md">Contributing</a>
+<a href="CONTRIBUTING.md">Contributing</a> ·
+<a href="../documentation/GOVERNANCE.md">Governance</a>
 </sub>

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,15 +17,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
 
       - name: Verify release metadata
         run: |
@@ -40,15 +42,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # v3
 
       - name: Install dependencies
         run: uv sync --dev
@@ -68,15 +72,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # v3
 
       - name: Install dependencies
         run: uv sync --dev
@@ -91,15 +97,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # v3
 
       - name: Install browser test dependencies
         run: uv sync --dev --extra mcp --extra browser
@@ -135,15 +143,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # v3
 
       - name: Install dependencies
         run: uv sync --dev --extra mcp

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,6 +10,29 @@ permissions:
   contents: read
 
 jobs:
+  release-contract:
+    name: Release metadata contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Verify release metadata
+        run: |
+          uv lock --check
+          npm run version:check
+          uv run pytest tests/test_release_metadata.py -q
+
   lint:
     name: Lint and type check
     runs-on: ubuntu-latest
@@ -108,6 +131,7 @@ jobs:
       - lint
       - public-api-contract
       - browser_login
+      - release-contract
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,12 +18,15 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ github.ref_name }}
+          persist-credentials: false
+          ref: ${{ github.sha }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        with:
+          enable-cache: false
 
       - name: Verify tag and release metadata
         env:
@@ -62,29 +65,107 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      npm-exists: ${{ steps.npm-registry.outputs.exists }}
+      pypi-exists: ${{ steps.pypi-registry.outputs.exists }}
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ github.ref_name }}
+          persist-credentials: false
+          ref: ${{ github.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        with:
+          enable-cache: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "20"
 
       - name: Build distributions
         run: uv build
 
+      - name: Verify existing PyPI artifacts
+        id: pypi-registry
+        run: |
+          python scripts/verify_registry_artifacts.py pypi \
+            --project nuguard \
+            --version "${GITHUB_REF_NAME#v}" \
+            --dist-dir dist \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Build npm package
+        run: |
+          mkdir npm-dist
+          npm pack ./npm --pack-destination npm-dist
+
+      - name: Verify existing npm artifact
+        id: npm-registry
+        run: |
+          python scripts/verify_registry_artifacts.py npm \
+            --package @nuguardai/nuguard \
+            --version "${GITHUB_REF_NAME#v}" \
+            --tarball "npm-dist/nuguardai-nuguard-${GITHUB_REF_NAME#v}.tgz" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Build Smithery bundle
+        run: |
+          uv run python scripts/publish_smithery.py \
+            --dry-run \
+            --skip-pypi \
+            --skip-git-tag \
+            --allow-dirty \
+            --allow-branch
+
+      - name: Prepare verified Smithery CLI
+        env:
+          SMITHERY_CLI_INTEGRITY: sha512-rwczHp2Df6P9P+8Y2YFU/ERrg9QTlLgrMDFt/A1T8VS5vBvoBYjklAEhx6MYiRVbHwBrre5ZrgZfw+N1E+xrdQ==
+        run: |
+          mkdir smithery-cli-dist smithery-cli
+          npm pack smithery@1.2.0 --pack-destination smithery-cli-dist
+          node - <<'NODE'
+          const { createHash } = require("node:crypto");
+          const { readFileSync } = require("node:fs");
+
+          const archive = readFileSync("smithery-cli-dist/smithery-1.2.0.tgz");
+          const actual = `sha512-${createHash("sha512").update(archive).digest("base64")}`;
+          if (actual !== process.env.SMITHERY_CLI_INTEGRITY) {
+            throw new Error(`Smithery CLI integrity mismatch: ${actual}`);
+          }
+          NODE
+          tar -xzf smithery-cli-dist/smithery-1.2.0.tgz \
+            -C smithery-cli \
+            --strip-components=2 \
+            package/dist/index.js
+
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-package-distributions
           path: dist/
+
+      - name: Upload npm package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: npm-package-distribution
+          path: npm-dist/*.tgz
+
+      - name: Upload Smithery bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: smithery-bundle
+          path: |
+            server.mcpb
+            smithery-cli/index.js
 
   publish-pypi:
     name: Publish to PyPI
@@ -98,33 +179,21 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
-
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions
           path: dist/
 
-      - name: Verify existing PyPI artifacts
-        id: pypi-registry
-        run: |
-          python scripts/verify_registry_artifacts.py pypi \
-            --project nuguard \
-            --version "${GITHUB_REF_NAME#v}" \
-            --dist-dir dist \
-            >> "$GITHUB_OUTPUT"
-
       - name: Publish to PyPI
-        if: steps.pypi-registry.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        if: needs.build.outputs.pypi-exists != 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   publish-npm:
     name: Publish to npm
-    needs: publish-pypi
+    needs:
+      - build
+      - publish-pypi
     runs-on: ubuntu-latest
     environment:
       name: npm
@@ -133,73 +202,49 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
-
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Verify existing npm artifact
-        id: npm-registry
-        run: |
-          python scripts/verify_registry_artifacts.py npm \
-            --package @nuguardai/nuguard \
-            --version "${GITHUB_REF_NAME#v}" \
-            --package-dir npm \
-            >> "$GITHUB_OUTPUT"
+      - name: Download npm package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: npm-package-distribution
+          path: npm-dist/
 
       - name: Publish to npm
-        if: steps.npm-registry.outputs.exists != 'true'
-        working-directory: npm/
-        run: npm publish --access public
+        if: needs.build.outputs.npm-exists != 'true'
+        run: npm publish npm-dist/*.tgz --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-smithery:
     name: Update Smithery listing
-    needs: publish-pypi
+    needs:
+      - build
+      - publish-pypi
     runs-on: ubuntu-latest
     environment:
       name: smithery
       url: https://smithery.ai/server/NuGuardAI/nuguard
 
     steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
       - name: Set up Node.js (for smithery CLI)
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
 
-      - name: Install smithery CLI
-        run: npm install -g smithery
-
-      - name: Install script dependencies
-        run: pip install pyyaml
+      - name: Download Smithery bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: smithery-bundle
 
       - name: Publish to Smithery
         env:
           SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
-        run: |
-          python scripts/publish_smithery.py \
-            --version "${GITHUB_REF_NAME#v}" \
-            --skip-pypi \
-            --skip-git-tag \
-            --allow-dirty \
-            --allow-branch
+        run: node smithery-cli/index.js mcp publish server.mcpb -n NuGuardAI/nuguard
 
   finalize-release:
     name: Publish GitHub Release

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,20 +1,73 @@
 name: Publish to PyPI and Smithery
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build distributions
+  validate:
+    name: Validate release contract
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout release tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Verify tag and release metadata
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          VERSION=$(uv version --short)
+          test "$RELEASE_TAG" = "v$VERSION" || {
+            echo "Release tag $RELEASE_TAG does not match package version v$VERSION" >&2
+            exit 1
+          }
+          uv lock --check
+          npm run version:check
+
+  draft-release:
+    name: Create draft GitHub Release
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create or reuse draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" --draft --verify-tag --generate-notes
+
+  build:
+    name: Build distributions
+    needs:
+      - validate
+      - draft-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -41,16 +94,32 @@ jobs:
       name: pypi
       url: https://pypi.org/project/nuguard/
     permissions:
+      contents: read
       id-token: write
 
     steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
 
+      - name: Verify existing PyPI artifacts
+        id: pypi-registry
+        run: |
+          python scripts/verify_registry_artifacts.py pypi \
+            --project nuguard \
+            --version "${GITHUB_REF_NAME#v}" \
+            --dist-dir dist \
+            >> "$GITHUB_OUTPUT"
+
       - name: Publish to PyPI
+        if: steps.pypi-registry.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-npm:
@@ -64,8 +133,10 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout release tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -73,7 +144,17 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Verify existing npm artifact
+        id: npm-registry
+        run: |
+          python scripts/verify_registry_artifacts.py npm \
+            --package @nuguardai/nuguard \
+            --version "${GITHUB_REF_NAME#v}" \
+            --package-dir npm \
+            >> "$GITHUB_OUTPUT"
+
       - name: Publish to npm
+        if: steps.npm-registry.outputs.exists != 'true'
         working-directory: npm/
         run: npm publish --access public
         env:
@@ -88,8 +169,10 @@ jobs:
       url: https://smithery.ai/server/NuGuardAI/nuguard
 
     steps:
-      - name: Checkout
+      - name: Checkout release tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -112,7 +195,25 @@ jobs:
           SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
         run: |
           python scripts/publish_smithery.py \
+            --version "${GITHUB_REF_NAME#v}" \
             --skip-pypi \
             --skip-git-tag \
             --allow-dirty \
             --allow-branch
+
+  finalize-release:
+    name: Publish GitHub Release
+    needs:
+      - publish-npm
+      - publish-smithery
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -2,10 +2,54 @@ name: Publish To TestPyPI
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git tag or commit containing a PEP 440 prerelease version
+        required: true
+        type: string
+
+concurrency:
+  group: testpypi-${{ inputs.ref }}
+  cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate TestPyPI contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout requested ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Verify prerelease metadata
+        run: |
+          uv lock --check
+          npm run version:check
+          uv run python - <<'PY'
+          from packaging.version import Version
+          import tomllib
+
+          with open("pyproject.toml", "rb") as stream:
+              version = Version(tomllib.load(stream)["project"]["version"])
+          if not version.is_prerelease:
+              raise SystemExit(f"TestPyPI requires a prerelease version, got {version}")
+          PY
+
   build:
     name: Build Distributions
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -13,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -52,3 +98,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -2,36 +2,35 @@ name: Publish To TestPyPI
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Git tag or commit containing a PEP 440 prerelease version
-        required: true
-        type: string
 
 concurrency:
-  group: testpypi-${{ inputs.ref }}
+  group: testpypi-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:
   validate:
     name: Validate TestPyPI contract
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      - name: Checkout requested ref
-        uses: actions/checkout@v4
+      - name: Checkout dispatched develop commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ inputs.ref }}
+          persist-credentials: false
+          ref: ${{ github.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        with:
+          enable-cache: false
 
       - name: Verify prerelease metadata
         run: |
@@ -56,23 +55,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ inputs.ref }}
+          persist-credentials: false
+          ref: ${{ github.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        with:
+          enable-cache: false
 
       - name: Build distributions
         run: uv build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-package-distributions
           path: dist/
@@ -89,13 +91,12 @@ jobs:
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true

--- a/documentation/GOVERNANCE.md
+++ b/documentation/GOVERNANCE.md
@@ -14,6 +14,9 @@
 ## Release Ownership
 
 Maintainers are responsible for versioning, release approval, and security sign-off.
+The [NuGuard release runbook](releasing.md) is the canonical procedure for preparing,
+validating, and publishing releases. Only repository maintainers should create or push
+release tags or run production publishing workflows.
 
 ## Evolution
 

--- a/documentation/releasing.md
+++ b/documentation/releasing.md
@@ -27,6 +27,11 @@ uv build
 
 ## Publish a stable release
 
+Repository administrators must protect `v*` tags so only maintainers can create
+or update them. The `pypi`, `npm`, `smithery`, and `testpypi` environments should
+require maintainer approval, and PyPI/TestPyPI trusted publishers must be scoped
+to their corresponding workflow and environment.
+
 After the release commit is merged, create and push an annotated version tag
 that exactly matches the package version:
 
@@ -36,7 +41,11 @@ git push origin v0.9.8
 ```
 
 The production workflow checks out that tag, verifies its version and all
-release metadata, and creates a draft GitHub Release. It then publishes to
+release metadata, and creates a draft GitHub Release. Build jobs pin the tag
+event's immutable commit SHA, disable dependency caches, and prepare the
+artifacts and integrity-verified publishing tools before any job receives
+registry credentials. Credentialed jobs download those artifacts without
+checking out or executing repository code. The workflow then publishes to
 PyPI, npm, and Smithery. The GitHub Release becomes public only after every
 destination succeeds. A failed run leaves the release as a draft; rerun the
 failed workflow jobs after correcting credentials or registry availability.
@@ -51,6 +60,9 @@ provenance.
 ## Publish to TestPyPI
 
 TestPyPI accepts only a committed PEP 440 prerelease version, such as
-`0.9.8rc1`. Run the **Publish To TestPyPI** workflow manually and provide the
-exact tag or commit in its required `ref` input. The workflow validates that
-ref and its release metadata before building or publishing.
+`0.9.8rc1`. Merge the prerelease version commit into `develop`, select
+`develop` in the **Run workflow** branch selector, and run **Publish To
+TestPyPI**. The workflow refuses other branches, pins both jobs to the dispatch
+commit, disables dependency caching, and validates prerelease metadata before
+building or publishing. TestPyPI versions are immutable, so use a new
+prerelease version instead of retrying a version that was already published.

--- a/documentation/releasing.md
+++ b/documentation/releasing.md
@@ -1,0 +1,56 @@
+# Releasing NuGuard
+
+`pyproject.toml` is the canonical source for the NuGuard version. Runtime,
+package, plugin, marketplace, lockfile, and Smithery versions must match it.
+
+## Prepare a release
+
+From a clean branch based on the intended release commit, update every version
+projection with one command:
+
+```bash
+npm run version:bump -- 0.9.8
+```
+
+The command uses `uv version` to update `pyproject.toml` and `uv.lock`, then
+updates all other NuGuard-owned manifests transactionally. If validation or a
+write fails, it restores the original version files.
+
+Validate and commit the complete version change:
+
+```bash
+npm run version:check
+uv lock --check
+uv run pytest tests/test_release_metadata.py tests/test_sync_marketplace_script.py -q
+uv build
+```
+
+## Publish a stable release
+
+After the release commit is merged, create and push an annotated version tag
+that exactly matches the package version:
+
+```bash
+git tag -a v0.9.8 -m "Release v0.9.8"
+git push origin v0.9.8
+```
+
+The production workflow checks out that tag, verifies its version and all
+release metadata, and creates a draft GitHub Release. It then publishes to
+PyPI, npm, and Smithery. The GitHub Release becomes public only after every
+destination succeeds. A failed run leaves the release as a draft; rerun the
+failed workflow jobs after correcting credentials or registry availability.
+On retries, existing PyPI files must match the local SHA-256 digests and an
+existing npm tarball must match the local SRI integrity value. A mismatch or
+registry outage stops the release instead of mixing artifact provenance.
+
+Do not create historical tags as part of a current release. Historical tags
+must be reconciled separately from package publication using verified artifact
+provenance.
+
+## Publish to TestPyPI
+
+TestPyPI accepts only a committed PEP 440 prerelease version, such as
+`0.9.8rc1`. Run the **Publish To TestPyPI** workflow manually and provide the
+exact tag or commit in its required `ref` input. The workflow validates that
+ref and its release metadata before building or publishing.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "sync-marketplace": "node scripts/sync-marketplace.js"
+    "sync-marketplace": "node scripts/sync-marketplace.js",
+    "version:bump": "node scripts/sync-marketplace.js",
+    "version:check": "node scripts/validate-all-plugins.js"
   }
 }

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "AI application security — SBOM generation, static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-    "version": "0.5.3",
+    "version": "0.9.7",
     "repository": "https://github.com/NuGuardAI/nuguard"
   },
   "plugins": [
@@ -15,7 +15,7 @@
       "name": "nuguard",
       "source": "./",
       "description": "AI application security — generate an AI Bill of Materials (AI-SBOM), run static analysis, behavioral validation, and adversarial red-team testing for AI agents and LLM-powered applications.",
-      "version": "0.5.3",
+      "version": "0.9.7",
       "category": "security",
       "tags": [
         "ai-security",

--- a/scripts/publish_smithery.py
+++ b/scripts/publish_smithery.py
@@ -123,8 +123,10 @@ def _run(
     if dry_run:
         print(f"  [dry-run] {' '.join(cmd)}")
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-    result = subprocess.run(cmd, capture_output=capture, text=True, cwd=cwd)
-    return result
+    try:
+        return subprocess.run(cmd, capture_output=capture, text=True, cwd=cwd)
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
 
 
 def _git_is_clean() -> bool:
@@ -159,7 +161,6 @@ def _git_commits_ahead_of_origin() -> int:
 
 def preflight(version: str, allow_dirty: bool, allow_branch: bool, skip_git_tag: bool) -> list[str]:
     errors: list[str] = []
-    warnings: list[str] = []
 
     # Version consistency
     pyproject_ver = _read_pyproject_version()
@@ -179,11 +180,16 @@ def preflight(version: str, allow_dirty: bool, allow_branch: bool, skip_git_tag:
     try:
         init_ver = _read_init_version()
         if init_ver != version:
-            warnings.append(
+            errors.append(
                 f"nuguard/__init__.py __version__={init_ver!r} differs from pyproject.toml {version!r}"
             )
     except ValueError as e:
-        warnings.append(str(e))
+        errors.append(str(e))
+
+    contract = _run(["node", "scripts/validate-all-plugins.js"])
+    if contract.returncode != 0:
+        details = (contract.stdout + contract.stderr).strip()
+        errors.append(f"Release metadata validation failed:\n{details}")
 
     # Git state
     if not allow_dirty and not _git_is_clean():
@@ -210,9 +216,6 @@ def preflight(version: str, allow_dirty: bool, allow_branch: bool, skip_git_tag:
             errors.append(
                 f"Git tag {tag!r} already exists. Bump the version first."
             )
-
-    for w in warnings:
-        print(f"  WARNING: {w}")
 
     return errors
 
@@ -299,7 +302,7 @@ def _build_smithery_bundle(version: str) -> Path:
             "type": "binary",
             "mcp_config": {
                 "command": "uvx",
-                "args": ["--from", "nuguard[mcp]", "nuguard-mcp"],
+                "args": ["--from", f"nuguard[mcp]=={version}", "nuguard-mcp"],
                 "env": env,
             },
         },
@@ -404,7 +407,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
 
-    version = args.version or _read_smithery_version()
+    version = args.version or _read_pyproject_version()
     print(f"nuguard publish {'(dry run) ' if args.dry_run else ''}— v{version}")
     print()
 

--- a/scripts/sync-marketplace.js
+++ b/scripts/sync-marketplace.js
@@ -1,39 +1,162 @@
 #!/usr/bin/env node
 /**
- * Reads the canonical version from pyproject.toml and propagates it to every
- * plugin/marketplace manifest in the repo so they stay in sync.
+ * Optionally bumps the canonical pyproject.toml version with uv, then
+ * transactionally propagates it to every NuGuard-owned version projection.
  */
 import { readFileSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-
-// Canonical version lives in pyproject.toml
-const pyproject = readFileSync(join(ROOT, 'pyproject.toml'), 'utf8');
-const match = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
-if (!match) {
-  console.error('ERROR: version field not found in pyproject.toml');
+const TARGET_VERSION = process.argv[2];
+if (process.env.npm_lifecycle_event === 'version:bump' && !TARGET_VERSION) {
+  console.error('ERROR: version:bump requires a target version');
   process.exit(1);
 }
-const VERSION = match[1];
-console.log(`version: ${VERSION}\n`);
+const JSON_TARGETS = [
+  'npm/package.json',
+  '.claude-plugin/plugin.json',
+  '.claude-plugin/marketplace.json',
+  'plugin/.claude-plugin/plugin.json',
+  'plugin/.claude-plugin/marketplace.json',
+  'marketplace.json',
+  'gemini-extension.json',
+  'openclaw.plugin.json',
+];
+const VERSION_FILES = [
+  'pyproject.toml',
+  'uv.lock',
+  'nuguard/__init__.py',
+  ...JSON_TARGETS,
+  'smithery.yaml',
+];
+let originals = new Map();
+
+function synchronize() {
+  originals = new Map(
+    VERSION_FILES.map(relPath => [relPath, readFileSync(join(ROOT, relPath))]),
+  );
+
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireVersion(object, label) {
+  if (typeof object.version !== 'string' || object.version.length === 0) {
+    throw new Error(`${label} missing string version field`);
+  }
+}
+
+function loadJson(relPath) {
+  const data = JSON.parse(originals.get(relPath).toString('utf8'));
+  return requireObject(data, relPath);
+}
+
+  const jsonDocuments = new Map(JSON_TARGETS.map(path => [path, loadJson(path)]));
+
+for (const path of [
+  'npm/package.json',
+  '.claude-plugin/plugin.json',
+  'plugin/.claude-plugin/plugin.json',
+  'gemini-extension.json',
+  'openclaw.plugin.json',
+]) {
+  requireVersion(jsonDocuments.get(path), path);
+}
+
+for (const path of [
+  '.claude-plugin/marketplace.json',
+  'plugin/.claude-plugin/marketplace.json',
+  'marketplace.json',
+]) {
+  const document = jsonDocuments.get(path);
+  const metadata = requireObject(document.metadata, `${path} metadata`);
+  requireVersion(metadata, `${path} metadata`);
+  if (!Array.isArray(document.plugins) || document.plugins.length === 0) {
+    throw new Error(`${path} plugins must be a non-empty array`);
+  }
+  for (const [index, plugin] of document.plugins.entries()) {
+    requireVersion(requireObject(plugin, `${path} plugins[${index}]`), `${path} plugins[${index}]`);
+  }
+}
+
+  const initSource = originals.get('nuguard/__init__.py').toString('utf8');
+  if (!/^__version__\s*=\s*["'][^"']+["']/m.test(initSource)) {
+    throw new Error('nuguard/__init__.py missing __version__ assignment');
+  }
+  const smitherySource = originals.get('smithery.yaml').toString('utf8');
+  if (!/^version:\s*"[^"]+"/m.test(smitherySource)) {
+    throw new Error('smithery.yaml missing quoted version field');
+  }
+
+  const originalPyproject = originals.get('pyproject.toml').toString('utf8');
+  const originalVersion = originalPyproject.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!originalVersion) {
+    throw new Error('version field not found in pyproject.toml');
+  }
+
+  if (TARGET_VERSION) {
+    const result = spawnSync('uv', ['version', TARGET_VERSION, '--no-sync'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    if (result.error) {
+      throw new Error(`uv version failed: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      const details = (result.stderr || result.stdout || 'unknown error').trim();
+      throw new Error(`uv version failed: ${details}`);
+    }
+  }
+
+  // Canonical version lives in pyproject.toml
+  const pyproject = readFileSync(join(ROOT, 'pyproject.toml'), 'utf8');
+  const match = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error('version field not found in pyproject.toml');
+  }
+  const VERSION = match[1];
+  console.log(`version: ${VERSION}\n`);
 
 function patchJson(relPath, patcher) {
   const abs = join(ROOT, relPath);
-  const data = JSON.parse(readFileSync(abs, 'utf8'));
+  const data = jsonDocuments.get(relPath);
+  const before = JSON.stringify(data);
   patcher(data);
+  if (JSON.stringify(data) === before) {
+    console.log(`  unchanged ${relPath}`);
+    return;
+  }
   writeFileSync(abs, JSON.stringify(data, null, 2) + '\n');
   console.log(`  updated ${relPath}`);
 }
 
 function patchYaml(relPath) {
   const abs = join(ROOT, relPath);
-  const src = readFileSync(abs, 'utf8');
+  const src = originals.get(relPath).toString('utf8');
   const out = src.replace(/^version:\s*"[^"]*"/m, `version: "${VERSION}"`);
+  if (out === src) {
+    console.log(`  unchanged ${relPath}`);
+    return;
+  }
   writeFileSync(abs, out);
   console.log(`  updated ${relPath}`);
 }
+
+  const updatedInit = initSource.replace(
+    /^(__version__\s*=\s*)["'][^"']+["']/m,
+    `$1"${VERSION}"`,
+  );
+  if (updatedInit === initSource) {
+    console.log('  unchanged nuguard/__init__.py');
+  } else {
+    writeFileSync(join(ROOT, 'nuguard/__init__.py'), updatedInit);
+    console.log('  updated nuguard/__init__.py');
+  }
 
 // npm package
 patchJson('npm/package.json', d => { d.version = VERSION; });
@@ -65,4 +188,16 @@ patchJson('openclaw.plugin.json', d => { d.version = VERSION; });
 // Smithery YAML
 patchYaml('smithery.yaml');
 
-console.log(`\nAll manifests synced to ${VERSION}`);
+  console.log(`\nAll manifests synced to ${VERSION}`);
+}
+
+try {
+  synchronize();
+} catch (error) {
+  for (const [relPath, content] of originals) {
+    writeFileSync(join(ROOT, relPath), content);
+  }
+  console.error(`ERROR: ${error.message}`);
+  console.error('All version files were restored.');
+  process.exit(1);
+}

--- a/scripts/validate-all-plugins.js
+++ b/scripts/validate-all-plugins.js
@@ -28,19 +28,64 @@ function readJson(relPath) {
   }
 }
 
+function readText(relPath) {
+  const abs = join(ROOT, relPath);
+  if (!existsSync(abs)) { fail(`${relPath} not found`); return null; }
+  try {
+    return readFileSync(abs, 'utf8');
+  } catch (e) {
+    fail(`${relPath} could not be read: ${e.message}`);
+    return null;
+  }
+}
+
 function checkExists(relPath, label) {
   if (!existsSync(join(ROOT, relPath))) { fail(`${label}: path not found — ${relPath}`); return false; }
   ok(`${label} exists`);
   return true;
 }
 
+function checkDeclaredPaths(value, basePath, label) {
+  const paths = typeof value === 'string' ? [value] : value;
+  if (!Array.isArray(paths) || paths.some(path => typeof path !== 'string')) {
+    fail(`${label}: expected a string or array of strings`);
+    return;
+  }
+  for (const path of paths) {
+    checkExists(join(basePath, path.replace(/^\.\//, '')), label);
+  }
+}
+
 // ── 1. Canonical version ──────────────────────────────────────────────────────
 console.log('\n[1] Canonical version');
-const pyproject = readFileSync(join(ROOT, 'pyproject.toml'), 'utf8');
+const pyproject = readText('pyproject.toml');
+if (pyproject === null) process.exit(1);
 const vMatch = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
 if (!vMatch) { fail('version not found in pyproject.toml'); process.exit(1); }
 const VERSION = vMatch[1];
 ok(`pyproject.toml version = ${VERSION}`);
+
+const runtime = readText('nuguard/__init__.py');
+if (runtime !== null) {
+  const runtimeMatch = runtime.match(/^__version__\s*=\s*["']([^"']+)["']/m);
+  if (!runtimeMatch) fail('nuguard/__init__.py __version__ not found');
+  else if (runtimeMatch[1] !== VERSION) fail(`nuguard/__init__.py version ${runtimeMatch[1]} ≠ ${VERSION}`);
+  else ok(`nuguard/__init__.py version = ${runtimeMatch[1]}`);
+}
+
+const lockfile = readText('uv.lock');
+if (lockfile !== null) {
+  const projectPackages = lockfile
+    .split(/^\[\[package\]\]\s*$/m)
+    .filter(block => /^name\s*=\s*"nuguard"\s*$/m.test(block));
+  if (projectPackages.length !== 1) fail(`uv.lock expected one nuguard package, found ${projectPackages.length}`);
+  else {
+    const lockMatch = projectPackages[0].match(/^version\s*=\s*"([^"]+)"/m);
+    if (!lockMatch) fail('uv.lock nuguard package missing version');
+    else if (lockMatch[1] !== VERSION) fail(`uv.lock nuguard version ${lockMatch[1]} ≠ ${VERSION}`);
+    else ok(`uv.lock nuguard version = ${lockMatch[1]}`);
+  }
+}
 
 // ── 2. Root .claude-plugin/plugin.json ───────────────────────────────────────
 console.log('\n[2] Root .claude-plugin/plugin.json');
@@ -55,7 +100,7 @@ if (rootPlugin) {
     if (rootPlugin[field]) fail(`.claude-plugin/plugin.json must not declare "${field}" as a string path — use root symlinks for auto-discovery`);
   }
 
-  if (rootPlugin.mcpServers) checkExists(rootPlugin.mcpServers.replace(/^\.\//, ''), 'mcpServers path');
+  if (rootPlugin.mcpServers) checkDeclaredPaths(rootPlugin.mcpServers, '', 'mcpServers path');
 }
 
 // Root symlinks enable convention-based auto-discovery
@@ -74,7 +119,7 @@ if (subPlugin) {
 
   // agents is declared in plugin.json; commands/skills are in marketplace.json
   if (!subPlugin.agents) warn('plugin/.claude-plugin/plugin.json missing "agents" field');
-  else checkExists(join('plugin', subPlugin.agents).replace(/\/\.\//g, '/'), 'plugin agents path');
+  else checkDeclaredPaths(subPlugin.agents, 'plugin', 'plugin agents path');
 }
 
 // ── 4. Marketplace manifests ──────────────────────────────────────────────────
@@ -87,10 +132,20 @@ for (const relPath of ['.claude-plugin/marketplace.json', 'plugin/.claude-plugin
   else if (mv !== VERSION) fail(`${relPath} metadata.version ${mv} ≠ ${VERSION}`);
   else ok(`${relPath} metadata.version = ${mv}`);
 
-  for (const p of (m.plugins || [])) {
-    if (p.version && p.version !== VERSION)
-      fail(`${relPath} plugins[].version ${p.version} ≠ ${VERSION}`);
-    else if (p.version) ok(`${relPath} plugins[${p.name}].version = ${p.version}`);
+  if (!Array.isArray(m.plugins)) {
+    fail(`${relPath} plugins must be an array`);
+  } else {
+    for (const p of m.plugins) {
+      if (!p || typeof p !== 'object' || Array.isArray(p)) {
+        fail(`${relPath} plugins[] must contain objects`);
+      } else if (!p.version) {
+        fail(`${relPath} plugins[] missing version`);
+      } else if (p.version !== VERSION) {
+        fail(`${relPath} plugins[].version ${p.version} ≠ ${VERSION}`);
+      } else {
+        ok(`${relPath} plugins[${p.name}].version = ${p.version}`);
+      }
+    }
   }
 }
 
@@ -111,11 +166,13 @@ for (const [relPath, vPath] of [
 }
 
 // smithery.yaml
-const smithery = readFileSync(join(ROOT, 'smithery.yaml'), 'utf8');
-const sy = smithery.match(/^version:\s*"([^"]+)"/m);
-if (!sy) fail('smithery.yaml version not found');
-else if (sy[1] !== VERSION) fail(`smithery.yaml version ${sy[1]} ≠ ${VERSION}`);
-else ok(`smithery.yaml version = ${sy[1]}`);
+const smithery = readText('smithery.yaml');
+if (smithery !== null) {
+  const sy = smithery.match(/^version:\s*"([^"]+)"/m);
+  if (!sy) fail('smithery.yaml version not found');
+  else if (sy[1] !== VERSION) fail(`smithery.yaml version ${sy[1]} ≠ ${VERSION}`);
+  else ok(`smithery.yaml version = ${sy[1]}`);
+}
 
 // ── 6. Agent files ────────────────────────────────────────────────────────────
 console.log('\n[6] Agent files');
@@ -124,7 +181,7 @@ if (existsSync(agentsDir)) {
   const { readdirSync } = await import('fs');
   for (const f of readdirSync(agentsDir).filter(f => f.endsWith('.md'))) {
     const src = readFileSync(join(agentsDir, f), 'utf8');
-    const fm = src.match(/^---\n([\s\S]*?)\n---/);
+    const fm = src.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!fm) { fail(`plugin/agents/${f}: no YAML frontmatter`); continue; }
     for (const field of ['name', 'description', 'model', 'color']) {
       if (!fm[1].includes(`${field}:`)) fail(`plugin/agents/${f}: frontmatter missing "${field}"`);

--- a/scripts/verify_registry_artifacts.py
+++ b/scripts/verify_registry_artifacts.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Verify that existing registry artifacts match locally built release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+class VerificationError(RuntimeError):
+    """Raised when registry state cannot be safely treated as a retry."""
+
+
+def _load_registry_json(url: str) -> dict[str, Any] | None:
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise VerificationError(f"Registry request failed with HTTP {exc.code}: {url}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise VerificationError(f"Registry request failed: {url}: {exc}") from exc
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise VerificationError(f"Registry returned invalid JSON: {url}") from exc
+
+    if not isinstance(payload, dict):
+        raise VerificationError(f"Registry returned a non-object response: {url}")
+    return payload
+
+
+def verify_pypi(project: str, version: str, dist_dir: Path) -> bool:
+    """Return whether PyPI has the exact local artifact set for a version."""
+    artifacts = sorted(path for path in dist_dir.iterdir() if path.is_file())
+    if not artifacts:
+        raise VerificationError(f"No release artifacts found in {dist_dir}")
+
+    encoded_project = urllib.parse.quote(project, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    payload = _load_registry_json(
+        f"https://pypi.org/pypi/{encoded_project}/{encoded_version}/json"
+    )
+    if payload is None:
+        return False
+
+    urls = payload.get("urls")
+    if not isinstance(urls, list):
+        raise VerificationError("PyPI response is missing the artifact list")
+
+    remote_hashes: dict[str, str] = {}
+    for item in urls:
+        if not isinstance(item, dict):
+            raise VerificationError("PyPI artifact entry is not an object")
+        filename = item.get("filename")
+        digests = item.get("digests")
+        sha256 = digests.get("sha256") if isinstance(digests, dict) else None
+        if not isinstance(filename, str) or not isinstance(sha256, str):
+            raise VerificationError("PyPI artifact entry is missing filename or SHA-256")
+        remote_hashes[filename] = sha256.lower()
+
+    local_hashes = {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in artifacts
+    }
+    if remote_hashes != local_hashes:
+        raise VerificationError(
+            "PyPI already contains this version, but its artifact names or SHA-256 "
+            "digests do not match the tagged build"
+        )
+    return True
+
+
+def _npm_package_metadata(package_dir: Path) -> dict[str, Any]:
+    npm = shutil.which("npm")
+    if npm is None:
+        raise VerificationError("npm is required to verify npm artifacts")
+    try:
+        result = subprocess.run(
+            [npm, "pack", "--dry-run", "--json"],
+            cwd=package_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise VerificationError("npm is required to verify npm artifacts") from exc
+    if result.returncode != 0:
+        raise VerificationError(f"npm pack failed: {(result.stderr or result.stdout).strip()}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise VerificationError("npm pack returned invalid JSON") from exc
+    if not isinstance(payload, list) or len(payload) != 1 or not isinstance(payload[0], dict):
+        raise VerificationError("npm pack returned an unexpected artifact list")
+    return payload[0]
+
+
+def verify_npm(package_name: str, version: str, package_dir: Path) -> bool:
+    """Return whether npm has the exact locally packable artifact for a version."""
+    local = _npm_package_metadata(package_dir)
+    if local.get("name") != package_name or local.get("version") != version:
+        raise VerificationError("Local npm package name or version does not match the release")
+    local_integrity = local.get("integrity")
+    if not isinstance(local_integrity, str):
+        raise VerificationError("npm pack did not report artifact integrity")
+
+    encoded_name = urllib.parse.quote(package_name, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    payload = _load_registry_json(
+        f"https://registry.npmjs.org/{encoded_name}/{encoded_version}"
+    )
+    if payload is None:
+        return False
+
+    dist = payload.get("dist")
+    remote_integrity = dist.get("integrity") if isinstance(dist, dict) else None
+    if not isinstance(remote_integrity, str):
+        raise VerificationError("npm response is missing dist.integrity")
+    if not _integrity_matches(local_integrity, remote_integrity):
+        raise VerificationError(
+            "npm already contains this version, but its artifact integrity does not "
+            "match the tagged build"
+        )
+    return True
+
+
+def _integrity_matches(local: str, remote: str) -> bool:
+    algorithm, separator, _ = local.partition("-")
+    if not separator or algorithm != "sha512":
+        raise VerificationError(f"Unsupported npm integrity algorithm: {algorithm!r}")
+    return hmac.compare_digest(local, remote)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="registry", required=True)
+
+    pypi = subparsers.add_parser("pypi")
+    pypi.add_argument("--project", required=True)
+    pypi.add_argument("--version", required=True)
+    pypi.add_argument("--dist-dir", type=Path, required=True)
+
+    npm = subparsers.add_parser("npm")
+    npm.add_argument("--package", required=True)
+    npm.add_argument("--version", required=True)
+    npm.add_argument("--package-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        if args.registry == "pypi":
+            exists = verify_pypi(args.project, args.version, args.dist_dir)
+        else:
+            exists = verify_npm(args.package, args.version, args.package_dir)
+    except VerificationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"exists={str(exists).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_registry_artifacts.py
+++ b/scripts/verify_registry_artifacts.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import hmac
 import json
-import shutil
-import subprocess
 import sys
+import tarfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -79,39 +79,28 @@ def verify_pypi(project: str, version: str, dist_dir: Path) -> bool:
     return True
 
 
-def _npm_package_metadata(package_dir: Path) -> dict[str, Any]:
-    npm = shutil.which("npm")
-    if npm is None:
-        raise VerificationError("npm is required to verify npm artifacts")
+def _npm_package_metadata(tarball: Path) -> dict[str, Any]:
     try:
-        result = subprocess.run(
-            [npm, "pack", "--dry-run", "--json"],
-            cwd=package_dir,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        raise VerificationError("npm is required to verify npm artifacts") from exc
-    if result.returncode != 0:
-        raise VerificationError(f"npm pack failed: {(result.stderr or result.stdout).strip()}")
-    try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
-        raise VerificationError("npm pack returned invalid JSON") from exc
-    if not isinstance(payload, list) or len(payload) != 1 or not isinstance(payload[0], dict):
-        raise VerificationError("npm pack returned an unexpected artifact list")
-    return payload[0]
+        with tarfile.open(tarball, "r:gz") as archive:
+            package_json = archive.extractfile("package/package.json")
+            if package_json is None:
+                raise VerificationError("npm tarball is missing package/package.json")
+            payload = json.load(package_json)
+    except (OSError, tarfile.TarError, KeyError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"Could not read npm tarball metadata: {tarball}") from exc
+    if not isinstance(payload, dict):
+        raise VerificationError("npm tarball package.json is not an object")
+    return payload
 
 
-def verify_npm(package_name: str, version: str, package_dir: Path) -> bool:
+def verify_npm(package_name: str, version: str, tarball: Path) -> bool:
     """Return whether npm has the exact locally packable artifact for a version."""
-    local = _npm_package_metadata(package_dir)
+    local = _npm_package_metadata(tarball)
     if local.get("name") != package_name or local.get("version") != version:
         raise VerificationError("Local npm package name or version does not match the release")
-    local_integrity = local.get("integrity")
-    if not isinstance(local_integrity, str):
-        raise VerificationError("npm pack did not report artifact integrity")
+    local_integrity = "sha512-" + base64.b64encode(
+        hashlib.sha512(tarball.read_bytes()).digest()
+    ).decode("ascii")
 
     encoded_name = urllib.parse.quote(package_name, safe="")
     encoded_version = urllib.parse.quote(version, safe="")
@@ -152,7 +141,7 @@ def _parse_args() -> argparse.Namespace:
     npm = subparsers.add_parser("npm")
     npm.add_argument("--package", required=True)
     npm.add_argument("--version", required=True)
-    npm.add_argument("--package-dir", type=Path, required=True)
+    npm.add_argument("--tarball", type=Path, required=True)
     return parser.parse_args()
 
 
@@ -162,7 +151,7 @@ def main() -> int:
         if args.registry == "pypi":
             exists = verify_pypi(args.project, args.version, args.dist_dir)
         else:
-            exists = verify_npm(args.package, args.version, args.package_dir)
+            exists = verify_npm(args.package, args.version, args.tarball)
     except VerificationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,7 @@
 # Smithery manifest — Claude marketplace MCP server
 # https://smithery.ai/docs/config
 name: nuguard
-version: "0.9.6"
+version: "0.9.7"
 description: |
   AI Application Security — generate an AI Bill of Materials (AI-SBOM), run static
   analysis, behavioral validation, and adversarial red-team testing for AI agents

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -99,7 +99,8 @@ def _checkout_refs(job: dict[str, object]) -> list[str]:
     for step in steps:
         if not isinstance(step, dict):
             continue
-        if step.get("uses") != "actions/checkout@v4":
+        uses = step.get("uses")
+        if not isinstance(uses, str) or not uses.startswith("actions/checkout@"):
             continue
         with_block = step.get("with")
         assert isinstance(with_block, dict), "checkout step with: expected mapping"
@@ -163,8 +164,8 @@ def test_release_metadata_matches_pyproject_version() -> None:
     assert project_packages[0]["version"] == expected
 
 
-def test_publish_pypi_workflow_requires_tag_push_and_tag_checkout() -> None:
-    """Production publishing must run only for version tags and check out that tag."""
+def test_publish_pypi_workflow_requires_tag_push_and_event_sha_checkout() -> None:
+    """Production publishing must run for version tags and pin the event commit."""
     workflow = _load_workflow("publish-pypi.yml")
     events = _workflow_events(workflow)
 
@@ -173,11 +174,13 @@ def test_publish_pypi_workflow_requires_tag_push_and_tag_checkout() -> None:
     assert isinstance(push, dict)
     assert push.get("tags") == ["v*"]
 
-    tag_ref = "${{ github.ref_name }}"
-    for name in ["validate", "build", "publish-pypi", "publish-npm", "publish-smithery"]:
+    tag_ref = "${{ github.sha }}"
+    for name in ["validate", "build"]:
         refs = _checkout_refs(_job(workflow, name))
         assert refs, f"{name}: expected at least one checkout step"
         assert set(refs) == {tag_ref}
+    for name in ["publish-pypi", "publish-npm", "publish-smithery"]:
+        assert not _checkout_refs(_job(workflow, name))
 
 
 def test_publish_pypi_workflow_validates_metadata_before_build() -> None:
@@ -198,8 +201,11 @@ def test_publish_pypi_publication_job_dependencies_are_strict() -> None:
     """PyPI publication jobs must preserve dependency order for safe releases."""
     workflow = _load_workflow("publish-pypi.yml")
     assert _job_needs(_job(workflow, "publish-pypi")) == {"build"}
-    assert _job_needs(_job(workflow, "publish-npm")) == {"publish-pypi"}
-    assert _job_needs(_job(workflow, "publish-smithery")) == {"publish-pypi"}
+    assert _job_needs(_job(workflow, "publish-npm")) == {"build", "publish-pypi"}
+    assert _job_needs(_job(workflow, "publish-smithery")) == {
+        "build",
+        "publish-pypi",
+    }
     assert _job_needs(_job(workflow, "draft-release")) == {"validate"}
     assert _job_needs(_job(workflow, "finalize-release")) == {
         "publish-npm",
@@ -216,23 +222,72 @@ def test_publish_pypi_publication_job_dependencies_are_strict() -> None:
 def test_publish_workflow_verifies_registry_artifact_provenance() -> None:
     """Existing versions may be skipped only after exact artifact verification."""
     workflow = _load_workflow("publish-pypi.yml")
+    build_job = _job(workflow, "build")
     pypi_job = _job(workflow, "publish-pypi")
     npm_job = _job(workflow, "publish-npm")
 
-    pypi_script = _step_run(pypi_job, "Verify existing PyPI artifacts")
+    pypi_script = _step_run(build_job, "Verify existing PyPI artifacts")
     assert "verify_registry_artifacts.py pypi" in pypi_script
-    npm_script = _step_run(npm_job, "Verify existing npm artifact")
+    npm_script = _step_run(build_job, "Verify existing npm artifact")
     assert "verify_registry_artifacts.py npm" in npm_script
     assert _step(pypi_job, "Publish to PyPI").get("if") == (
-        "steps.pypi-registry.outputs.exists != 'true'"
+        "needs.build.outputs.pypi-exists != 'true'"
     )
     assert _step(npm_job, "Publish to npm").get("if") == (
-        "steps.npm-registry.outputs.exists != 'true'"
+        "needs.build.outputs.npm-exists != 'true'"
     )
 
     workflow_text = (_WORKFLOWS / "publish-pypi.yml").read_text(encoding="utf-8")
     assert "skip-existing" not in workflow_text
     assert "npm view" not in workflow_text
+
+
+def test_modified_workflows_pin_third_party_actions() -> None:
+    """Release and PR workflows must not execute mutable third-party action refs."""
+    for workflow_name in ["pr-tests.yml", "publish-pypi.yml", "publish-testpypi.yml"]:
+        workflow_text = (_WORKFLOWS / workflow_name).read_text(encoding="utf-8")
+        uses = re.findall(r"^\s*uses:\s*[^@\s]+@([^\s#]+)", workflow_text, re.MULTILINE)
+        assert uses, f"{workflow_name}: expected action references"
+        assert all(re.fullmatch(r"[0-9a-f]{40}", ref) for ref in uses), (
+            f"{workflow_name}: mutable action reference found: {uses}"
+        )
+
+
+def test_modified_workflows_do_not_persist_checkout_credentials() -> None:
+    """Jobs executing repository code must not retain the checkout token."""
+    for workflow_name in ["pr-tests.yml", "publish-pypi.yml", "publish-testpypi.yml"]:
+        workflow = _load_workflow(workflow_name)
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                if str(step.get("uses", "")).startswith("actions/checkout@"):
+                    assert step.get("with", {}).get("persist-credentials") is False
+
+
+def test_privileged_publish_jobs_do_not_execute_repository_code() -> None:
+    """Credentialed production jobs may only download and publish built artifacts."""
+    workflow = _load_workflow("publish-pypi.yml")
+    for job_name in ["publish-pypi", "publish-npm", "publish-smithery"]:
+        job = _job(workflow, job_name)
+        assert not _checkout_refs(job)
+        steps = job.get("steps")
+        assert isinstance(steps, list)
+        run_scripts = "\n".join(
+            str(step.get("run", "")) for step in steps if isinstance(step, dict)
+        )
+        assert "scripts/" not in run_scripts
+
+    smithery_job = _job(workflow, "publish-smithery")
+    smithery_scripts = "\n".join(
+        str(step.get("run", ""))
+        for step in smithery_job.get("steps", [])
+        if isinstance(step, dict)
+    )
+    assert "npm install" not in smithery_scripts
+
+    build_job = _job(workflow, "build")
+    prepare_script = _step_run(build_job, "Prepare verified Smithery CLI")
+    assert "npm pack smithery@1.2.0" in prepare_script
+    assert "SMITHERY_CLI_INTEGRITY" in prepare_script
 
 
 def test_publish_helper_reports_missing_executable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -249,27 +304,33 @@ def test_publish_helper_reports_missing_executable(monkeypatch: pytest.MonkeyPat
     assert "node not found" in result.stderr
 
 
-def test_publish_testpypi_workflow_requires_explicit_ref_and_validation_gate() -> None:
-    """TestPyPI workflow must require manual ref input and validate before build."""
+def test_publish_testpypi_workflow_restricts_execution_to_develop() -> None:
+    """TestPyPI must pin trusted develop code and validate it before building."""
     workflow = _load_workflow("publish-testpypi.yml")
     events = _workflow_events(workflow)
 
     dispatch = events.get("workflow_dispatch")
-    assert isinstance(dispatch, dict)
-    inputs = dispatch.get("inputs")
-    assert isinstance(inputs, dict)
-    ref_input = inputs.get("ref")
-    assert isinstance(ref_input, dict)
-    assert ref_input.get("required") is True
-    assert ref_input.get("type") == "string"
+    assert dispatch is None
 
-    expected_ref = "${{ inputs.ref }}"
+    expected_ref = "${{ github.sha }}"
     for name in ["validate", "build"]:
         refs = _checkout_refs(_job(workflow, name))
         assert refs, f"{name}: expected checkout step"
         assert set(refs) == {expected_ref}
 
-    validate_script = _step_run(_job(workflow, "validate"), "Verify prerelease metadata")
+    validate_job = _job(workflow, "validate")
+    assert validate_job.get("if") == "github.ref == 'refs/heads/develop'"
+
+    for name in ["validate", "build"]:
+        setup_uv = next(
+            step
+            for step in _job(workflow, name)["steps"]
+            if isinstance(step, dict)
+            and str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+        )
+        assert setup_uv.get("with") == {"enable-cache": False}
+
+    validate_script = _step_run(validate_job, "Verify prerelease metadata")
     assert "uv lock --check" in validate_script
     assert "npm run version:check" in validate_script
     assert "version.is_prerelease" in validate_script
@@ -277,6 +338,9 @@ def test_publish_testpypi_workflow_requires_explicit_ref_and_validation_gate() -
 
     assert _job_needs(_job(workflow, "build")) == {"validate"}
     assert _job_needs(_job(workflow, "publish")) == {"build"}
+
+    workflow_text = (_WORKFLOWS / "publish-testpypi.yml").read_text(encoding="utf-8")
+    assert "skip-existing" not in workflow_text
 
 
 def test_build_smithery_bundle_pins_exact_mcp_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,328 @@
+"""Release metadata must project one canonical NuGuard version."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import tomllib
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOWS = _ROOT / ".github" / "workflows"
+
+
+def _json_version(path: str, *keys: str) -> str:
+    value: object = json.loads((_ROOT / path).read_text(encoding="utf-8"))
+    for key in keys:
+        if isinstance(value, dict):
+            value = value[key]
+        else:
+            assert isinstance(value, list), f"{path}: expected container before {key!r}"
+            value = value[int(key)]
+    assert isinstance(value, str), f"{path}: expected string at {'.'.join(keys)}"
+    return value
+
+
+def _marketplace_versions(path: str) -> dict[str, str]:
+    document = json.loads((_ROOT / path).read_text(encoding="utf-8"))
+    assert isinstance(document, dict), f"{path}: expected object"
+    metadata = document.get("metadata")
+    plugins = document.get("plugins")
+    assert isinstance(metadata, dict), f"{path}: expected metadata object"
+    assert isinstance(plugins, list), f"{path}: expected plugins array"
+    assert plugins, f"{path}: expected at least one plugin"
+    versions = {f"{path} metadata": str(metadata.get("version", ""))}
+    for index, plugin in enumerate(plugins):
+        assert isinstance(plugin, dict), f"{path}: plugin {index} must be an object"
+        versions[f"{path} plugin {index}"] = str(plugin.get("version", ""))
+    return versions
+
+
+def _load_workflow(name: str) -> dict[str, object]:
+    workflow = yaml.safe_load((_WORKFLOWS / name).read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict), f"{name}: expected mapping"
+    return workflow
+
+
+def _workflow_events(workflow: dict[str, object]) -> dict[str, object]:
+    # PyYAML may parse the key "on" as a boolean under YAML 1.1 semantics.
+    events = workflow.get("on")
+    if events is None:
+        events = workflow.get(True)
+    assert isinstance(events, dict), "workflow on: expected mapping"
+    return events
+
+
+def _job(workflow: dict[str, object], name: str) -> dict[str, object]:
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "workflow jobs: expected mapping"
+    job = jobs.get(name)
+    assert isinstance(job, dict), f"job {name!r}: expected mapping"
+    return job
+
+
+def _job_needs(job: dict[str, object]) -> set[str]:
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        return {needs}
+    assert isinstance(needs, list), "job needs: expected string or list"
+    assert all(isinstance(item, str) for item in needs)
+    return set(needs)
+
+
+def _step_run(job: dict[str, object], step_name: str) -> str:
+    step = _step(job, step_name)
+    run_value = step.get("run")
+    assert isinstance(run_value, str), f"step {step_name!r}: expected run script"
+    return run_value
+
+
+def _step(job: dict[str, object], step_name: str) -> dict[str, object]:
+    steps = job.get("steps")
+    assert isinstance(steps, list), "job steps: expected list"
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            return step
+    raise AssertionError(f"step {step_name!r} not found")
+
+
+def _checkout_refs(job: dict[str, object]) -> list[str]:
+    refs: list[str] = []
+    steps = job.get("steps")
+    assert isinstance(steps, list), "job steps: expected list"
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("uses") != "actions/checkout@v4":
+            continue
+        with_block = step.get("with")
+        assert isinstance(with_block, dict), "checkout step with: expected mapping"
+        ref = with_block.get("ref")
+        assert isinstance(ref, str), "checkout step ref: expected string"
+        refs.append(ref)
+    return refs
+
+
+def _load_publish_smithery_module() -> types.ModuleType:
+    script = _ROOT / "scripts" / "publish_smithery.py"
+    spec = importlib.util.spec_from_file_location("publish_smithery_script", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_metadata_matches_pyproject_version() -> None:
+    """Every release-facing manifest must match the canonical pyproject version."""
+    pyproject = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    expected = pyproject["project"]["version"]
+
+    init_text = (_ROOT / "nuguard" / "__init__.py").read_text(encoding="utf-8")
+    init_match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', init_text, re.MULTILINE)
+    assert init_match, "nuguard/__init__.py: __version__ not found"
+
+    smithery = yaml.safe_load((_ROOT / "smithery.yaml").read_text(encoding="utf-8"))
+    assert isinstance(smithery, dict), "smithery.yaml: expected mapping"
+
+    versions = {
+        "nuguard/__init__.py": init_match.group(1),
+        "npm/package.json": _json_version("npm/package.json", "version"),
+        ".claude-plugin/plugin.json": _json_version(
+            ".claude-plugin/plugin.json", "version"
+        ),
+        "plugin/.claude-plugin/plugin.json": _json_version(
+            "plugin/.claude-plugin/plugin.json", "version"
+        ),
+        "gemini-extension.json": _json_version("gemini-extension.json", "version"),
+        "openclaw.plugin.json": _json_version("openclaw.plugin.json", "version"),
+        "smithery.yaml": str(smithery.get("version", "")),
+    }
+    for marketplace in [
+        ".claude-plugin/marketplace.json",
+        "plugin/.claude-plugin/marketplace.json",
+        "marketplace.json",
+    ]:
+        versions.update(_marketplace_versions(marketplace))
+
+    mismatches = {
+        source: version for source, version in versions.items() if version != expected
+    }
+    assert not mismatches, f"Expected every release version to equal {expected}: {mismatches}"
+
+    lock = tomllib.loads((_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    project_packages = [
+        package for package in lock["package"] if package.get("name") == "nuguard"
+    ]
+    assert len(project_packages) == 1
+    assert project_packages[0]["version"] == expected
+
+
+def test_publish_pypi_workflow_requires_tag_push_and_tag_checkout() -> None:
+    """Production publishing must run only for version tags and check out that tag."""
+    workflow = _load_workflow("publish-pypi.yml")
+    events = _workflow_events(workflow)
+
+    assert "workflow_dispatch" not in events
+    push = events.get("push")
+    assert isinstance(push, dict)
+    assert push.get("tags") == ["v*"]
+
+    tag_ref = "${{ github.ref_name }}"
+    for name in ["validate", "build", "publish-pypi", "publish-npm", "publish-smithery"]:
+        refs = _checkout_refs(_job(workflow, name))
+        assert refs, f"{name}: expected at least one checkout step"
+        assert set(refs) == {tag_ref}
+
+
+def test_publish_pypi_workflow_validates_metadata_before_build() -> None:
+    """PyPI workflow validate job must gate build with tag/version and metadata checks."""
+    workflow = _load_workflow("publish-pypi.yml")
+    validate_job = _job(workflow, "validate")
+    build_job = _job(workflow, "build")
+
+    script = _step_run(validate_job, "Verify tag and release metadata")
+    assert "test \"$RELEASE_TAG\" = \"v$VERSION\"" in script
+    assert "uv lock --check" in script
+    assert "npm run version:check" in script
+
+    assert _job_needs(build_job) == {"validate", "draft-release"}
+
+
+def test_publish_pypi_publication_job_dependencies_are_strict() -> None:
+    """PyPI publication jobs must preserve dependency order for safe releases."""
+    workflow = _load_workflow("publish-pypi.yml")
+    assert _job_needs(_job(workflow, "publish-pypi")) == {"build"}
+    assert _job_needs(_job(workflow, "publish-npm")) == {"publish-pypi"}
+    assert _job_needs(_job(workflow, "publish-smithery")) == {"publish-pypi"}
+    assert _job_needs(_job(workflow, "draft-release")) == {"validate"}
+    assert _job_needs(_job(workflow, "finalize-release")) == {
+        "publish-npm",
+        "publish-smithery",
+    }
+
+    draft_script = _step_run(_job(workflow, "draft-release"), "Create or reuse draft release")
+    assert "gh release create" in draft_script
+    assert "--draft" in draft_script
+    finalize_script = _step_run(_job(workflow, "finalize-release"), "Publish draft release")
+    assert 'gh release edit "$RELEASE_TAG" --draft=false' in finalize_script
+
+
+def test_publish_workflow_verifies_registry_artifact_provenance() -> None:
+    """Existing versions may be skipped only after exact artifact verification."""
+    workflow = _load_workflow("publish-pypi.yml")
+    pypi_job = _job(workflow, "publish-pypi")
+    npm_job = _job(workflow, "publish-npm")
+
+    pypi_script = _step_run(pypi_job, "Verify existing PyPI artifacts")
+    assert "verify_registry_artifacts.py pypi" in pypi_script
+    npm_script = _step_run(npm_job, "Verify existing npm artifact")
+    assert "verify_registry_artifacts.py npm" in npm_script
+    assert _step(pypi_job, "Publish to PyPI").get("if") == (
+        "steps.pypi-registry.outputs.exists != 'true'"
+    )
+    assert _step(npm_job, "Publish to npm").get("if") == (
+        "steps.npm-registry.outputs.exists != 'true'"
+    )
+
+    workflow_text = (_WORKFLOWS / "publish-pypi.yml").read_text(encoding="utf-8")
+    assert "skip-existing" not in workflow_text
+    assert "npm view" not in workflow_text
+
+
+def test_publish_helper_reports_missing_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Publisher prerequisites should fail preflight without an uncaught traceback."""
+    module = _load_publish_smithery_module()
+
+    def raise_missing(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("node not found")
+
+    monkeypatch.setattr(module.subprocess, "run", raise_missing)
+    result = module._run(["node", "scripts/validate-all-plugins.js"])
+
+    assert result.returncode == 127
+    assert "node not found" in result.stderr
+
+
+def test_publish_testpypi_workflow_requires_explicit_ref_and_validation_gate() -> None:
+    """TestPyPI workflow must require manual ref input and validate before build."""
+    workflow = _load_workflow("publish-testpypi.yml")
+    events = _workflow_events(workflow)
+
+    dispatch = events.get("workflow_dispatch")
+    assert isinstance(dispatch, dict)
+    inputs = dispatch.get("inputs")
+    assert isinstance(inputs, dict)
+    ref_input = inputs.get("ref")
+    assert isinstance(ref_input, dict)
+    assert ref_input.get("required") is True
+    assert ref_input.get("type") == "string"
+
+    expected_ref = "${{ inputs.ref }}"
+    for name in ["validate", "build"]:
+        refs = _checkout_refs(_job(workflow, name))
+        assert refs, f"{name}: expected checkout step"
+        assert set(refs) == {expected_ref}
+
+    validate_script = _step_run(_job(workflow, "validate"), "Verify prerelease metadata")
+    assert "uv lock --check" in validate_script
+    assert "npm run version:check" in validate_script
+    assert "version.is_prerelease" in validate_script
+    assert "TestPyPI requires a prerelease version" in validate_script
+
+    assert _job_needs(_job(workflow, "build")) == {"validate"}
+    assert _job_needs(_job(workflow, "publish")) == {"build"}
+
+
+def test_build_smithery_bundle_pins_exact_mcp_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Generated Smithery bundle must pin nuguard[mcp] to an exact package version."""
+    module = _load_publish_smithery_module()
+
+    smithery_yaml = tmp_path / "smithery.yaml"
+    smithery_yaml.write_text(
+        "\n".join(
+            [
+                "name: nuguard",
+                "version: \"9.9.9\"",
+                "startCommand:",
+                "  configSchema:",
+                "    type: object",
+                "    properties:",
+                "      litellm_api_key:",
+                "        type: string",
+                "        description: LiteLLM key",
+                "        default: \"\"",
+                "      nuguard_config_path:",
+                "        type: string",
+                "        default: \"\"",
+                "tools:",
+                "  - name: nuguard_scan",
+                "    description: Scan target",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "SMITHERY_YAML", smithery_yaml)
+    monkeypatch.setattr(module, "SMITHERY_BUNDLE", tmp_path / "server.mcpb")
+
+    bundle = module._build_smithery_bundle("1.2.3")
+    assert bundle.exists()
+
+    with zipfile.ZipFile(bundle, "r") as archive:
+        manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+
+    assert manifest["version"] == "1.2.3"
+    assert manifest["server"]["mcp_config"]["command"] == "uvx"
+    assert manifest["server"]["mcp_config"]["args"] == [
+        "--from",
+        "nuguard[mcp]==1.2.3",
+        "nuguard-mcp",
+    ]

--- a/tests/test_sync_marketplace_script.py
+++ b/tests/test_sync_marketplace_script.py
@@ -1,0 +1,200 @@
+"""Tests for scripts/sync-marketplace.js transactional version synchronization."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "sync-marketplace.js"
+_VERSION_FILES = [
+    "pyproject.toml",
+    "uv.lock",
+    "nuguard/__init__.py",
+    "npm/package.json",
+    ".claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+    "plugin/.claude-plugin/plugin.json",
+    "plugin/.claude-plugin/marketplace.json",
+    "marketplace.json",
+    "gemini-extension.json",
+    "openclaw.plugin.json",
+    "smithery.yaml",
+]
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_version_fixture(root: Path, pyproject_version: str = "1.2.3") -> None:
+    _write(root / "scripts" / "sync-marketplace.js", _SCRIPT.read_text(encoding="utf-8"))
+    _write(
+        root / "pyproject.toml",
+        "\n".join(
+            [
+                "[project]",
+                'name = "nuguard"',
+                f'version = "{pyproject_version}"',
+                "",
+            ]
+        ),
+    )
+    _write(
+        root / "uv.lock",
+        "\n".join(
+            [
+                "version = 1",
+                "revision = 3",
+                'requires-python = ">=3.12"',
+                "",
+                "[[package]]",
+                'name = "nuguard"',
+                'version = "0.0.1"',
+                'source = { editable = "." }',
+                "",
+            ]
+        ),
+    )
+    _write(root / "nuguard" / "__init__.py", '__version__ = "0.0.1"\n')
+
+    plugin_doc = {"name": "nuguard-plugin", "version": "0.0.1"}
+    market_doc = {
+        "metadata": {"version": "0.0.1"},
+        "plugins": [{"name": "nuguard-plugin", "version": "0.0.1"}],
+    }
+    _write(root / "npm" / "package.json", json.dumps(plugin_doc, indent=2) + "\n")
+    _write(root / ".claude-plugin" / "plugin.json", json.dumps(plugin_doc, indent=2) + "\n")
+    _write(
+        root / ".claude-plugin" / "marketplace.json", json.dumps(market_doc, indent=2) + "\n"
+    )
+    _write(
+        root / "plugin" / ".claude-plugin" / "plugin.json",
+        json.dumps(plugin_doc, indent=2) + "\n",
+    )
+    _write(
+        root / "plugin" / ".claude-plugin" / "marketplace.json",
+        json.dumps(market_doc, indent=2) + "\n",
+    )
+    _write(root / "marketplace.json", json.dumps(market_doc, indent=2) + "\n")
+    _write(root / "gemini-extension.json", json.dumps(plugin_doc, indent=2) + "\n")
+    _write(root / "openclaw.plugin.json", json.dumps(plugin_doc, indent=2) + "\n")
+    _write(root / "smithery.yaml", 'name: nuguard\nversion: "0.0.1"\n')
+
+
+def _run_sync_script(
+    root: Path,
+    *args: str,
+    lifecycle_event: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required to run sync-marketplace.js tests")
+    env = os.environ.copy()
+    if lifecycle_event is not None:
+        env["npm_lifecycle_event"] = lifecycle_event
+    return subprocess.run(
+        [node, "scripts/sync-marketplace.js", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_sync_marketplace_synchronizes_all_projected_versions(tmp_path: Path) -> None:
+    """sync-marketplace updates all version projections from pyproject.toml in one pass."""
+    _make_version_fixture(tmp_path, pyproject_version="2.4.6")
+
+    result = _run_sync_script(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    init_text = (tmp_path / "nuguard" / "__init__.py").read_text(encoding="utf-8")
+    assert '__version__ = "2.4.6"' in init_text
+
+    for rel_path in [
+        "npm/package.json",
+        ".claude-plugin/plugin.json",
+        "plugin/.claude-plugin/plugin.json",
+        "gemini-extension.json",
+        "openclaw.plugin.json",
+    ]:
+        payload = json.loads((tmp_path / rel_path).read_text(encoding="utf-8"))
+        assert payload["version"] == "2.4.6", rel_path
+
+    for rel_path in [
+        ".claude-plugin/marketplace.json",
+        "plugin/.claude-plugin/marketplace.json",
+        "marketplace.json",
+    ]:
+        payload = json.loads((tmp_path / rel_path).read_text(encoding="utf-8"))
+        assert payload["metadata"]["version"] == "2.4.6", rel_path
+        assert payload["plugins"][0]["version"] == "2.4.6", rel_path
+
+    smithery = (tmp_path / "smithery.yaml").read_text(encoding="utf-8")
+    assert 'version: "2.4.6"' in smithery
+
+    before_second_run = {
+        rel_path: (tmp_path / rel_path).read_bytes() for rel_path in _VERSION_FILES
+    }
+    second_result = _run_sync_script(tmp_path)
+    assert second_result.returncode == 0, second_result.stderr
+    after_second_run = {
+        rel_path: (tmp_path / rel_path).read_bytes() for rel_path in _VERSION_FILES
+    }
+    assert after_second_run == before_second_run
+
+
+def test_sync_marketplace_malformed_input_leaves_all_files_unchanged(tmp_path: Path) -> None:
+    """Malformed marketplace metadata aborts sync and preserves all tracked version files."""
+    _make_version_fixture(tmp_path, pyproject_version="3.0.0")
+
+    broken_marketplace = {
+        "metadata": [],
+        "plugins": [{"name": "nuguard-plugin", "version": "0.0.1"}],
+    }
+    _write(
+        tmp_path / "marketplace.json",
+        json.dumps(broken_marketplace, indent=2) + "\n",
+    )
+
+    before = {
+        rel_path: (tmp_path / rel_path).read_bytes()
+        for rel_path in _VERSION_FILES
+    }
+
+    result = _run_sync_script(tmp_path)
+
+    assert result.returncode != 0
+    assert "ERROR:" in result.stderr
+    assert "All version files were restored." in result.stderr
+
+    after = {
+        rel_path: (tmp_path / rel_path).read_bytes()
+        for rel_path in _VERSION_FILES
+    }
+    assert after == before
+
+
+def test_version_bump_repairs_stale_lock_for_same_version(tmp_path: Path) -> None:
+    """version:bump must reconcile uv.lock even when pyproject already has the target."""
+    if shutil.which("uv") is None:
+        pytest.skip("uv is required to test version:bump")
+    _make_version_fixture(tmp_path, pyproject_version="2.4.6")
+
+    result = _run_sync_script(
+        tmp_path,
+        "2.4.6",
+        lifecycle_event="version:bump",
+    )
+
+    assert result.returncode == 0, result.stderr
+    lock_text = (tmp_path / "uv.lock").read_text(encoding="utf-8")
+    assert 'name = "nuguard"\nversion = "2.4.6"' in lock_text

--- a/tests/test_verify_registry_artifacts.py
+++ b/tests/test_verify_registry_artifacts.py
@@ -6,11 +6,10 @@ import hashlib
 import importlib.util
 import io
 import json
-import subprocess
+import tarfile
 import types
 import urllib.error
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -36,6 +35,15 @@ class _Response(io.BytesIO):
 
 def _response(payload: object) -> _Response:
     return _Response(json.dumps(payload).encode("utf-8"))
+
+
+def _npm_tarball(path: Path, name: str, version: str) -> Path:
+    package_json = json.dumps({"name": name, "version": version}).encode("utf-8")
+    with tarfile.open(path, "w:gz") as archive:
+        member = tarfile.TarInfo("package/package.json")
+        member.size = len(package_json)
+        archive.addfile(member, io.BytesIO(package_json))
+    return path
 
 
 def test_verify_pypi_accepts_only_exact_artifacts(
@@ -90,34 +98,20 @@ def test_verify_npm_compares_registry_integrity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = _load_module()
-    local_integrity = "sha512-dGVzdA=="
-    monkeypatch.setattr(module.shutil, "which", lambda executable: "/usr/bin/npm")
-    monkeypatch.setattr(
-        module.subprocess,
-        "run",
-        Mock(
-            return_value=subprocess.CompletedProcess(
-                [],
-                0,
-                stdout=json.dumps(
-                    [
-                        {
-                            "name": "@nuguardai/nuguard",
-                            "version": "1.2.3",
-                            "integrity": local_integrity,
-                        }
-                    ]
-                ),
-                stderr="",
-            )
-        ),
+    tarball = _npm_tarball(
+        tmp_path / "nuguardai-nuguard-1.2.3.tgz",
+        "@nuguardai/nuguard",
+        "1.2.3",
     )
+    local_integrity = "sha512-" + module.base64.b64encode(
+        module.hashlib.sha512(tarball.read_bytes()).digest()
+    ).decode("ascii")
     monkeypatch.setattr(
         module.urllib.request,
         "urlopen",
         lambda *args, **kwargs: _response({"dist": {"integrity": local_integrity}}),
     )
-    assert module.verify_npm("@nuguardai/nuguard", "1.2.3", tmp_path) is True
+    assert module.verify_npm("@nuguardai/nuguard", "1.2.3", tarball) is True
 
     monkeypatch.setattr(
         module.urllib.request,
@@ -125,4 +119,4 @@ def test_verify_npm_compares_registry_integrity(
         lambda *args, **kwargs: _response({"dist": {"integrity": "sha512-b3RoZXI="}}),
     )
     with pytest.raises(module.VerificationError, match="does not match"):
-        module.verify_npm("@nuguardai/nuguard", "1.2.3", tmp_path)
+        module.verify_npm("@nuguardai/nuguard", "1.2.3", tarball)

--- a/tests/test_verify_registry_artifacts.py
+++ b/tests/test_verify_registry_artifacts.py
@@ -1,0 +1,128 @@
+"""Tests for release registry provenance verification."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import types
+import urllib.error
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module() -> types.ModuleType:
+    path = _ROOT / "scripts" / "verify_registry_artifacts.py"
+    spec = importlib.util.spec_from_file_location("verify_registry_artifacts", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Response(io.BytesIO):
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+def _response(payload: object) -> _Response:
+    return _Response(json.dumps(payload).encode("utf-8"))
+
+
+def test_verify_pypi_accepts_only_exact_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    wheel = tmp_path / "nuguard-1.2.3-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    digest = hashlib.sha256(b"wheel").hexdigest()
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _response(
+            {"urls": [{"filename": wheel.name, "digests": {"sha256": digest}}]}
+        ),
+    )
+
+    assert module.verify_pypi("nuguard", "1.2.3", tmp_path) is True
+
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _response(
+            {"urls": [{"filename": wheel.name, "digests": {"sha256": "0" * 64}}]}
+        ),
+    )
+    with pytest.raises(module.VerificationError, match="do not match"):
+        module.verify_pypi("nuguard", "1.2.3", tmp_path)
+
+
+def test_verify_pypi_distinguishes_missing_version_from_registry_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    (tmp_path / "artifact.whl").write_bytes(b"wheel")
+
+    def raise_http_404(*args: object, **kwargs: object) -> None:
+        raise urllib.error.HTTPError("url", 404, "missing", {}, None)
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", raise_http_404)
+    assert module.verify_pypi("nuguard", "1.2.3", tmp_path) is False
+
+    def raise_http_503(*args: object, **kwargs: object) -> None:
+        raise urllib.error.HTTPError("url", 503, "unavailable", {}, None)
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", raise_http_503)
+    with pytest.raises(module.VerificationError, match="HTTP 503"):
+        module.verify_pypi("nuguard", "1.2.3", tmp_path)
+
+
+def test_verify_npm_compares_registry_integrity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    local_integrity = "sha512-dGVzdA=="
+    monkeypatch.setattr(module.shutil, "which", lambda executable: "/usr/bin/npm")
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        Mock(
+            return_value=subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": "@nuguardai/nuguard",
+                            "version": "1.2.3",
+                            "integrity": local_integrity,
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _response({"dist": {"integrity": local_integrity}}),
+    )
+    assert module.verify_npm("@nuguardai/nuguard", "1.2.3", tmp_path) is True
+
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _response({"dist": {"integrity": "sha512-b3RoZXI="}}),
+    )
+    with pytest.raises(module.VerificationError, match="does not match"):
+        module.verify_npm("@nuguardai/nuguard", "1.2.3", tmp_path)


### PR DESCRIPTION
## Summary
- make `pyproject.toml` the canonical release version and synchronize all owned manifests transactionally
- validate runtime, lockfile, plugin, marketplace, npm, and Smithery versions in PR and release workflows
- publish stable releases only from matching `v*` tags, with draft GitHub Releases finalized after all registries succeed
- verify existing PyPI and npm artifacts by digest before treating retries as successful
- restrict TestPyPI publishing to the immutable `develop` dispatch SHA with caches disabled
- isolate credentialed publishing jobs from repository checkout and code execution
- pin third-party Actions and the Smithery CLI to immutable identities
- document the release, repository protections, and historical-tag reconciliation process

## Validation
- `uv run pytest tests/test_release_metadata.py tests/test_sync_marketplace_script.py tests/test_verify_registry_artifacts.py tests/test_pr_workflow_dependencies.py -q` (18 passed)
- `uv run ruff check scripts/publish_smithery.py scripts/verify_registry_artifacts.py tests/test_release_metadata.py tests/test_sync_marketplace_script.py tests/test_verify_registry_artifacts.py`
- `npm run version:check`
- `uv lock --check`
- `uv build`
- Smithery CLI tarball SHA-512 verification and extraction simulation
- full 12-category PR security review

Closes #521